### PR TITLE
Update schema_v2.py

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -260,7 +260,31 @@ base_schema = {
             },
         }
     },
-    'platforms': {},
+    'platforms': {
+         'type': 'list',
+        'schema': {
+            'type': 'dict',
+            'schema': {
+                'name': {
+                    'type': 'string',
+                    'required': True,
+                },
+               'groups': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'children': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+            }
+        }  
+      
+    },
     'provisioner': {
         'type': 'dict',
         'schema': {
@@ -506,33 +530,6 @@ driver_vagrant_provider_section_schema = {
                     },
                 }
             },
-        }
-    },
-}
-
-platforms_base_schema = {
-    'platforms': {
-        'type': 'list',
-        'schema': {
-            'type': 'dict',
-            'schema': {
-                'name': {
-                    'type': 'string',
-                    'required': True,
-                },
-                'groups': {
-                    'type': 'list',
-                    'schema': {
-                        'type': 'string',
-                    }
-                },
-                'children': {
-                    'type': 'list',
-                    'schema': {
-                        'type': 'string',
-                    }
-                },
-            }
         }
     },
 }
@@ -948,7 +945,7 @@ def validate(c):
         util.merge_dicts(schema, dependency_command_nullable_schema)
 
     # Driver
-    util.merge_dicts(schema, platforms_base_schema)
+    util.merge_dicts(schema, base_schema)
     if c['driver']['name'] == 'docker':
         util.merge_dicts(schema, platforms_docker_schema)
     elif c['driver']['name'] == 'vagrant':
@@ -957,7 +954,7 @@ def validate(c):
     elif c['driver']['name'] == 'lxd':
         util.merge_dicts(schema, platforms_lxd_schema)
     else:
-        util.merge_dicts(schema, platforms_base_schema)
+        util.merge_dicts(schema, base_schema)
 
     # Verifier
     if c['verifier']['name'] == 'goss':


### PR DESCRIPTION
Platforms_base_schema destroy copy.deepcopy(base_schema). Then when validating multiply molecules it's running with errors. Eg. two moleule with different drivers. One Azure second docker . If docker will be validated first from it schema we are getting 
 'image': {
                    'type': 'string',
which is not valid for azure driver but will be in schema. 
ERROR: Failed to validate.
{'platforms': [{0: [{'image': ['must be of string type']}], 1: [{'image': ['must be of string type']}], 2: [{'image': ['must be of string type']}]}]}

Moving platforms_base_schema to base_schema and changing the util.merge_dicts fixes the issue.

#### PR Type

- Bugfix Pull Request