### PR TITLE
Add ability to call molecule as a python module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Important Changes
 
 .. _`Move to Red Hat`: https://molecule.readthedocs.io/en/latest/contributing.html#move-to-red-hat
 .. _`quay.io`: https://quay.io/repository/ansible/molecule
+.. Molecule can now be called as a python module (python -m molecule)
 
 2.19
 ====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ History
 Unreleased
 ==========
 
+* Molecule can now be called as a python module (python -m molecule). Patch by `@ssbarnea`_.
+
+.. _`@ssbarnea`: https://github.com/ssbarnea
+
 Important Changes
 -----------------
 
@@ -13,7 +17,6 @@ Important Changes
 
 .. _`Move to Red Hat`: https://molecule.readthedocs.io/en/latest/contributing.html#move-to-red-hat
 .. _`quay.io`: https://quay.io/repository/ansible/molecule
-.. Molecule can now be called as a python module (python -m molecule)
 
 2.19
 ====

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -53,7 +53,16 @@ Install Molecule:
 
 .. code-block:: bash
 
-    $ sudo pip install molecule
+    $ pip install --user molecule
+
+Installing molecule package also installed its main script ``molecule``,
+usually in ``PATH``. Users should know that molecule can also be called as a
+python module, using ``python -m molecule ...``. This alternative method has
+some benefits:
+
+* allows to control which python interpreter is used by molecule
+* allows molecule installation at user level without even needing to have
+  the script in ``PATH``.
 
 Source
 ======

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -60,7 +60,7 @@ usually in ``PATH``. Users should know that molecule can also be called as a
 python module, using ``python -m molecule ...``. This alternative method has
 some benefits:
 
-* allows to control which python interpreter is used by molecule
+* allows to explicitly control which python interpreter is used by molecule
 * allows molecule installation at user level without even needing to have
   the script in ``PATH``.
 

--- a/molecule/__main__.py
+++ b/molecule/__main__.py
@@ -1,0 +1,25 @@
+#  Copyright (c) 2018 Red Hat, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+from .shell import main
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Also documents module calling:
    python -m molecule ...

Fixes: #1522 (#1521)

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

