### PR TITLE
Add purge_networks arg to docker driver

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -79,6 +79,7 @@ class Docker(base.Base):
               - name: foo
               - name: bar
             network_mode: host
+            purge_networks: true
             docker_host: tcp://localhost:12376
             env:
               FOO: bar

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -715,6 +715,9 @@ platforms_docker_schema = {
                 'network_mode': {
                     'type': 'string',
                 },
+                'purge_networks': {
+                    'type': 'boolean',
+                }
             }
         }
     },

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -75,6 +75,7 @@
         ulimits: "{{ item.ulimits | default(omit) }}"
         networks: "{{ item.networks | default(omit) }}"
         network_mode: "{{ item.network_mode | default(omit) }}"
+        purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -75,6 +75,7 @@
         ulimits: "{{ item.ulimits | default(omit) }}"
         networks: "{{ item.networks | default(omit) }}"
         network_mode: "{{ item.network_mode | default(omit) }}"
+        purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -97,6 +97,8 @@ def _model_platforms_docker_section_data():
             ],
             'network_mode':
             'mode',
+            'purge_networks':
+            True,
             'foo':
             'bar'
         }]
@@ -161,6 +163,7 @@ def _model_platforms_docker_errors_section_data():
                 },
             ],
             'network_mode': int(),
+            'purge_networks': int(),
         }]
     }
 
@@ -213,6 +216,7 @@ def test_platforms_docker_has_errors(_config):
                     }]
                 }],
                 'network_mode': ['must be of string type'],
+                'purge_networks': ['must be of boolean type'],
                 'ulimits': [{
                     0: ['must be of string type']
                 }],


### PR DESCRIPTION
Users building containers in isolated docker networks may not want the
default docker bridge network attached.

This exposes the docker module's `purge_networks` argument in the driver configuration.

#### PR Type
- Feature Pull Request
