### PR TITLE
Change italic to inline code formatting in docs

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -52,7 +52,7 @@ test roles from a monolith repo.
             └── README.md
 
 The role initialized with Molecule (baz in this case) would simply reference
-the dependant roles via it's `playbook.yml` or meta dependencies.
+the dependant roles via it's ``playbook.yml`` or meta dependencies.
 
 Molecule can test complex scenarios leveraging this technique.
 
@@ -61,7 +61,7 @@ Molecule can test complex scenarios leveraging this technique.
     $ cd monolith-repo/roles/baz
     $ molecule test
 
-Molecule is simply setting the `ANSIBLE_*` environment variables.  To view the
+Molecule is simply setting the ``ANSIBLE_*`` environment variables.  To view the
 environment variables set during a Molecule operation pass the ``--debug``
 flag.
 
@@ -77,7 +77,7 @@ flag.
     ANSIBLE_ROLES_PATH: /private/tmp/monolith-repo/roles:/private/tmp/monolith-repo/roles/baz/molecule/default/.molecule/roles
 
 Molecule can be customized any number of ways.  Updating the provisioner's env
-section in `molecule.yml` to suit the needs of the developer and layout of the
+section in ``molecule.yml`` to suit the needs of the developer and layout of the
 project.
 
 .. code-block:: yaml
@@ -179,7 +179,7 @@ Playbooks and tests can be shared across scenarios.
     │       └── molecule.yml
 
 Tests can be shared across scenarios.  In this example the `tests` directory
-lives in a shared location and `molecule.yml` is points to the shared tests.
+lives in a shared location and ``molecule.yml`` is points to the shared tests.
 
 .. code-block:: yaml
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -43,7 +43,7 @@ Requirements
 ------------
 
 Depending on the driver chosen, you may need to install additional python
-packages.  See the driver's documentation or `INSTALL.rst`, which is created
+packages.  See the driver's documentation or ``INSTALL.rst``, which is created
 when initializing a new scenario.
 
 Install

--- a/doc/source/porting.rst
+++ b/doc/source/porting.rst
@@ -25,8 +25,8 @@ cleanup of files.
 Manually
 ========
 
-1. In the basedir of your existing role, create a new `default` scenario.  This
-   scenario is equivalent to your existing Molecule v1 setup. 
+1. In the basedir of your existing role, create a new ``default`` scenario.  This
+   scenario is equivalent to your existing Molecule v1 setup.
 
 .. code-block:: bash
 
@@ -36,20 +36,20 @@ Manually
 .. important:
 
     The linting checks will likely fail since the role was not created with
-    `molecule init role`.  The errors can be ignored by placing a `.yamllint`
+    ``molecule init role``.  The errors can be ignored by placing a ``.yamllint``
     file in the project root of the role.  This will be corrected in the
     future.
 
 2. Move existing Testinfra tests to the new scenario's test directory located
-   at `molecule/default/tests/test_default.py`.
+   at ``molecule/default/tests/test_default.py``.
 
 3. If necessary port existing Serverspec tests to Testinfra.  A Testinfra
-   skeleton has been created at `molecule/default/tests/test_default.py`.
+   skeleton has been created at ``molecule/default/tests/test_default.py``.
 
-4. Port role's existing `molecule.yml` to the new format located in the
+4. Port role's existing ``molecule.yml`` to the new format located in the
    scenario's directory at `molecule/default/molecule.yml`.
 
-5. Port role's existing `playbook.yml` to the new location in the scenario's
+5. Port role's existing ``playbook.yml`` to the new location in the scenario's
    directory at `molecule/default/playbook.yml`.
 
 6. Cleanup

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -67,12 +67,12 @@ class NewInitCaller(type):
 @six.add_metaclass(NewInitCaller)
 class Config(object):
     """
-    Molecule searches the current directory for `molecule.yml` files by
+    Molecule searches the current directory for ``molecule.yml`` files by
     globbing `molecule/*/molecule.yml`.  The files are instantiated into
     a list of Molecule :class:`.Config` objects, and each Molecule subcommand
     operates on this list.
 
-    The directory in which the `molecule.yml` resides is the Scenario's
+    The directory in which the ``molecule.yml`` resides is the Scenario's
     directory.  Molecule performs most functions within this directory.
 
     The :class:`.Config` object has instantiated Dependency_, Driver_,
@@ -95,7 +95,7 @@ class Config(object):
         :param command_args: An optional dict of options passed to the
          subcommand from the CLI.
         :param ansible_args: An optional tuple of arguments provided to the
-         `ansible-playbook` command.
+         ``ansible-playbook`` command.
         :returns: None
         """
         self.molecule_file = molecule_file
