### PR TITLE
Adds docker python module as requirement

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -85,10 +85,6 @@ class Docker(base.Base):
             restart_policy: on-failure
             restart_retries: 1
 
-    .. code-block:: bash
-
-        $ sudo pip install docker-py
-
     Provide the files Molecule will preserve upon each subcommand execution.
 
     .. code-block:: yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click==6.7
 click-completion==0.3.1
 colorama==0.3.9
 cookiecutter==1.6.0
+docker>=2.0.0
 flake8==3.5.0
 python-gilt==1.2.1
 Jinja2==2.10


### PR DESCRIPTION
Adds the docker python module as requirement for molecule.
Can't find the issue or PR at the moment but if I remember correctly @ssbarnea mentioned that the user experience was somewhat lacking since out of the box Molecule doesn't work.

Since Docker is the default driver I don't see a problem with installing it as a dependency for Molecule.

The [docker_container module](https://docs.ansible.com/ansible/latest/modules/docker_container_module.html) requires >1.7.0 but the docker module only goes back to 2.0.0 on [PyPi ](https://pypi.org/project/docker/#history)(then the renaming happened from docker-py > docker). So everything above 2.0.0 should be alright.

The only point for discussion is Python 2.6 which requires the older docker-py module.
But since Ansible dropped some of the 2.6 support in [v2.7](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html) I do not see an issue in this.
Should I add the requirement for Python 2.7 somewhere in the docs?

#### PR Type

- Feature Pull Request
