### PR TITLE
Feature: Add in entrypoint to docker provisioner config

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -54,6 +54,7 @@ class Docker(base.Base):
                 username: $USERNAME
                 password: $PASSWORD
                 email: user@example.com
+            entrypoint: bash
             command: sleep infinity
             privileged: True|False
             security_opts:

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -63,6 +63,7 @@
         state: started
         recreate: false
         log_driver: json-file
+        entrypoint: "{{ item.entrypoint | default('bash') }}"
         command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -63,6 +63,7 @@
         state: started
         recreate: false
         log_driver: json-file
+        entrypoint: "{{ item.entrypoint | default('bash') }}"
         command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"


### PR DESCRIPTION
Allow the user to set an entrypoint for their container. Currently, only `command` is supported. 

#### PR Type

- Feature Pull Request
