### PR TITLE
Molecule - Ansible by Red Hat

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,8 @@ Ansible installation method (one of):
 - pip
 - OS package
 
+Detail any linters or test runners used:
+
 # Desired Behavior
 
 Please give some details of the feature being requested or what

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,11 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+---
+
 # Issue Type
 
 - Bug report
-- Feature request
 
 # Molecule and Ansible details
 
@@ -29,7 +33,7 @@ Ansible installation method (one of):
 Please give some details of the feature being requested or what
 should happen if providing a bug report.
 
-# Actual Behaviour (Bug report only)
+# Actual Behaviour
 
 Please give some details of what is actually happening.
 Include a [minimum complete verifiable example](http://stackoverflow.com/help/mcve) with

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: ✨ Feature request
+about: Suggest an idea for this project
+---
+
+# Issue Type
+
+- Feature request
+
+# Molecule and Ansible details
+
+```
+ansible --version
+```
+
+```
+molecule --version
+```
+
+Molecule installation method (one of):
+
+- source
+- pip
+
+Ansible installation method (one of):
+
+- source
+- pip
+- OS package
+
+# Desired Behavior
+
+Please give some details of the feature being requested or what
+should happen if providing a bug report.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,11 +10,7 @@ about: Suggest an idea for the Molecule project
 # Molecule and Ansible details
 
 ```
-ansible --version
-```
-
-```
-molecule --version
+ansible --version && molecule --version
 ```
 
 Molecule installation method (one of):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: ✨ Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for the Molecule project
 ---
 
 # Issue Type
@@ -30,5 +30,4 @@ Ansible installation method (one of):
 
 # Desired Behavior
 
-Please give some details of the feature being requested or what
-should happen if providing a bug report.
+Please give some details of the feature being requested

--- a/.github/ISSUE_TEMPLATE/security_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/security_bug_report.md
@@ -1,0 +1,8 @@
+---
+name: 🔥 Security bug report
+about: How to report security vulnerabilities
+---
+
+For all security related bugs, email security@ansible.com instead of using this issue tracker and you will receive a prompt response.
+
+For more information, see https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+##### Summary
+
+Please include details of what it is, how to use it, how it's been tested
+
+##### PR Type
+
+- Bugfix Pull Request
+- Docs Pull Request
+- Feature Pull Request

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,7 @@
-##### Summary
 
 Please include details of what it is, how to use it, how it's been tested
 
-##### PR Type
+#### PR Type
 
 - Bugfix Pull Request
 - Docs Pull Request

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,11 +8,15 @@ Contributing
 * Create a topic branch from where you want to base your work.
 * Check for unnecessary whitespace with ``git diff --check`` before committing.
 * Make sure you have added tests for your changes.
+* You must use ``git commit --signoff`` for any commit to be merged, and agree
+  that usage of ``--signoff`` constitutes agreement with the terms of `DCO 1.1`.
+
 * Run all the tests to ensure nothing else was accidentally broken.
 * Reformat the code by following the formatting section below.
 * Submit a pull request.
 
-.. _`Issue`: https://github.com/metacloud/molecule/issues
+.. _`Issue`: https://github.com/ansible/molecule/issues
+.. _`DCO 1.1`: https://github.com/ansible/molecule/blob/master/DCO_1_1.md
 
 Installing
 ==========

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ Contributing
 * Check for unnecessary whitespace with ``git diff --check`` before committing.
 * Make sure you have added tests for your changes.
 * You must use ``git commit --signoff`` for any commit to be merged, and agree
-  that usage of ``--signoff`` constitutes agreement with the terms of `DCO 1.1`.
+  that usage of ``--signoff`` constitutes agreement with the terms of `DCO 1.1`_.
 
 * Run all the tests to ensure nothing else was accidentally broken.
 * Reformat the code by following the formatting section below.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,3 +44,59 @@ To bring in updated upstream modules.  Update `gilt.yml` and execute the followi
 
 .. _`Ansible Goss`: https://github.com/indusbox/goss-ansible
 .. _`Gilt`: http://gilt.readthedocs.io
+
+
+Move to Red Hat
+===============
+
+During the end of October 2018 the Molecule was moved to its new home under Ansible by Red Hat.
+
+Update Git repo location
+------------------------
+
+The Molecule project has moved:
+
+old location: ``https://github.com/metacloud/molecule``
+
+new location: ``https://github.com/ansible/molecule``
+
+If you have the source checked out you should use ``git remote set-url origin``
+to point to the new location
+
+Please follow GitHub's official `changing a remote's URL`_ guide.
+
+.. _`changing a remote's URL`: https://help.github.com/articles/changing-a-remote-s-url/
+
+New Docker location
+-------------------
+
+For people that use the Docker image, we are now publishing to a new location `Molecule on quay.io`_.
+
+old location: ``https://hub.docker.com/r/retr0h/molecule/``
+
+new location: ``https://quay.io/repository/ansible/molecule``
+
+How to use::
+
+  docker pull quay.io/ansible/molecule:latest
+
+.. _`Molecule on quay.io`: https://quay.io/repository/ansible/molecule
+
+
+Release announcements
+---------------------
+
+Want to know about releases, subscribe to `ansible-announce list`_
+
+.. _`ansible-announce list`: https://groups.google.com/group/ansible-announce
+
+Talk to us
+----------
+
+Join us in ``#ansible-molecule`` on `freenode`_, or `molecule-users Forum`_.
+
+The full list of Ansible email lists and IRC channels can be found in the `communication page`_.
+
+.. _`freenode`: https://freenode.net
+.. _`molecule-users Forum`: https://groups.google.com/forum/#!forum/molecule-users
+.. _`communication page`: https://docs.ansible.com/ansible/latest/community/communication.html

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ To bring in updated upstream modules.  Update `gilt.yml` and execute the followi
 Move to Red Hat
 ===============
 
-During the end of October 2018 the Molecule was moved to its new home under Ansible by Red Hat.
+During the end of October 2018 the Molecule Project was moved to its new home under Ansible by Red Hat.
 
 Update Git repo location
 ------------------------
@@ -61,7 +61,7 @@ old location: ``https://github.com/metacloud/molecule``
 new location: ``https://github.com/ansible/molecule``
 
 If you have the source checked out you should use ``git remote set-url origin``
-to point to the new location
+to point to the new location.
 
 Please follow GitHub's official `changing a remote's URL`_ guide.
 

--- a/DCO_1_1.md
+++ b/DCO_1_1.md
@@ -1,0 +1,45 @@
+DCO
+===
+
+All contributors must use `git commit --signoff` for any
+commit to be merged, and agree that usage of --signoff constitutes
+agreement with the terms of DCO 1.1, which appears below:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License
 
 Copyright (c) 2015-2018 Cisco Systems, Inc.
+Copyright (c) 2018 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -80,13 +80,15 @@ https://molecule.readthedocs.io/
 Contact
 =======
 
-* Join us in the ``#molecule-users`` channel on `freenode`_.
+* Join us in the ``#ansible-molecule`` channel on `freenode`_.
 * Join the discussion in `molecule-users Forum`_
-* Want to know about releases, subscribe to `ansible-announce <https://groups.google.com/group/ansible-announce>`_
-* For the full list of Ansible email Lists, IRC channels see the `Communication page <https://docs.ansible.com/ansible/latest/community/communication.html>`_
+* Want to know about releases, subscribe to `ansible-announce list`_
+* For the full list of Ansible email Lists, IRC channels see the `communication page`_
 
 .. _`freenode`: https://freenode.net
 .. _`molecule-users Forum`: https://groups.google.com/forum/#!forum/molecule-users
+.. _`ansible-announce list`: https://groups.google.com/group/ansible-announce
+.. _`communication page`: https://docs.ansible.com/ansible/latest/community/communication.html
 
 Ansible Support
 ===============

--- a/README.rst
+++ b/README.rst
@@ -80,19 +80,13 @@ https://molecule.readthedocs.io/
 Contact
 =======
 
-IRC
----
-
-Join us in the #molecule-users channel on `freenode`_.
+* Join us in the ``#molecule-users`` channel on `freenode`_.
+* Join the discussion in `molecule-users Forum`_
+* Want to know about releases, subscribe to `ansible-announce <https://groups.google.com/group/ansible-announce>`_
+* For the full list of Ansible email Lists, IRC channels see the `Communication page <https://docs.ansible.com/ansible/latest/community/communication.html>`_
 
 .. _`freenode`: https://freenode.net
-
-Forums
-------
-
-* `molecule-users`_
-
-.. _`molecule-users`: https://groups.google.com/forum/#!forum/molecule-users
+.. _`molecule-users Forum`: https://groups.google.com/forum/#!forum/molecule-users
 
 Ansible Support
 ===============

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ supports.
    use it, Molecule can test it.  Molecule simply leverages Ansible's module
    system to manage instances.
 
-.. _`playbooks`: https://docs.ansible.com/ansible/playbooks.html
-.. _`role`: http://docs.ansible.com/ansible/playbooks_roles.html
+.. _`playbooks`: https://docs.ansible.com/ansible/latest/playbooks.html
+.. _`role`: http://docs.ansible.com/ansible/latest/playbooks_roles.html
 
 Quick Start
 ===========
@@ -106,9 +106,15 @@ License
 
 `MIT`_
 
-.. _`MIT`: https://github.com/metacloud/molecule/blob/master/LICENSE
+.. _`MIT`: https://github.com/ansible/molecule/blob/master/LICENSE
 
 The logo is licensed under the `Creative Commons NoDerivatives 4.0 License`_.
 If you have some other use in mind, contact us.
 
 .. _`Creative Commons NoDerivatives 4.0 License`: https://creativecommons.org/licenses/by-nd/4.0/
+
+
+Authors
+=======
+
+Molecule was created by `Retr0h <https://github.com/retr0h>`_ and is now maintained as part of the `Ansible <https://ansible.com>`_ by Red Hat project.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker:dind
-LABEL maintainer "John Dewey <john@dewey.ws>"
+LABEL maintainer "Ansible <info@ansible.com>"
 
 ENV TEST_USER=molecule
 ENV TEST_HOME_DIR=/home/${TEST_USER}

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,4 +1,4 @@
-USER := retr0h
+USER := ansible
 TAG := $(shell git describe --tags `git rev-list --tags --max-count=1`)
 LATEST_IMAGE := $(USER)/molecule:latest
 TAG_IMAGE := $(USER)/molecule:$(TAG)
@@ -24,10 +24,5 @@ docker-build:
 
 push:
 	./.tox/py27-ansible25-unit/bin/twine upload dist/* -r pypi
-
-docker-push:
-	@echo "+ $@"
-	sudo docker push $(LATEST_IMAGE)
-	sudo docker push $(TAG_IMAGE)
 
 .PHONY: build

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Molecule'
-copyright = u' %s, Cisco Systems, Inc.' % datetime.date.today().year
+copyright = u' %s, Red Hat Inc.' % datetime.date.today().year
 author = u'AUTHORS.rst'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -129,13 +129,13 @@ html_theme = 'alabaster'
 # html_theme_options = {}
 html_theme_options = {
     'logo': 'logo.png',
-    'github_user': 'metacloud',
+    'github_user': 'ansible',
     'github_repo': 'molecule',
     'github_button': True,
     'travis_button': False,
     'show_powered_by': False,
     'extra_nav_links': {
-        'View on github': 'https://github.com/metacloud/molecule',
+        'View on GitHub': 'https://github.com/ansible/molecule',
     },
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -132,10 +132,11 @@ html_theme_options = {
     'github_user': 'ansible',
     'github_repo': 'molecule',
     'github_button': True,
-    'travis_button': False,
+    'badge_branch': 'master',
+    'travis_button': True,
     'show_powered_by': False,
     'extra_nav_links': {
-        'View on GitHub': 'https://github.com/ansible/molecule',
+    'View on GitHub': 'https://github.com/ansible/molecule',
     },
 }
 

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -69,5 +69,5 @@ Roadmap
 * See `Issues`_ on Github.com.
 
 .. _`PyPI`: https://pypi.python.org/pypi/molecule
-.. _`ISSUES`: https://github.com/metacloud/molecule/issues
+.. _`ISSUES`: https://github.com/ansible/molecule/issues
 .. _`Twine`: https://pypi.python.org/pypi/twine

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -4,7 +4,7 @@ Examples
 
 A good source of examples are the `scenario`_ functional tests.
 
-.. _`scenario`: https://github.com/metacloud/molecule/tree/master/test/scenarios/driver
+.. _`scenario`: https://github.com/ansible/molecule/tree/master/test/scenarios/driver
 
 Docker
 ======
@@ -12,7 +12,7 @@ Docker
 Molecule can be executed via an Alpine Linux container by leveraging dind
 (Docker in Docker).  Currently, we only build images for the latest version
 of Ansible and Molecule.  In the future we may break this out into Molecule/
-Ansible versioned pairs.  The images are located on `Docker Hub`_.
+Ansible versioned pairs.  The images are located on `quay.io`_.
 
 To test a role, change directory into the role to test, and execute Molecule as
 follows.
@@ -23,10 +23,10 @@ follows.
         -v '$(pwd)':/tmp/$(basename "${PWD}"):ro \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -w /tmp/$(basename "${PWD}") \
-        retr0h/molecule:latest \
+        quay.io/ansible/molecule:latest \
         sudo molecule test
 
-.. _`Docker Hub`: https://hub.docker.com/r/retr0h/molecule/
+.. _`quay.io`: https://quay.io/repository/ansible/molecule
 
 Monolith Repo
 =============

--- a/molecule/provisioner/lint/ansible_lint.py
+++ b/molecule/provisioner/lint/ansible_lint.py
@@ -75,8 +75,8 @@ class AnsibleLint(base.Base):
             env:
               FOO: bar
 
-    .. _`Ansible Lint`: https://github.com/willthames/ansible-lint
-    .. _`bug`: https://github.com/willthames/ansible-lint/issues/279
+    .. _`Ansible Lint`: https://github.com/ansible/ansible-lint
+    .. _`bug`: https://github.com/ansible/ansible-lint/issues/279
     """
 
     def __init__(self, config):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = molecule
 summary = Molecule aids in the development and testing of Ansible roles.
 license = MIT
 description-file = README.rst
-home-page = https://github.com/metacloud/molecule
+home-page = https://github.com/ansible/molecule
 requires-python = 2.7
 classifier =
     Development Status :: 4 - Beta

--- a/test/scenarios/idempotence/tasks/main.yml
+++ b/test/scenarios/idempotence/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Steps provided by @saez0pub
-# Taken from https://github.com/metacloud/molecule/issues/835
+# Taken from https://github.com/ansible/molecule/issues/835
 
 - name: Create /tmp/test1
   file: name=/tmp/test1 state=directory


### PR DESCRIPTION
* Update links to point to new repo
* Require DCO Signoff
* Docker
  * Docker has moved to https://quay.io/repository/ansible/molecule
  * quay.io builds on commit, so remove steps from `Makefile`
* Use GitHub issue templates, also direct security concerns to `security@ansible.com`
* Update links to ansible-lint

https://github.com/ansible/community/issues/366