### PR TITLE
fix: EC2 create security group in correct vpc

### DIFF
--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -28,12 +28,20 @@
     keypair_name: molecule_key
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
-    - name: Create security group
+    - name: Find the vpc for the subnet
+      ec2_vpc_subnet_facts:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ molecule_yml.platforms }}"
+      register: subnet_facts
+
+    - name: Create security groups
       ec2_group:
+        vpc_id: "{{ item.subnets[0].vpc_id }}"
         name: "{{ security_group_name }}"
         description: "{{ security_group_name }}"
         rules: "{{ security_group_rules }}"
         rules_egress: "{{ security_group_rules_egress }}"
+      loop: "{{ subnet_facts.results }}"
 
     - name: Test for presence of local keypair
       stat:


### PR DESCRIPTION
Currently the security group is created in the default vpc. If we provide
a non-default vpc_subnet_id for the Molecule instance the security group
and instance will be in different vpcs and the instance creation will
fail with:
```
"msg": "The following group names are not valid: molecule"
```

Patch the module to create the security group in the same subnet as the
instance. This is done for each instance mentioned in molecule.yml
platforms.


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request