@@ -282,8 +282,8 @@ class Config(object):
     def _reget_config(self):
         """
         Perform the same prioritized recursive merge from `get_config`, this
-        time, interpolating the `keep_string` left behind in the original
-        `get_config` call.  This is probably __very__ bad.
+        time, interpolating the ``keep_string`` left behind in the original
+        ``get_config`` call.  This is probably __very__ bad.
 
         :return: dict
         """
@@ -300,7 +300,7 @@ class Config(object):
 
         1. Loads Molecule defaults.
         2. Loads a base config (if provided) and merges ontop of defaults.
-        3. Loads the scenario's `molecule file` and merges ontop of previous
+        3. Loads the scenario's ``molecule file`` and merges ontop of previous
            merge.
 
         :return: dict

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -33,13 +33,13 @@ class AnsibleGalaxy(base.Base):
     """
     `Ansible Galaxy`_ is the default dependency manager.
 
-    Additional options can be passed to `ansible-galaxy install` through the
+    Additional options can be passed to ``ansible-galaxy install`` through the
     options dict.  Any option set in this section will override the defaults.
 
     .. note::
 
-        Molecule will remove any options matching '^[v]+$', and pass `-vvv`
-        to the underlying `ansible-galaxy` command when executing
+        Molecule will remove any options matching '^[v]+$', and pass ``-vvv``
+        to the underlying ``ansible-galaxy`` command when executing
         `molecule --debug`.
 
     .. code-block:: yaml
@@ -52,7 +52,7 @@ class AnsibleGalaxy(base.Base):
             role-file: requirements.yml
 
 
-    The dependency manager can be disabled by setting `enabled` to False.
+    The dependency manager can be disabled by setting ``enabled`` to False.
 
     .. code-block:: yaml
 
@@ -94,7 +94,7 @@ class AnsibleGalaxy(base.Base):
         return d
 
     # NOTE(retr0h): Override the base classes' options() to handle
-    # `ansible-galaxy` one-off.
+    # ``ansible-galaxy`` one-off.
     @property
     def options(self):
         o = self._config.config['dependency']['options']
@@ -111,7 +111,7 @@ class AnsibleGalaxy(base.Base):
 
     def bake(self):
         """
-        Bake an `ansible-galaxy` command so it's ready to execute and returns
+        Bake an ``ansible-galaxy`` command so it's ready to execute and returns
         None.
 
         :return: None
@@ -152,7 +152,7 @@ class AnsibleGalaxy(base.Base):
 
     def _setup(self):
         """
-        Prepare the system for using `ansible-galaxy` and returns None.
+        Prepare the system for using ``ansible-galaxy`` and returns None.
 
         :return: None
         """

--- a/molecule/dependency/base.py
+++ b/molecule/dependency/base.py
@@ -38,7 +38,7 @@ class Base(object):
     @abc.abstractmethod
     def execute(self):  # pragma: no cover
         """
-        Executes `cmd` and returns None.
+        Executes ``cmd`` and returns None.
 
         :return: None
         """
@@ -47,7 +47,7 @@ class Base(object):
     @abc.abstractproperty
     def default_options(self):  # pragma: no cover
         """
-        Default CLI arguments provided to `cmd` and returns a dict.
+        Default CLI arguments provided to ``cmd`` and returns a dict.
 
         :return: dict
         """
@@ -56,7 +56,7 @@ class Base(object):
     @abc.abstractproperty
     def default_env(self):  # pragma: no cover
         """
-        Default env variables provided to `cmd` and returns a dict.
+        Default env variables provided to ``cmd`` and returns a dict.
 
         :return: dict
         """

