### PR TITLE
Enable auto release and prerelease on pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .tox/
 .vagrant/
 .pytest_cache/
+build/
+dist/
 doc/build/
 htmlcov/
 pytestdebug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ cache:
 services:
 - docker
 
+stages:
+- test
+- release
+
 language: python
 
 .mixtures:  # is not used by Travis CI, but helps avoid duplication
@@ -287,7 +291,10 @@ jobs:
     env:
       <<: *env-functional-shard_3
       ANSIBLE_VERSION: devel
-
+  - release
+      <<: *if-cron-or-manual-run-or-tagged
+      stage: release
+      script: tox -e upload
 env:
   global:
     TOXENV_TMPL: "'ansible${ANSIBLE_VERSION}-${TESTS_TYPE}'"

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,16 @@ commands =
 extras =
     docs
 
+[testenv:upload]
+envdir = {toxworkdir}/py27-ansible25-unit
+whitelist_externals =
+    rm
+commands=
+    rm -rf dist/*
+    python setup.py sdist bdist_wheel
+    twine check dist/*
+    twine upload dist/*
+
 [testenv:pur]
 commands=
     pur -r requirements.txt


### PR DESCRIPTION
Pushed tags will release on pypi if all jobs are passing.

Cron and manual builds will pre-release on pypi if all jobs are passing.

No risks as pypi nevers allows release override. Also all non tagged
versions do count as prereleases.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

You will have to update this pull request to add TRAVIS_USERNAME and TRAVIS_PASSWORD into .travis.yml file, last one needs to be encrypted using `travis encryp` cli to secure it.

Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Feature Pull Request
