### PR TITLE
Add --molecule-idempotence-notest tag to skip-tags during idempotence…

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -42,7 +42,8 @@ class Ansible(base.Base):
     ``init`` subcommand will provide the necessary files for convenience.
 
     Molecule will skip tasks which are tagged with either `molecule-notest` or
-    `notest`.
+    `notest`. With the tag `molecule-idempotence-notest` tasks are only
+    skipped during the idempotence action step.
 
     .. important::
 
@@ -386,6 +387,10 @@ class Ansible(base.Base):
         d = {
             'skip-tags': 'molecule-notest,notest',
         }
+
+        if self._config.action == 'idempotence':
+            d['skip-tags'] += ',molecule-idempotence-notest'
+
         if self._config.debug:
             d['vvv'] = True
             d['diff'] = True

--- a/test/unit/provisioner/test_ansible_playbook.py
+++ b/test/unit/provisioner/test_ansible_playbook.py
@@ -116,6 +116,22 @@ def test_bake_does_not_have_ansible_args(_inventory_directory, _instance):
         assert sorted(x) == sorted(result)
 
 
+def test_bake_idem_does_have_skip_tag(_inventory_directory, _instance):
+    _instance._config.action = 'idempotence'
+    _instance.bake()
+
+    x = [
+        str(sh.ansible_playbook),
+        '--inventory={}'.format(_inventory_directory),
+        '--skip-tags=molecule-notest,notest,molecule-idempotence-notest',
+        'playbook',
+    ]
+
+    result = str(_instance._ansible_command).split()
+
+    assert sorted(x) == sorted(result)
+
+
 def test_execute(patched_run_command, _instance):
     _instance._ansible_command = 'patched-command'
     result = _instance.execute()


### PR DESCRIPTION
Hello,

please consider including this small patch which adds a new feature.

During the idempotence action ansible-playbook is called with a third skip-tag:

`molecule-idempotence-notest`

The tag is only used during the idempotence action and
allows to ignore tasks during this run like notest and molecule-notest do for all actions.

This provides another means to control the behaviour during task execution during
the idempotence action run. So that one is not forced to set changed_when: false and
similiar to make the idempotence action run cleanly.

#### PR Type
- Feature Pull Request