--- a/molecule/dependency/gilt.py
+++ b/molecule/dependency/gilt.py
@@ -33,7 +33,7 @@ class Gilt(base.Base):
     """
     `Gilt`_ is an alternate dependency manager.
 
-    Additional options can be passed to `gilt overlay` through the options
+    Additional options can be passed to ``gilt overlay`` through the options
     dict.  Any option set in this section will override the defaults.
 
     .. code-block:: yaml
@@ -44,7 +44,7 @@ class Gilt(base.Base):
             debug: True
 
 
-    The dependency manager can be disabled by setting `enabled` to False.
+    The dependency manager can be disabled by setting ``enabled`` to False.
 
     .. code-block:: yaml
 
@@ -85,7 +85,7 @@ class Gilt(base.Base):
 
     def bake(self):
         """
-        Bake a `gilt` command so it's ready to execute and returns None.
+        Bake a ``gilt`` command so it's ready to execute and returns None.
 
         :return: None
         """

--- a/molecule/dependency/shell.py
+++ b/molecule/dependency/shell.py
@@ -31,15 +31,15 @@ LOG = logger.get_logger(__name__)
 
 class Shell(base.Base):
     """
-    `Shell` is an alternate dependency manager.  It is intended to run a
+    ``Shell`` is an alternate dependency manager.  It is intended to run a
     command in situations where `Ansible Galaxy`_ and `Gilt`_ don't suffice.
 
-    The `command` to execute is required, and is relative to Molecule's project
+    The ``command`` to execute is required, and is relative to Molecule's project
     directory when referencing a script not in $PATH.
 
     .. note::
 
-        Unlike the other dependency managers, `options` are ignored and not
+        Unlike the other dependency managers, ``options`` are ignored and not
         passed to `shell`.  Additional flags/subcommands should simply be added
         to the `command`.
 
@@ -49,7 +49,7 @@ class Shell(base.Base):
           name: shell
           command: path/to/command --flag1 subcommand --flag2
 
-    The dependency manager can be disabled by setting `enabled` to False.
+    The dependency manager can be disabled by setting ``enabled`` to False.
 
     .. code-block:: yaml
 
@@ -89,7 +89,7 @@ class Shell(base.Base):
 
     def bake(self):
         """
-        Bake a `shell` command so it's ready to execute and returns None.
+        Bake a ``shell`` command so it's ready to execute and returns None.
 
         :return: None
         """

--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -29,10 +29,10 @@ LOG = logger.get_logger(__name__)
 class Azure(base.Base):
     """
     The class responsible for managing `Azure`_ instances.  `Azure`_
-    is `not` the default driver used in Molecule.
+    is ``not`` the default driver used in Molecule.
 
     Molecule leverages Ansible's `azure_module`_, by mapping variables
-    from `molecule.yml` into `create.yml` and `destroy.yml`.
+    from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. _`azure_module`: http://docs.ansible.com/ansible/latest/guide_azure.html
 

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -73,7 +73,7 @@ class Base(object):
     @abc.abstractproperty
     def login_cmd_template(self):  # pragma: no cover
         """
-        The login command template to be populated by `login_options` and
+        The login command template to be populated by ``login_options`` and
         returns a string.
 
         :returns: str

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -31,7 +31,7 @@ class Delegated(base.Base):
     the default driver used in Molecule.
 
     Under this driver, it is the developers responsibility to implement the
-    create and destroy playbooks.  `Managed` is the default behaviour of all
+    create and destroy playbooks.  ``Managed`` is the default behaviour of all
     drivers.
 
     .. code-block:: yaml
@@ -94,7 +94,7 @@ class Delegated(base.Base):
         platforms:
           - name: instance-vagrant
 
-    Provide the files Molecule will preserve post `destroy` action.
+    Provide the files Molecule will preserve post ``destroy`` action.
 
     .. code-block:: yaml
 

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -34,7 +34,7 @@ class Docker(base.Base):
     the default driver used in Molecule.
 
     Molecule leverages Ansible's `docker_container`_ module, by mapping
