### PR TITLE
Fixing #1603 Add openssh-client to Docker image for git+ssh support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,6 +25,7 @@ ENV PACKAGES="\
     ruby-rdoc \
     ruby-irb \
     git \
+    openssh-client
 "
 
 ENV PIP_PACKAGES="\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,7 +25,7 @@ ENV PACKAGES="\
     ruby-rdoc \
     ruby-irb \
     git \
-    openssh-client
+    openssh-client \
 "
 
 ENV PIP_PACKAGES="\


### PR DESCRIPTION
This PR addresses the issue https://github.com/ansible/molecule/issues/1603

#### PR Type

- Bugfix Pull Request