### PR TITLE
Respect PY_COLORS variable

### DIFF
--- a/doc/source/ci.rst
+++ b/doc/source/ci.rst
@@ -1,6 +1,10 @@
 Continuous integration
 ----------------------
 
+Molecule output will use ``ANSI`` colors if stdout is an interactive TTY and
+``TERM`` value seems to support it. You can define ``PY_COLORS=1`` to force
+use of ``ANSI`` colors, which can be handly for some CI systems.
+
 Travis CI
 ^^^^^^^^^
 

--- a/molecule/logger.py
+++ b/molecule/logger.py
@@ -19,11 +19,22 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import logging
+import os
 import sys
 
 import colorama
+from ansible.module_utils.parsing.convert_bool import boolean as to_bool
 
-colorama.init(autoreset=True)
+
+def should_do_markup():
+    py_colors = os.environ.get('PY_COLORS', None)
+    if py_colors is not None:
+        return to_bool(py_colors, strict=False)
+
+    return sys.stdout.isatty() and os.environ.get('TERM') != 'dumb'
+
+
+colorama.init(autoreset=True, strip=not should_do_markup())
 
 SUCCESS = 100
 OUT = 101

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -30,12 +30,10 @@ import anyconfig
 import colorama
 import yaml
 
-from molecule import logger
+from molecule.logger import get_logger
 
-LOG = logger.get_logger(__name__)
+LOG = get_logger(__name__)
 MERGE_STRATEGY = anyconfig.MS_DICTS
-
-colorama.init(autoreset=True)
 
 
 class SafeDumper(yaml.SafeDumper):

--- a/test/unit/test_logger.py
+++ b/test/unit/test_logger.py
@@ -126,3 +126,29 @@ def test_cyan_text():
     x = '{}{}{}'.format(colorama.Fore.CYAN, 'foo', colorama.Style.RESET_ALL)
 
     assert x == logger.cyan_text('foo')
+
+
+def test_markup_detection_pycolors0(monkeypatch):
+    monkeypatch.setenv('PY_COLORS', '0')
+    assert not logger.should_do_markup()
+
+
+def test_markup_detection_pycolors1(monkeypatch):
+    monkeypatch.setenv('PY_COLORS', '1')
+    assert logger.should_do_markup()
+
+
+def test_markup_detection_tty_yes(mocker):
+    mocker.patch('sys.stdout.isatty', return_value=True)
+    mocker.patch('os.environ', {'TERM': 'xterm'})
+    assert logger.should_do_markup()
+    mocker.resetall()
+    mocker.stopall()
+
+
+def test_markup_detection_tty_no(mocker):
+    mocker.patch('os.environ', {})
+    mocker.patch('sys.stdout.isatty', return_value=False)
+    assert not logger.should_do_markup()
+    mocker.resetall()
+    mocker.stopall()


### PR DESCRIPTION
Allow PY_COLORS to control coloring support.

Allow user to define PY_COLORS=1 or 0 to force use or not use of
ANSI coloring sequences.

Use of this option overrided default behavior of detecting TTY status
of stdout and allows users to control its use CI systems which
may support ANSI but where there is no TTY.

Implementation based on https://github.com/pytest-dev/py/blob/master/py/_io/terminalwriter.py#L131
which is also used by tox and many other similar tools.

Fixes: #1510