### PR TITLE
added an alternate Jenkinsfile and comments on Multibranch pipelines.

### DIFF
--- a/doc/source/ci.rst
+++ b/doc/source/ci.rst
@@ -144,7 +144,54 @@ Jenkins Pipeline
 
     }
 
+The following `Jenkinsfile` uses the official 'quay.io/ansible/molecule' image.
 
+.. code-block:: groovy
+
+    pipeline {
+      agent {
+        docker {
+          image 'quay.io/ansible/molecule'
+          args '-v /var/run/docker.sock:/var/run/docker.sock'
+        }
+      }
+
+      stages {
+
+        stage ('Display versions') {
+          steps {
+            sh '''
+              docker -v
+              python -V
+              ansible --version
+              molecule --version
+            '''
+          }
+        }
+
+        stage ('Molecule test') {
+          steps {
+            sh 'sudo molecule test --all'
+          }
+        }
+
+      } // close stages
+    }   // close pipeline
+
+.. note::
+
+    For Jenkins to work properly using a `Multibranch Pipeline` or a `GitHub Organisation` - as used by Blue Ocean, the role name in the scenario/playbook.yml should be changed to perform a lookup of the role root directory. For example :
+
+.. code-block:: yaml
+
+    ---
+    - name: Converge
+      hosts: all
+      roles:
+        - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+
+
+This is the cleaner of the current choices. See `issue1567_comment`_ for additional detail.
 
 Tox
 ^^^
@@ -245,3 +292,4 @@ conflict.
 .. _`Gitlab`: https://gitlab.com
 .. _`Tox`: https://tox.readthedocs.io/en/latest
 .. _`--parallel functionality`: https://tox.readthedocs.io/en/latest/config.html#cmdoption-tox-p
+.. _`issue1567_comment`: https://github.com/ansible/molecule/issues/1567#issuecomment-436876722


### PR DESCRIPTION
Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Docs Pull Request

Wit the current docs : 

- The Documented Jenkinsfile did not work on our central servers. The Jenkins sandbox environment limits some changes. I have not been able to determine if it is my specific jenkins or if it is general - so I have not removed the pipeline example.

For Jenkins :
- Jenkins renames the role root directory to the workspace name in multibranch projects. So the role is not found . After finding the comments I tested on internal roles. (  https://github.com/ansible/molecule/issues/1567#issuecomment-436876722 ) - this comment is is for general Jenkins - not just in the docker image.

For Jenkinsfile within a docker environment: 

- Added usage of the official docker image from the top of the examples section (https://molecule.readthedocs.io/en/latest/examples.html). Jenkins takes care of mounting the workspace in the container, so the only volume required to mount is the docker socket.