-    variables from `molecule.yml` into `create.yml` and `destroy.yml`.
+    variables from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. _`docker_container`: http://docs.ansible.com/ansible/latest/docker_container_module.html
 

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -29,10 +29,10 @@ LOG = logger.get_logger(__name__)
 class EC2(base.Base):
     """
     The class responsible for managing `EC2`_ instances.  `EC2`_
-    is `not` the default driver used in Molecule.
+    is ``not`` the default driver used in Molecule.
 
     Molecule leverages Ansible's `ec2_module`_, by mapping variables from
-    `molecule.yml` into `create.yml` and `destroy.yml`.
+    ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. _`ec2_module`: http://docs.ansible.com/ansible/latest/ec2_module.html
 

--- a/molecule/driver/gce.py
+++ b/molecule/driver/gce.py
@@ -36,7 +36,7 @@ class GCE(base.Base):
     has deployed project wide ssh key.
 
     Molecule leverages Ansible's `gce_module`_, by mapping variables from
-    `molecule.yml` into `create.yml` and `destroy.yml`.
+    ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. _`gce_module`: http://docs.ansible.com/ansible/latest/gce_module.html
 

--- a/molecule/driver/linode.py
+++ b/molecule/driver/linode.py
@@ -29,7 +29,7 @@ class Linode(base.Base):
     is `not` the default driver used in Molecule.
 
     Molecule leverages Ansible's `linode_module`_, by mapping variables
-    from `molecule.yml` into `create.yml` and `destroy.yml`.
+    from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. important::
 

--- a/molecule/driver/lxc.py
+++ b/molecule/driver/lxc.py
@@ -30,7 +30,7 @@ class LXC(base.Base):
     default driver used in Molecule.
 
     Molecule leverages Ansible's `lxc_container`_ module, by mapping variables
-    from `molecule.yml` into `create.yml` and `destroy.yml`.
+    from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. _`lxc_container`: http://docs.ansible.com/ansible/latest/lxc_container_module.html
 

--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -30,7 +30,7 @@ class LXD(base.Base):
     default driver used in Molecule.
 
     Molecule leverages Ansible's `lxd_container`_ module, by mapping variables
-    from `molecule.yml` into `create.yml` and `destroy.yml`.
+    from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
     The `lxd_container`_ module leverages the LXD API. Usefull information
     about, for example the source variable can be found in the `LXD API documentation`.
 

--- a/molecule/driver/openstack.py
+++ b/molecule/driver/openstack.py
@@ -32,7 +32,7 @@ class Openstack(base.Base):
     is `not` the default driver used in Molecule.
 
     Molecule leverages Ansible's `openstack_module`_, by mapping variables
-    from `molecule.yml` into `create.yml` and `destroy.yml`.
+    from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. _`openstack_module`: http://docs.ansible.com/ansible/latest/os_server_module.html
 

--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -33,23 +33,23 @@ class Vagrant(base.Base):
     `not` the default driver used in Molecule.
 
     Molecule leverages Molecule's own :ref:`molecule_vagrant_module`, by
-    mapping variables from `molecule.yml` into `create.yml` and `destroy.yml`.
+    mapping variables from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. important::
 
         This driver is alpha quality software.  Do not perform any additonal
-        tasks inside the `create` playbook.  Molecule does not know about the
-        Vagrant instances' configuration until the `converge` playbook is
+        tasks inside the ``create`` playbook.  Molecule does not know about the
+        Vagrant instances' configuration until the ``converge`` playbook is
         executed.
 
-        The `create` playbook boots instances, then the instance data is
+        The ``create`` playbook boots instances, then the instance data is
         written to disk.  The instance data is then added to Molecule's Ansible
         inventory on the next execution of `molecule.command.create`, which
-        happens to be the `converge` playbook.
+        happens to be the ``converge`` playbook.
 
         This is an area needing improvement.  Gluing togher Ansible playbook
         return data and molecule is clunky.  Moving the playbook execution
-        from `sh` to python is less than ideal, since the playbook's return
+        from ``sh`` to python is less than ideal, since the playbook's return
         data needs handled by an internal callback plugin.
 
         Operating this far inside Ansible's internals doesn't feel right.  Nor

--- a/molecule/interpolation.py
+++ b/molecule/interpolation.py
@@ -27,7 +27,7 @@ class InvalidInterpolation(Exception):
 class Interpolator(object):
     """
     Configuration options may contain environment variables.  For example,
