### PR TITLE
fix: EC2 create security group in correct vpc

### DIFF
--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -28,8 +28,14 @@
     keypair_name: molecule_key
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
+    - name: Find the vpc for the subnet
+      ec2_vpc_subnet_facts:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      register: subnet_facts
+
     - name: Create security group
       ec2_group:
+        vpc_id: "{{ subnet_facts[0].vpc_id }}"
         name: "{{ security_group_name }}"
         description: "{{ security_group_name }}"
         rules: "{{ security_group_rules }}"


### PR DESCRIPTION
Currently the securty group is created in the default vpc. If we provide
a non-default vpc_subnet_id for the Molecule instance the security group
and instance will be in different vpcs and the instance creation will
fail with:
```
"msg": "The following group names are not valid: molecule"
```

Patch the module to create the security group in the same subnet as the
instance.


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request
