### PR TITLE
Explicitly call out commonly needed fields to run systemd in docker

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -37,6 +37,7 @@ class Docker(base.Base):
     variables from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
     .. _`docker_container`: http://docs.ansible.com/ansible/latest/docker_container_module.html
+    .. _`Docker Security Configuration`: https://docs.docker.com/engine/reference/run/#security-configuration
 
     .. code-block:: yaml
 
@@ -86,6 +87,26 @@ class Docker(base.Base):
             restart_retries: 1
             buildargs:
                 http_proxy: http://proxy.example.com:8080/
+
+    When attempting to utilize a container image with `systemd`_ as your init
+    system inside the container to simulate a real machine, make sure to set
+    the ``privileged``, ``volume_mounts``, ``command``, and ``environment``
+    values. An example using the ``centos:7`` image is below:
+
+    .. note:: Do note that running containers in privileged mode is considerably
+              less secure. For details, please reference `Docker Security
+              Configuration`_
+
+    .. code-block:: yaml
+
+        platforms:
+        - name: instance
+            image: centos:7
+            privileged: true
+            volume_mounts:
+            - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+            command: "/usr/sbin/init"
+            environment: { container: docker }
 
     .. code-block:: bash
 


### PR DESCRIPTION
Added some docs in the `docker` driver configuration section to explicitly highlight what's needed to utilize systemd inside the target container.

Signed-off-by: Adam Miller <admiller@redhat.com>

#### PR Type
- Docs Pull Request