-    suppose the shell contains `VERIFIER_NAME=testinfra` and the following
+    suppose the shell contains ``VERIFIER_NAME=testinfra`` and the following
     molecule.yml is supplied.
 
     .. code-block:: yaml
@@ -35,27 +35,27 @@ class Interpolator(object):
         verifier:
           - name: ${VERIFIER_NAME}
 
-    Molecule will substitute `$VERIFIER_NAME` with the value of the
-    `VERIFIER_NAME` environment variable.
+    Molecule will substitute ``$VERIFIER_NAME`` with the value of the
+    ``VERIFIER_NAME`` environment variable.
 
     .. warning::
 
         If an environment variable is not set, Molecule substitutes with an
         empty string.
 
-    Both `$VARIABLE` and `${VARIABLE}` syntax are supported. Extended
-    shell-style features, such as `${VARIABLE-default}` and
-    `${VARIABLE:-default}` are also supported.
+    Both ``$VARIABLE`` and ``${VARIABLE}`` syntax are supported. Extended
+    shell-style features, such as ``${VARIABLE-default}`` and
+    ``${VARIABLE:-default}`` are also supported.
 
     If a literal dollar sign is needed in a configuration, use a double dollar
     sign (`$$`).
 
-    Molecule will substitute special `MOLECULE_` environment variables defined
+    Molecule will substitute special ``MOLECULE_`` environment variables defined
     in `molecule.yml`.
 
     .. important::
 
-        Remember, the `MOLECULE_` namespace is reserved for Molecule.  Do not
+        Remember, the ``MOLECULE_`` namespace is reserved for Molecule.  Do not
         prefix your own variables with `MOLECULE_`.
 
     A file may be placed in the root of the project as `env.yml`, and Molecule

--- a/molecule/lint/base.py
+++ b/molecule/lint/base.py
@@ -38,7 +38,7 @@ class Base(object):
     @abc.abstractproperty
     def default_options(self):  # pragma: no cover
         """
-        Default CLI arguments provided to `cmd` and returns a dict.
+        Default CLI arguments provided to ``cmd`` and returns a dict.
 
         :return: dict
         """
@@ -47,7 +47,7 @@ class Base(object):
     @abc.abstractproperty
     def default_env(self):  # pragma: no cover
         """
-        Default env variables provided to `cmd` and returns a dict.
+        Default env variables provided to ``cmd`` and returns a dict.
 
         :return: dict
         """
@@ -56,7 +56,7 @@ class Base(object):
     @abc.abstractmethod
     def execute(self):  # pragma: no cover
         """
-        Executes `cmd` and returns None.
+        Executes ``cmd`` and returns None.
 
         :return: None
         """

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -37,7 +37,7 @@ class Yamllint(base.Base):
     validity, also checks for key repetition, and cosmetic problems such as
     lines length, trailing spaces, and indentation.
 
-    Additional options can be passed to `yamllint` through the options
+    Additional options can be passed to ``yamllint`` through the options
     dict.  Any option set in this section will override the defaults.
 
     .. code-block:: yaml
@@ -47,7 +47,7 @@ class Yamllint(base.Base):
           options:
             config-file: foo/bar
 
-    The project linting can be disabled by setting `enabled` to False.
+    The project linting can be disabled by setting ``enabled`` to False.
 
     .. code-block:: yaml
 
@@ -69,7 +69,7 @@ class Yamllint(base.Base):
 
     def __init__(self, config):
         """
-        Sets up the requirements to execute `yamllint` and returns None.
+        Sets up the requirements to execute ``yamllint`` and returns None.
 
         :param config: An instance of a Molecule config.
         :return: None
@@ -90,7 +90,7 @@ class Yamllint(base.Base):
 
     def bake(self):
         """
