### PR TITLE
Fix wrong documentation.

### DIFF
--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -45,7 +45,7 @@ class Azure(base.Base):
 
     .. code-block:: bash
 
-        $ pip install 'molecule[azure]'
+        $ pip install 'ansible[azure]'
 
     Change the options passed to the ssh client.
 


### PR DESCRIPTION
To install the azure driver you have to run pip install 'ansible[azure]'.

Signed-off-by: shortmann <kahllund@mac.com>

#### PR Type

- Docs Pull Request
