### PR TITLE
Documentation: explain Docker registry credentials

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -96,7 +96,7 @@ class Docker(base.Base):
     .. code-block:: bash
 
         $ export USERNAME=foo
-        $ export PASSWORD=BAR
+        $ export PASSWORD=bar
 
     Provide the files Molecule will preserve upon each subcommand execution.
 

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -89,6 +89,15 @@ class Docker(base.Base):
 
         $ sudo pip install docker-py
 
+    When pulling from a private registry, the username and password must be
+    exported as environment variables in the current shell. The only supported
+    variables are $USERNAME and $PASSWORD.
+
+    .. code-block:: bash
+
+        $ export USERNAME=foo
+        $ export PASSWORD=BAR
+
     Provide the files Molecule will preserve upon each subcommand execution.
 
     .. code-block:: yaml


### PR DESCRIPTION
This PR explains exactly how to provide credentials to the Docker driver when using a private image registry.