### PR TITLE
Remove single quotes from docker example

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -20,7 +20,7 @@ follows.
 .. code-block:: bash
 
     docker run --rm -it \
-        -v '$(pwd)':/tmp/$(basename "${PWD}"):ro \
+        -v $(pwd):/tmp/$(basename "${PWD}"):ro \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -w /tmp/$(basename "${PWD}") \
         quay.io/ansible/molecule:latest \


### PR DESCRIPTION
This PR fixes the documentation issue #1629 

```
$ docker run --rm -it \
>     -v $(pwd):/tmp/$(basename "${PWD}"):ro \
>     -v /var/run/docker.sock:/var/run/docker.sock \
>     -w /tmp/$(basename "${PWD}") \
>     quay.io/ansible/molecule:latest \
>     sudo molecule test
--> Validating schema /tmp/capside.cloudwatch-agent/molecule/default/molecule.yml.
Validation completed successfully.
--> Test matrix
    
└── default
    ├── lint
    ├── destroy
    ├── dependency
    ├── syntax
    ├── create
    ├── prepare
    ├── converge
    ├── idempotence
    ├── side_effect
    ├── verify
    └── destroy
```

#### PR Type

- Docs Pull Request

