### PR TITLE
Disable YAML lint truthy rule by default

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
@@ -8,6 +8,4 @@ rules:
     max-spaces-inside: 1
     level: error
   line-length: disable
-  # NOTE(retr0h): Templates no longer fail this lint rule.
-  #               Uncomment if running old Molecule templates.
-  # truthy: disable
+  truthy: disable

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -88,7 +88,7 @@ class Delegated(base.Base):
 
     .. important::
 
-        It is the developers responsibility to configure the ssh config file.
+        It is the developer's responsibility to configure the ssh config file.
 
     .. code-block:: yaml
 

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -80,10 +80,21 @@ class Yamllint(base.Base):
 
     @property
     def default_options(self):
-        return {
+        opts = {
             's': True,
-            'truthy': False,
         }
+
+        # Config file and default flags are mutually exclusive. If 'c' or
+        # 'config-file' are specified, do not override the default
+        config_file_flags = set([
+            'c',
+            'config-file',
+        ])
+        lint_options = set(self._config.config['lint'].get('options', {}).keys())
+        if not config_file_flags.intersection(lint_options):
+            opts['d'] = '{extends: default, rules: {truthy: disable}}'
+
+        return opts
 
     @property
     def default_env(self):

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -80,22 +80,9 @@ class Yamllint(base.Base):
 
     @property
     def default_options(self):
-        opts = {
+        return {
             's': True,
         }
-
-        # Config file and default flags are mutually exclusive. If 'c' or
-        # 'config-file' are specified, do not override the default
-        config_file_flags = set([
-            'c',
-            'config-file',
-        ])
-        lint_options = self._config.config['lint'].get('options', {})
-        lint_option_keys = lint_options.keys()
-        if not config_file_flags.intersection(lint_option_keys):
-            opts['d'] = "'{extends: default, rules: {truthy: disable}}'"
-
-        return opts
 
     @property
     def default_env(self):

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -37,21 +37,8 @@ class Yamllint(base.Base):
     validity it also checks for key repetition as well as cosmetic problems
     such as line length, trailing spaces, and indentation.
 
-    The default ``yamllint`` settings that ship with ``molecule`` are:
-
-    .. code-block: yaml
-
-        extends: default
-
-        rules:
-          braces:
-            max-spaces-inside: 1
-            level: error
-          brackets:
-            max-spaces-inside: 1
-            level: error
-          line-length: disable
-          truthy: disable
+    The default ``yamllint`` settings that ship with ``molecule`` can be found
+    in the `cookiecutter template`_.
 
 
     Additional options can be passed to ``yamllint`` through the options
@@ -84,6 +71,7 @@ class Yamllint(base.Base):
 
     .. _`yamllint`: https://github.com/adrienverge/yamllint
     .. _`yamllint rules`: https://yamllint.readthedocs.io/en/stable/rules.html
+    .. _`cookiecutter template`: https://github.com/ansible/molecule/blob/master/molecule/cookiecutter/molecule/%7B%7Bcookiecutter.role_name%7D%7D/.yamllint
     """
 
     def __init__(self, config):

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -31,14 +31,32 @@ LOG = logger.get_logger(__name__)
 
 class Yamllint(base.Base):
     """
-    `Yamllint`_ is the default projet linter.
+    `yamllint`_ is the default projet linter.
 
-    `Yamllint`_ is a linter for YAML files.  In addition to checking for syntax
-    validity, also checks for key repetition, and cosmetic problems such as
-    lines length, trailing spaces, and indentation.
+    `yamllint`_ is a linter for YAML files. In addition to checking for syntax
+    validity it also checks for key repetition as well as cosmetic problems such as
+    line length, trailing spaces, and indentation.
+
+    The default ``yamllint`` settings that ship with ``molecule`` are:
+
+    .. code-block: yaml
+
+        extends: default
+
+        rules:
+          braces:
+            max-spaces-inside: 1
+            level: error
+          brackets:
+            max-spaces-inside: 1
+            level: error
+          line-length: disable
+          truthy: disable
+
 
     Additional options can be passed to ``yamllint`` through the options
-    dict.  Any option set in this section will override the defaults.
+    dict. Any option set in this section will override the defaults. See the
+    `yamllint rules`_ for more options.
 
     .. code-block:: yaml
 
@@ -47,7 +65,7 @@ class Yamllint(base.Base):
           options:
             config-file: foo/bar
 
-    The project linting can be disabled by setting ``enabled`` to False.
+    The project linting can be disabled by setting ``enabled`` to ``False``.
 
     .. code-block:: yaml
 
@@ -64,7 +82,8 @@ class Yamllint(base.Base):
           env:
             FOO: bar
 
-    .. _`Yamllint`: https://github.com/adrienverge/yamllint
+    .. _`yamllint`: https://github.com/adrienverge/yamllint
+    .. _`yamllint rules`: https://yamllint.readthedocs.io/en/stable/rules.html
     """
 
     def __init__(self, config):

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -82,6 +82,7 @@ class Yamllint(base.Base):
     def default_options(self):
         return {
             's': True,
+            'truthy': False,
         }
 
     @property

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -34,8 +34,8 @@ class Yamllint(base.Base):
     `yamllint`_ is the default projet linter.
 
     `yamllint`_ is a linter for YAML files. In addition to checking for syntax
-    validity it also checks for key repetition as well as cosmetic problems such as
-    line length, trailing spaces, and indentation.
+    validity it also checks for key repetition as well as cosmetic problems
+    such as line length, trailing spaces, and indentation.
 
     The default ``yamllint`` settings that ship with ``molecule`` are:
 

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -90,9 +90,10 @@ class Yamllint(base.Base):
             'c',
             'config-file',
         ])
-        lint_options = set(self._config.config['lint'].get('options', {}).keys())
-        if not config_file_flags.intersection(lint_options):
-            opts['d'] = '{extends: default, rules: {truthy: disable}}'
+        lint_options = self._config.config['lint'].get('options', {})
+        lint_option_keys = lint_options.keys()
+        if not config_file_flags.intersection(lint_option_keys):
+            opts['d'] = "'{extends: default, rules: {truthy: disable}}'"
 
         return opts
 

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -71,7 +71,9 @@ class Yamllint(base.Base):
 
     .. _`yamllint`: https://github.com/adrienverge/yamllint
     .. _`yamllint rules`: https://yamllint.readthedocs.io/en/stable/rules.html
-    .. _`cookiecutter template`: https://github.com/ansible/molecule/blob/master/molecule/cookiecutter/molecule/%7B%7Bcookiecutter.role_name%7D%7D/.yamllint
+    .. _`cookiecutter template`: https://github.com/ansible/molecule/blob/ma\
+        ster/molecule/cookiecutter/molecule/%7B%7Bcookiecutter.role_name%7\
+        D%7D/.yamllint
     """
 
     def __init__(self, config):

--- a/molecule/provisioner/ansible_playbook.py
+++ b/molecule/provisioner/ansible_playbook.py
@@ -51,7 +51,7 @@ class AnsiblePlaybook(object):
     def bake(self):
         """
         Bake an ``ansible-playbook`` command so it's ready to execute and
-        returns None.
+        returns ``None``.
 
         :return: None
         """

--- a/test/unit/lint/test_yamllint.py
+++ b/test/unit/lint/test_yamllint.py
@@ -75,6 +75,7 @@ def test_files_private_member(_patched_get_files, _instance):
 def test_default_options_property(_instance):
     x = {
         's': True,
+        'd': "'{extends: default, rules: {truthy: disable}}'",
     }
 
     assert x == _instance.default_options
@@ -101,6 +102,7 @@ def test_options_property(_instance):
     x = {
         's': True,
         'foo': 'bar',
+        'd': "'{extends: default, rules: {truthy: disable}}'",
     }
 
     assert x == _instance.options
@@ -113,6 +115,7 @@ def test_options_property_handles_cli_args(_instance):
     x = {
         's': True,
         'foo': 'bar',
+        'd': "'{extends: default, rules: {truthy: disable}}'",
     }
 
     # Does nothing.  The `yamllint` command does not support
@@ -127,6 +130,12 @@ def test_bake(_patched_get_files, _instance):
     x = [
         str(sh.Command('yamllint')),
         '-s',
+        '-d',
+        "'{extends:",
+        'default,',
+        'rules:',
+        '{truthy:',
+        "disable}}'",
         '--foo=bar',
         'foo.yml',
         'bar.yaml',
@@ -174,6 +183,12 @@ def test_execute_bakes(_patched_get_files, patched_run_command, _instance):
     x = [
         str(sh.Command('yamllint')),
         '-s',
+        '-d',
+        "'{extends:",
+        'default,',
+        'rules:',
+        '{truthy:',
+        "disable}}'",
         '--foo=bar',
         'foo.yml',
         'bar.yaml',

--- a/test/unit/lint/test_yamllint.py
+++ b/test/unit/lint/test_yamllint.py
@@ -75,7 +75,6 @@ def test_files_private_member(_patched_get_files, _instance):
 def test_default_options_property(_instance):
     x = {
         's': True,
-        'd': "'{extends: default, rules: {truthy: disable}}'",
     }
 
     assert x == _instance.default_options
@@ -102,7 +101,6 @@ def test_options_property(_instance):
     x = {
         's': True,
         'foo': 'bar',
-        'd': "'{extends: default, rules: {truthy: disable}}'",
     }
 
     assert x == _instance.options
@@ -115,7 +113,6 @@ def test_options_property_handles_cli_args(_instance):
     x = {
         's': True,
         'foo': 'bar',
-        'd': "'{extends: default, rules: {truthy: disable}}'",
     }
 
     # Does nothing.  The `yamllint` command does not support
@@ -130,12 +127,6 @@ def test_bake(_patched_get_files, _instance):
     x = [
         str(sh.Command('yamllint')),
         '-s',
-        '-d',
-        "'{extends:",
-        'default,',
-        'rules:',
-        '{truthy:',
-        "disable}}'",
         '--foo=bar',
         'foo.yml',
         'bar.yaml',
@@ -183,12 +174,6 @@ def test_execute_bakes(_patched_get_files, patched_run_command, _instance):
     x = [
         str(sh.Command('yamllint')),
         '-s',
-        '-d',
-        "'{extends:",
-        'default,',
-        'rules:',
-        '{truthy:',
-        "disable}}'",
         '--foo=bar',
         'foo.yml',
         'bar.yaml',

--- a/test/unit/lint/test_yamllint.py
+++ b/test/unit/lint/test_yamllint.py
@@ -75,6 +75,7 @@ def test_files_private_member(_patched_get_files, _instance):
 def test_default_options_property(_instance):
     x = {
         's': True,
+        'truthy': False,
     }
 
     assert x == _instance.default_options

--- a/test/unit/lint/test_yamllint.py
+++ b/test/unit/lint/test_yamllint.py
@@ -75,7 +75,6 @@ def test_files_private_member(_patched_get_files, _instance):
 def test_default_options_property(_instance):
     x = {
         's': True,
-        'truthy': False,
     }
 
     assert x == _instance.default_options


### PR DESCRIPTION
Ansible accepts flexible values for booleans and the default YAML lint rules should match what Ansible supports rather than enforcing strict `true/false` values. Ansible will continue to support the 1.1 pragma, e.g., `yes/no/true/false` (and more) values for boolean variables, even after the YAML 1.2 spec is released.

In the current default state, `molecule test` will fail when running `yamllint` against YAML files that Ansible considers valid. Molecule should not fail on files that Ansible considers valid.

During the [Ansible Docs meeting today](https://meetbot.fedoraproject.org/ansible-docs/2019-01-08/docs_working_group.2019-01-08-15.31.html), it was decided to use `yes/no/true/false` values in Ansible documentation to reduce confusion and be consistent.

This change aligns Molecule with what Ansible considers valid boolean values as well as Ansible documentation going forward.

There is a [feature request](https://github.com/adrienverge/yamllint/issues/150) to `yamllint` to have the `truthy` rule accept a list of valid values. If/when this is implemented in `yamllint`, we could update the Molecule defaults to only pass on the recommended boolean values, which are `yes/no/true/false` per the docs meeting earlier today.

Related:
#1308 
https://github.com/adrienverge/yamllint/issues/150

Signed-off-by: Sam Doran <sdoran@redhat.com>

#### PR Type

- Feature Pull Request