### PR TITLE
Docker pip

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,11 +31,8 @@ ENV PIP_PACKAGES="\
     ansible[azure] \
     virtualenv \
     molecule \
-    ansible \
     docker \
-    azure-cli \
     packaging \
-    msrestazure \
     pywinrm \
 "
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,8 +31,11 @@ ENV PIP_PACKAGES="\
     ansible[azure] \
     virtualenv \
     molecule \
+    ansible \
     docker \
+    azure-cli \
     packaging \
+    msrestazure \
     pywinrm \
 "
 

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -12,4 +12,4 @@ Requirements
 Install
 =======
 
-    $ sudo pip install docker
+    $ pip install molecule[docker]

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -7,10 +7,9 @@ Requirements
 
 * General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
 * Docker Engine
-* docker-py
-* docker
+* Docker python library https://docker-py.readthedocs.io/en/stable/
 
 Install
 =======
 
-    $ sudo pip install docker-py
+    $ sudo pip install docker


### PR DESCRIPTION
pip install docker-py is deprecated, pip install docker is correct.

see:
- https://docker-py.readthedocs.io/en/stable/
- https://pypi.org/project/docker-py/#history : not updated since 2016

Installing docker-py on a system already provisionned withb docker pip package will generate errors.

#### PR Type

- Docs Pull Request
