### PR TITLE
only colorize output to tty

### DIFF
--- a/molecule/logger.py
+++ b/molecule/logger.py
@@ -171,4 +171,7 @@ def cyan_text(msg):
 
 
 def color_text(color, msg):
-    return '{}{}{}'.format(color, msg, colorama.Style.RESET_ALL)
+    if sys.stdout.isatty():
+        return '{}{}{}'.format(color, msg, colorama.Style.RESET_ALL)
+    else:
+        return msg


### PR DESCRIPTION
The escape sequences make the output hard to read when output to a file and when shown on a white background.