### PR TITLE
Fixing #1556 VERR_ACCESS_DENIED

### DIFF
--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -79,6 +79,7 @@ class Vagrant(base.Base):
               gui: True
             provider_raw_config_args:
               - "customize ['modifyvm', :id, '--cpuexecutioncap', '50']"
+              - "customize ['modifyvm', :id, '--uartmode1', 'disconnected']"
             provider_override_args:
               - "vm.synced_folder './', '/vagrant', disabled: true, type: 'nfs'"
             provision: True


### PR DESCRIPTION
This should fix https://github.com/ansible/molecule/issues/1556 "vagrant driver writes vagrant-console-log to installation dir instead of $TMPDIR". 

I just added `'modifyvm', :id, '--uartmode1', 'disconnected'` to the default Vagrantfile of Molecule, as this seems to fix the issue. See also https://github.com/jonashackt/molecule-ansible-docker-vagrant/blob/master/docker/molecule/vagrant-ubuntu/molecule.yml

#### PR Type

- Bugfix Pull Request