-        Bake a `yamllint` command so it's ready to execute and returns None.
+        Bake a ``yamllint`` command so it's ready to execute and returns None.
 
         :return: None
         """

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -39,9 +39,9 @@ class Ansible(base.Base):
 
     Molecule's provisioner manages the instances lifecycle.  However, the user
     must provide the create, destroy, and converge playbooks.  Molecule's
-    `init` subcommand will provide the necessary files for convenience.
+    ``init`` subcommand will provide the necessary files for convenience.
 
-    Molecule will skip tasks which are taged with either `molecule-notest` or
+    Molecule will skip tasks which are taged with either ``molecule-notest`` or
     `notest`.
 
     .. important::
@@ -56,7 +56,7 @@ class Ansible(base.Base):
         data into the instance_conf_dict fact in the create playbook.  This
         allows Molecule to properly configure Ansible inventory.
 
-    Additional options can be passed to `ansible-playbook` through the options
+    Additional options can be passed to ``ansible-playbook`` through the options
     dict.  Any option set in this section will override the defaults.
 
     .. important::
@@ -65,13 +65,13 @@ class Ansible(base.Base):
 
     .. note::
 
-        Molecule will remove any options matching '^[v]+$', and pass `-vvv`
-        to the underlying `ansible-playbook` command when executing
+        Molecule will remove any options matching '^[v]+$', and pass ``-vvv``
+        to the underlying ``ansible-playbook`` command when executing
         `molecule --debug`.
 
-    Molecule will silence log output, unless invoked with the `--debug` flag.
+    Molecule will silence log output, unless invoked with the ``--debug`` flag.
     However, this results in quite a bit of output.  To enable Ansible log
-    output, add the following to the `provisioner` section of `molecule.yml`.
+    output, add the following to the ``provisioner`` section of ``molecule.yml``.
 
     .. code-block:: yaml
 
@@ -140,7 +140,7 @@ class Ansible(base.Base):
 
     The side effect playbook executes actions which produce side effects to the
     instances(s).  Intended to test HA failover scenarios or the like.  It is
-    not enabled by default.  Add the following to the provisioner's `playbooks`
+    not enabled by default.  Add the following to the provisioner's ``playbooks``
     section to enable.
 
     .. code-block:: yaml
@@ -256,7 +256,7 @@ class Ansible(base.Base):
         The source directory linking is relative to the scenario's
         directory.
 
-        The only valid keys are `group_vars` and `host_vars`.  Molecule's
+        The only valid keys are ``group_vars`` and ``host_vars``.  Molecule's
         schema validator will enforce this.
 
     .. code-block:: yaml
@@ -522,7 +522,7 @@ class Ansible(base.Base):
 
     def check(self):
         """
-        Executes `ansible-playbook` against the converge playbook with the
+        Executes ``ansible-playbook`` against the converge playbook with the
         ``--check`` flag and returns None.
 
         :return: None
@@ -533,7 +533,7 @@ class Ansible(base.Base):
 
     def converge(self, playbook=None, **kwargs):
         """
-        Executes `ansible-playbook` against the converge playbook unless
+        Executes ``ansible-playbook`` against the converge playbook unless
         specified otherwise and returns a string.
 
         :param playbook: An optional string containing an absolute path to a
@@ -550,7 +550,7 @@ class Ansible(base.Base):
 
     def destroy(self):
         """
-        Executes `ansible-playbook` against the destroy playbook and returns
+        Executes ``ansible-playbook`` against the destroy playbook and returns
         None.
 
         :return: None
@@ -560,7 +560,7 @@ class Ansible(base.Base):
 
     def side_effect(self):
         """
-        Executes `ansible-playbook` against the side_effect playbook and
+        Executes ``ansible-playbook`` against the side_effect playbook and
         returns None.
 
         :return: None
@@ -570,7 +570,7 @@ class Ansible(base.Base):
 
     def create(self):
         """
-        Executes `ansible-playbook` against the create playbook and returns
+        Executes ``ansible-playbook`` against the create playbook and returns
         None.
 
         :return: None
