### PR TITLE
cleanup of pip packages list and proposal for additional packages

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,14 +28,13 @@ ENV PACKAGES="\
 
 ENV PIP_PACKAGES="\
     ansible[azure] \
-    virtualenv \
-    molecule \
-    ansible \
+    ansible-lint-junit \
+    detox \
     docker \
-    azure-cli \
-    packaging \
-    msrestazure \
+    junit-xml \
+    molecule \
     pywinrm \
+    virtualenv \
 "
 
 ENV GEM_PACKAGES="\


### PR DESCRIPTION
Hello, this is a proposal for some changes in the list of pip packages. I believe it makes sense to integrate them to the official molecule image. 

First some cleanup:

Removal of ansible from the list: 

calling `pip install ansible[azure] ansible` makes no sense, only first occurence `ansible[azure]` will be installed, but as it implies `ansible` that's fine. For the record `pip install ansible ansible[azure]` does not install `ansible[azure]`, but only `ansible`.

Other removals: 

ansible[azure] implies packaging, msrestazure, azure-cli.

Additions:

ansible-lint-junit
detox
junit-xml
tox

As a maintainer of a repository of playbooks containing multiple ansible roles, I am using detox and tox to automate and parallelize the run of molecule test. 
I am also using ansible-lint-junit and junit-xml to let the build system generate nice reports. 

I really think that these packages are a nice fit for the official molecule docker image, as they are expanding the usecases. 

Here is a sample tox.ini to illustrate the usecase:

```
# Invocation:
# Run all tests in parallel (where possible):
#   detox
# Run all tests sequentially:
#   tox
# Run tests sequentially for specified roles:
#   tox -e some_role,additional_role
[tox]
# Each role is defined as an environment, to enable parallel runs of command 'molecule test'
envlist =
  some_role
  another_role
  playbooks
minversion = 3.2.1
skipsdist = true
[testenv]
basepython = python2
commands = bash -c "(cd {toxinidir}/roles/{envname} && molecule --debug test --all)"
description = molecule test on {envname}
passenv = *
setenv =
  # necessary for parallelization with detox
  # see https://molecule.readthedocs.io/en/latest/testing.html
  MOLECULE_EPHEMERAL_DIRECTORY={envname}
sitepackages = true
whitelist_externals =
  /bin/bash
  /usr/bin/rubocop
[testenv:playbooks]
deps = ansible-lint-junit
description = ansible-lint on all playbooks
commands = bash -c "find {toxinidir} -maxdepth 1 -name '*.yml' | xargs -n1 ansible-lint -v"
whitelist_externals =
  /bin/bash
  /usr/bin/find
  /usr/bin/xargs
```