### PR TITLE
[ON HOLD] 1699 lint at 160

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,4 @@
 exclude = .venv/,.tox/,dist/,build/,doc/,.eggs/,molecule/provisioner/ansible/plugins/libraries/goss.py
 format = pylint
 ignore = E741,W503
+max-line-length = 160

--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,7 @@ argument-rgx=[a-z_][a-z0-9_]{0,30}$
 
 [FORMAT]
 
-max-line-length=79
+max-line-length=160
 max-module-lines=1000
 
 [VARIABLES]

--- a/.yamllint
+++ b/.yamllint
@@ -10,4 +10,9 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  line-length: disable
+  line-length:
+    allow-non-breakable-inline-mappings: true
+    allow-non-breakable-words: true
+    max: 160
+  truthy: disable
+

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
@@ -11,4 +11,3 @@ rules:
     allow-non-breakable-inline-mappings: true
     allow-non-breakable-words: true
     max: 160
-  truthy: disable

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
@@ -7,7 +7,8 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  line-length: disable
-  # NOTE(retr0h): Templates no longer fail this lint rule.
-  #               Uncomment if running old Molecule templates.
-  # truthy: disable
+  line-length:
+    allow-non-breakable-inline-mappings: true
+    allow-non-breakable-words: true
+    max: 160
+  truthy: disable

--- a/test/resources/.yamllint
+++ b/test/resources/.yamllint
@@ -7,5 +7,8 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  line-length: disable
+  line-length:
+    allow-non-breakable-inline-mappings: true
+    allow-non-breakable-words: true
+    max: 160
   truthy: disable

--- a/test/resources/playbooks/azure/create.yml
+++ b/test/resources/playbooks/azure/create.yml
@@ -69,7 +69,7 @@
 
 
     # Mandatory configuration for Molecule to function.
-
+    # yamllint disable rule:line-length
     - name: Populate instance config dict
       set_fact:
         instance_conf_dict: {
@@ -81,6 +81,7 @@
       with_items: "{{ azure_jobs.results }}"
       register: instance_config_dict
       when: server.changed | bool
+      # yamllint enable rule:line-length
 
     - name: Convert instance config dict to a list
       set_fact:


### PR DESCRIPTION
fixes # 1699 
lint at 160 for flake8, yamllint, pylint
keep behaviour of  ansible-lint with its default value: [E204] Lines should be no longer than 120 chars

#### PR Type

- Bugfix Pull Request

