### PR TITLE
Improve Azure Driver

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -3,6 +3,10 @@ dependency:
   name: {{ cookiecutter.dependency_name }}
 driver:
   name: {{ cookiecutter.driver_name }}
+{%- if cookiecutter.driver_name == 'azure' %}
+  resource_group_name: molecule
+  location: westus
+{%- endif %}
 {%- if cookiecutter.driver_name == 'vagrant' %}
   provider:
     name: virtualbox
@@ -12,6 +16,12 @@ lint:
 platforms:
 {%- if cookiecutter.driver_name == 'azure' %}
   - name: instance
+    vm_size: Standard_A0
+    image:
+      offer: CentOS
+      publisher: OpenLogic
+      sku: "7.4"
+      version: latest
 {%- elif cookiecutter.driver_name == 'docker' %}
   - name: instance
     image: centos:7

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -6,8 +6,8 @@
   gather_facts: false
   no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
   vars:
-    resource_group_name: molecule
-    location: westus
+    resource_group_name: "{{ molecule_yml.driver.resource_group_name }}"
+    location: "{{ molecule_yml.driver.location }}"
     ssh_user: molecule
     ssh_port: 22
     virtual_network_name: molecule_vnet
@@ -43,7 +43,8 @@
       azure_rm_virtualmachine:
         resource_group: "{{ resource_group_name }}"
         name: "{{ item.name }}"
-        vm_size: Standard_A0
+        vm_size: "{{ item.vm_size }}"
+        managed_disk_type: Standard_LRS
         admin_username: "{{ ssh_user }}"
         public_ip_allocation_method: Dynamic
         ssh_password_enabled: false
@@ -51,10 +52,10 @@
           - path: "/home/{{ ssh_user }}/.ssh/authorized_keys"
             key_data: "{{ keypair.ssh_public_key }}"
         image:
-          offer: CentOS
-          publisher: OpenLogic
-          sku: '7.4'
-          version: latest
+          offer: "{{ item.image.offer }}"
+          publisher: "{{ item.image.publisher }}"
+          sku: "{{ item.image.sku }}"
+          version: "{{ item.image.version }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -6,7 +6,7 @@
   gather_facts: false
   no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
   vars:
-    resource_group_name: molecule
+    resource_group_name: "{{ molecule_yml.driver.resource_group_name }}"
   tasks:
     - name: Destroy molecule instance(s)
       azure_rm_virtualmachine:

--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -40,8 +40,15 @@ class Azure(base.Base):
 
         driver:
           name: azure
+          location: westus
+          resource_group_name: molecule
         platforms:
           - name: instance
+            offer: CentOS
+            publisher: OpenLogic
+            sku: '7.4'
+            version: latest
+
 
     .. code-block:: bash
 

--- a/test/scenarios/driver/azure/molecule/default/molecule.yml
+++ b/test/scenarios/driver/azure/molecule/default/molecule.yml
@@ -3,12 +3,20 @@ dependency:
   name: galaxy
 driver:
   name: azure
+  location: westus
+  resource_group_name: molecule
 lint:
   name: yamllint
   options:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance
+    vm_size: Standard_A0
+    image:
+      offer: CentOS
+      publisher: OpenLogic
+      sku: "7.4"
+      version: latest
 provisioner:
   name: ansible
   playbooks:

--- a/test/scenarios/driver/azure/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/azure/molecule/multi-node/molecule.yml
@@ -3,16 +3,30 @@ dependency:
   name: galaxy
 driver:
   name: azure
+  location: westus
+  resource_group_name: molecule
 lint:
   name: yamllint
   options:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance-1
+    vm_size: Standard_A0
+    image:
+      offer: CentOS
+      publisher: OpenLogic
+      sku: "7.4"
+      version: latest
     groups:
       - foo
       - bar
   - name: instance-2
+    vm_size: Standard_A0
+    image:
+      offer: CentOS
+      publisher: OpenLogic
+      sku: "7.4"
+      version: latest
     groups:
       - foo
       - baz
@@ -24,8 +38,6 @@ provisioner:
   inventory:
     group_vars:
       all:
-        resource_group_name: molecule
-        location: westus
         ssh_user: molecule
         ssh_port: 22
         virtual_network_name: molecule_vnet


### PR DESCRIPTION
Guys, 

This PR improves Azure Driver allowing to customize options like resource group name, location, vm size, image reference in the molecule configuration file. 

Other improve is create the instance with Azure Managed Disk. The current driver does not remove the storage account created for the instance disk.

Example:
```yaml
molecule/azure/molecule.yml
---
driver:
  name: azure
  location: eastus2
  resource_group_name: infra_test
platforms:
  - name: UbuntuServer16.04
    location: eastus2
    vm_size: Standard_A0
    image:
      offer: UbuntuServer
      publisher: Canonical
      sku: '16.04-LTS'
      version: latest
```

Let me know if this is useful.

Thanks,