### PR TITLE
Pass etc_hosts through to docker_container module if set in molecule config

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -75,6 +75,7 @@
         networks: "{{ item.networks | default(omit) }}"
         network_mode: "{{ item.network_mode | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
+        etc_hosts: "{{ item.etc_hosts | default(omit) }}"
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"


### PR DESCRIPTION
#### PR Type
- Feature Pull Request

Set `etc_hosts` parameter when using `docker_container` Ansible module in `create.yml`, which makes it possible to add entries to `/etc/hosts` in the container (it's not possible to modify that file once the container is started) if `etc_hosts` is set in the `platforms` item.

For example:

```yml
platforms:
  - name: xenial
    image: ubuntu:xenial
    etc_hosts:
      'test.local': '127.0.0.1'
```

Results in an entry in `/etc/hosts`

> root@xenial:/# grep test /etc/hosts
> 127.0.0.1	test.local