@@ -580,7 +580,7 @@ class Ansible(base.Base):
 
     def prepare(self):
         """
-        Executes `ansible-playbook` against the prepare playbook and returns
+        Executes ``ansible-playbook`` against the prepare playbook and returns
         None.
 
         :return: None
@@ -590,7 +590,7 @@ class Ansible(base.Base):
 
     def syntax(self):
         """
-        Executes `ansible-playbook` against the converge playbook with the
+        Executes ``ansible-playbook`` against the converge playbook with the
         ``-syntax-check`` flag and returns None.
 
         :return: None
@@ -601,7 +601,7 @@ class Ansible(base.Base):
 
     def verify(self):
         """
-        Executes `ansible-playbook` against the verify playbook and returns
+        Executes ``ansible-playbook`` against the verify playbook and returns
         None.
 
         :return: None

--- a/molecule/provisioner/ansible_playbook.py
+++ b/molecule/provisioner/ansible_playbook.py
@@ -29,15 +29,15 @@ LOG = logger.get_logger(__name__)
 class AnsiblePlaybook(object):
     def __init__(self, playbook, config, out=LOG.out, err=LOG.error):
         """
-        Sets up the requirements to execute `ansible-playbook` and returns
+        Sets up the requirements to execute ``ansible-playbook`` and returns
         None.
 
         :param playbook: A string containing the path to the playbook.
         :param config: An instance of a Molecule config.
         :param out: An optional function to process STDOUT for underlying
-         :func:`sh` call.
+         :func:``sh`` call.
         :param err: An optional function to process STDERR for underlying
-         :func:`sh` call.
+         :func:``sh`` call.
         :returns: None
         """
         self._ansible_command = None
@@ -50,7 +50,7 @@ class AnsiblePlaybook(object):
 
     def bake(self):
         """
-        Bake an `ansible-playbook` command so it's ready to execute and returns
+        Bake an ``ansible-playbook`` command so it's ready to execute and returns
         None.
 
         :return: None
@@ -78,7 +78,7 @@ class AnsiblePlaybook(object):
 
     def execute(self):
         """
-        Executes `ansible-playbook` and returns a string.
+        Executes ``ansible-playbook`` and returns a string.
 
         :return: str
         """

--- a/molecule/provisioner/base.py
+++ b/molecule/provisioner/base.py
@@ -39,7 +39,7 @@ class Base(object):
     @abc.abstractproperty
     def default_options(self):  # pragma: no cover
         """
-        Default CLI arguments provided to `cmd` and returns a dict.
+        Default CLI arguments provided to ``cmd`` and returns a dict.
 
         :return: dict
         """
@@ -48,7 +48,7 @@ class Base(object):
     @abc.abstractproperty
     def default_env(self):  # pragma: no cover
         """
-        Default env variables provided to `cmd` and returns a dict.
+        Default env variables provided to ``cmd`` and returns a dict.
 
         :return: dict
         """

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -34,7 +34,7 @@ class Scenario(object):
 
     A scenario is a self-contained directory containing everything necessary
     for testing the role in a particular way.  The default scenario is named
-    `default`, and every role should contain a default scenario.
+    ``default``, and every role should contain a default scenario.
 
     Any option set in this section will override the defaults.
 

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -91,7 +91,7 @@ def run_command(cmd, debug=False):
     """
     Execute the given command and returns None.
 
-    :param cmd: A `sh.Command` object to execute.
+    :param cmd: A ``sh.Command`` object to execute.
     :param debug: An optional bool to toggle debug output.
     :return: ``sh`` object
     """

--- a/molecule/verifier/base.py
+++ b/molecule/verifier/base.py
@@ -52,7 +52,7 @@ class Base(object):
     @abc.abstractproperty
     def default_options(self):  # pragma: no cover
         """
-        Default CLI arguments provided to `cmd` and returns a dict.
+        Default CLI arguments provided to ``cmd`` and returns a dict.
 
         :return: dict
         """
@@ -61,7 +61,7 @@ class Base(object):
     @abc.abstractproperty
     def default_env(self):  # pragma: no cover
         """
-        Default env variables provided to `cmd` and returns a dict.
+        Default env variables provided to ``cmd`` and returns a dict.
 
         :return: dict
         """
