### PR TITLE
fix #1634 - remove unnecessary packages from pip packages list in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,11 +31,8 @@ ENV PIP_PACKAGES="\
     ansible[azure] \
     virtualenv \
     molecule \
-    ansible \
     docker \
-    azure-cli \
     packaging \
-    msrestazure \
     pywinrm \
 "
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,12 +28,8 @@ ENV PACKAGES="\
 "
 
 ENV PIP_PACKAGES="\
-    ansible[azure] \
+    molecule[azure,docker,docs,ec2,gce,lxc,openstack,vagrant,windows] \
     virtualenv \
-    molecule \
-    docker \
-    packaging \
-    pywinrm \
 "
 
 ENV GEM_PACKAGES="\

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,8 @@ openstack =
     shade
 vagrant =
     python-vagrant
+windows =
+    pywinrm
 
 [pbr]
 skip_authors = True


### PR DESCRIPTION
Fixes #1634: pip packages error when running docker build.


#### PR Type

- Bugfix Pull Request

Previous errors:

```
azure-mgmt-batch 4.1.0 has requirement msrestazure~=0.4.7, but you'll have msrestazure 0.6.0 which is incompatible.
azure-mgmt-containerservice 3.0.1 has requirement msrestazure~=0.4.11, but you'll have msrestazure 0.6.0 which is incompatible.
azure-cli-batch 3.4.1 has requirement azure-mgmt-batch==5.0.1, but you'll have azure-mgmt-batch 4.1.0 which is incompatible.
azure-cli-batch 3.4.1 has requirement azure-mgmt-keyvault==1.1.0, but you'll have azure-mgmt-keyvault 0.40.0 which is incompatible.
azure-mgmt-recoveryservices 0.1.0 has requirement msrestazure~=0.4.11, but you'll have msrestazure 0.6.0 which is incompatible.
azure-mgmt-network 1.7.1 has requirement msrestazure~=0.4.11, but you'll have msrestazure 0.6.0 which is incompatible.
azure-cli-keyvault 2.2.8 has requirement azure-graphrbac==0.53.0, but you'll have azure-graphrbac 0.40.0 which is incompatible.
azure-cli-keyvault 2.2.8 has requirement azure-keyvault==1.1.0, but you'll have azure-keyvault 1.0.0a1 which is incompatible.
azure-cli-keyvault 2.2.8 has requirement azure-mgmt-keyvault==1.1.0, but you'll have azure-mgmt-keyvault 0.40.0 which is incompatible.
azure-mgmt-servicebus 0.5.3 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-storage 1.5.0 has requirement msrestazure~=0.4.11, but you'll have msrestazure 0.6.0 which is incompatible.
azure-cli-storage 2.2.7 has requirement azure-mgmt-storage==3.1.0, but you'll have azure-mgmt-storage 1.5.0 which is incompatible.
azure-cli-sql 2.1.6 has requirement azure-mgmt-sql==0.9.1, but you'll have azure-mgmt-sql 0.7.1 which is incompatible.
azure-cli-sql 2.1.6 has requirement azure-mgmt-storage==3.1.0, but you'll have azure-mgmt-storage 1.5.0 which is incompatible.
azure-cli-appservice 0.2.9 has requirement azure-mgmt-containerregistry==2.4.0, but you'll have azure-mgmt-containerregistry 2.0.0 which is incompatible.
azure-cli-appservice 0.2.9 has requirement azure-mgmt-storage==3.1.0, but you'll have azure-mgmt-storage 1.5.0 which is incompatible.
azure-cli-appservice 0.2.9 has requirement azure-mgmt-web==0.40.0, but you'll have azure-mgmt-web 0.32.0 which is incompatible.
azure-mgmt-iothub 0.6.0 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-datalake-analytics 0.2.0 has requirement msrestazure~=0.4.7, but you'll have msrestazure 0.6.0 which is incompatible.
azure-mgmt-reservations 0.3.1 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-authorization 0.50.0 has requirement azure-common>=1.1.12,~=1.1, but you'll have azure-common 1.1.11 which is incompatible.
azure-mgmt-eventhub 2.2.0 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
msrestazure 0.6.0 has requirement msrest<2.0.0,>=0.6.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-resource 1.2.2 has requirement msrestazure~=0.4.11, but you'll have msrestazure 0.6.0 which is incompatible.
azure-cli-rdbms 0.3.5 has requirement azure-mgmt-rdbms==1.5.0, but you'll have azure-mgmt-rdbms 1.2.0 which is incompatible.
azure-mgmt-signalr 0.1.1 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-cli-network 2.2.11 has requirement azure-mgmt-dns==2.1.0, but you'll have azure-mgmt-dns 1.2.0 which is incompatible.
azure-cli-network 2.2.11 has requirement azure-mgmt-network==2.4.0, but you'll have azure-mgmt-network 1.7.1 which is incompatible.
azure-cli-container 0.3.9 has requirement azure-mgmt-containerinstance==1.2.1, but you'll have azure-mgmt-containerinstance 0.4.0 which is incompatible.
azure-cli-container 0.3.9 has requirement azure-mgmt-network==2.3.0, but you'll have azure-mgmt-network 1.7.1 which is incompatible.
azure-cli-container 0.3.9 has requirement azure-mgmt-resource==2.0.0, but you'll have azure-mgmt-resource 1.2.2 which is incompatible.
azure-cli-botservice 0.1.3 has requirement azure-mgmt-web==0.40.0, but you'll have azure-mgmt-web 0.32.0 which is incompatible.
azure-mgmt-botservice 0.1.0 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-sql 0.7.1 has requirement msrestazure~=0.4.8, but you'll have msrestazure 0.6.0 which is incompatible.
azure-mgmt-cosmosdb 0.5.2 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-datalake-nspkg 3.0.1 has requirement azure-mgmt-nspkg>=3.0.0, but you'll have azure-mgmt-nspkg 2.0.0 which is incompatible.
azure-mgmt-iotcentral 1.0.0 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-cli-servicefabric 0.1.9 has requirement azure-graphrbac==0.53.0, but you'll have azure-graphrbac 0.40.0 which is incompatible.
azure-cli-servicefabric 0.1.9 has requirement azure-keyvault==1.1.0, but you'll have azure-keyvault 1.0.0a1 which is incompatible.
azure-cli-servicefabric 0.1.9 has requirement azure-mgmt-compute==4.3.1, but you'll have azure-mgmt-compute 2.1.0 which is incompatible.
azure-cli-servicefabric 0.1.9 has requirement azure-mgmt-keyvault==1.1.0, but you'll have azure-mgmt-keyvault 0.40.0 which is incompatible.
azure-cli-servicefabric 0.1.9 has requirement azure-mgmt-network==2.3.0, but you'll have azure-mgmt-network 1.7.1 which is incompatible.
azure-cli-servicefabric 0.1.9 has requirement azure-mgmt-storage==3.1.0, but you'll have azure-mgmt-storage 1.5.0 which is incompatible.
azure-cli-acr 2.1.11 has requirement azure-mgmt-containerregistry==2.4.0, but you'll have azure-mgmt-containerregistry 2.0.0 which is incompatible.
azure-cli-acr 2.1.11 has requirement azure-mgmt-storage==3.1.0, but you'll have azure-mgmt-storage 1.5.0 which is incompatible.
azure-cli-acs 2.3.13 has requirement azure-graphrbac==0.53.0, but you'll have azure-graphrbac 0.40.0 which is incompatible.
azure-cli-acs 2.3.13 has requirement azure-mgmt-compute==4.3.1, but you'll have azure-mgmt-compute 2.1.0 which is incompatible.
azure-cli-acs 2.3.13 has requirement azure-mgmt-containerservice==4.2.2, but you'll have azure-mgmt-containerservice 3.0.1 which is incompatible.
azure-mgmt-compute 2.1.0 has requirement msrestazure~=0.4.7, but you'll have msrestazure 0.6.0 which is incompatible.
azure-mgmt-hdinsight 0.1.0 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-cli-ams 0.3.1 has requirement azure-graphrbac==0.53.0, but you'll have azure-graphrbac 0.40.0 which is incompatible.
azure-cli-vm 2.2.10 has requirement azure-keyvault==1.1.0, but you'll have azure-keyvault 1.0.0a1 which is incompatible.
azure-cli-vm 2.2.10 has requirement azure-mgmt-compute==4.3.1, but you'll have azure-mgmt-compute 2.1.0 which is incompatible.
azure-cli-vm 2.2.10 has requirement azure-mgmt-keyvault==1.1.0, but you'll have azure-mgmt-keyvault 0.40.0 which is incompatible.
azure-cli-vm 2.2.10 has requirement azure-mgmt-network==2.4.0, but you'll have azure-mgmt-network 1.7.1 which is incompatible.
azure-cli-lab 0.1.4 has requirement azure-graphrbac==0.53.0, but you'll have azure-graphrbac 0.40.0 which is incompatible.
azure-mgmt-keyvault 0.40.0 has requirement msrestazure~=0.4.7, but you'll have msrestazure 0.6.0 which is incompatible.
azure-mgmt-media 1.0.1 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-advisor 2.0.1 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-dns 1.2.0 has requirement msrestazure~=0.4.11, but you'll have msrestazure 0.6.0 which is incompatible.
azure-mgmt-servicefabric 0.2.0 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.
azure-mgmt-recoveryservicesbackup 0.1.1 has requirement msrestazure~=0.4.11, but you'll have msrestazure 0.6.0 which is incompatible.
azure-cli-role 2.1.11 has requirement azure-graphrbac==0.53.0, but you'll have azure-graphrbac 0.40.0 which is incompatible.
azure-cli-role 2.1.11 has requirement azure-keyvault==1.1.0, but you'll have azure-keyvault 1.0.0a1 which is incompatible.
azure-cli-batchai 0.4.5 has requirement azure-mgmt-storage==3.1.0, but you'll have azure-mgmt-storage 1.5.0 which is incompatible.
azure-mgmt-web 0.32.0 has requirement msrestazure~=0.4.7, but you'll have msrestazure 0.6.0 which is incompatible.
[...]
```

