### PR TITLE
RTD requirements_file: null

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,3 +5,4 @@ python:
   extra_requirements:
   - docs
   pip_install: true
+requirements_file: null


### PR DESCRIPTION
RTD failing with `Problem parsing YAML configuration. Invalid "requirements_file": path doc-requirements.txt does not exist`

#### PR Type

- Docs Pull Request