@@ -70,7 +70,7 @@ class Base(object):
     @abc.abstractmethod
     def execute(self):  # pragma: no cover
         """
-        Executes `cmd` and returns None.
+        Executes ``cmd`` and returns None.
 
         :return: None
         """

--- a/molecule/verifier/goss.py
+++ b/molecule/verifier/goss.py
@@ -39,7 +39,7 @@ class Goss(base.Base):
     and execute Goss using a community written Goss Ansible module bundled with
     Molecule.
 
-    Additional options can be passed to `goss validate` by modifying the verify
+    Additional options can be passed to ``goss validate`` by modifying the verify
     playbook.
 
     .. code-block:: yaml
@@ -49,7 +49,7 @@ class Goss(base.Base):
           lint:
             name: yamllint
 
-    The testing can be disabled by setting `enabled` to False.
+    The testing can be disabled by setting ``enabled`` to False.
 
     .. code-block:: yaml
 
@@ -84,7 +84,7 @@ class Goss(base.Base):
 
     def __init__(self, config):
         """
-        Sets up the requirements to execute `goss` and returns None.
+        Sets up the requirements to execute ``goss`` and returns None.
 
         :param config: An instance of a Molecule config.
         :return: None

--- a/molecule/verifier/inspec.py
+++ b/molecule/verifier/inspec.py
@@ -43,10 +43,10 @@ class Inspec(base.Base):
     Ansible transport, in an attempt to provide Inspec support across all
     Molecule drivers.
 
-    Additional options can be passed to `inspec exec` by modifying the verify
+    Additional options can be passed to ``inspec exec`` by modifying the verify
     playbook.
 
-    The testing can be disabled by setting `enabled` to False.
+    The testing can be disabled by setting ``enabled`` to False.
 
     .. code-block:: yaml
 
@@ -81,7 +81,7 @@ class Inspec(base.Base):
 
     def __init__(self, config):
         """
-        Sets up the requirements to execute `inspec` and returns None.
+        Sets up the requirements to execute ``inspec`` and returns None.
 
         :param config: An instance of a Molecule config.
         :return: None

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -34,13 +34,13 @@ class Testinfra(base.Base):
     """
     `Testinfra`_ is the default test runner.
 
-    Additional options can be passed to `testinfra` through the options
+    Additional options can be passed to ``testinfra`` through the options
     dict.  Any option set in this section will override the defaults.
 
     .. note::
 
-        Molecule will remove any options matching '^[v]+$', and pass `-vvv`
-        to the underlying `py.test` command when executing `molecule --debug`.
+        Molecule will remove any options matching '^[v]+$', and pass ``-vvv``
+        to the underlying ``py.test`` command when executing ``molecule --debug``.
 
     .. code-block:: yaml
 
@@ -49,7 +49,7 @@ class Testinfra(base.Base):
           options:
             n: 1
 
-    The testing can be disabled by setting `enabled` to False.
+    The testing can be disabled by setting ``enabled`` to False.
 
     .. code-block:: yaml
 
@@ -91,7 +91,7 @@ class Testinfra(base.Base):
 
     def __init__(self, config):
         """
-        Sets up the requirements to execute `testinfra` and returns None.
+        Sets up the requirements to execute ``testinfra`` and returns None.
 
         :param config: An instance of a Molecule config.
         :return: None
@@ -118,7 +118,7 @@ class Testinfra(base.Base):
         return d
 
     # NOTE(retr0h): Override the base classes' options() to handle
-    # `ansible-galaxy` one-off.
+    # ``ansible-galaxy`` one-off.
     @property
     def options(self):
         o = self._config.config['verifier']['options']
@@ -150,7 +150,7 @@ class Testinfra(base.Base):
 
     def bake(self):
         """
-        Bake a `testinfra` command so it's ready to execute and returns None.
+        Bake a ``testinfra`` command so it's ready to execute and returns None.
 
         :return: None
         """


### PR DESCRIPTION
Most of the items that (I think) should have been formatting as inline code were actually italic. Some were inline code formatted while most were italic. This PR changes them all to be inline code formatted.

#### PR Type

- Docs Pull Request

