### PR TITLE
Revert "Parallelize unit tests on the pytest level"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ extras =
     openstack
     vagrant
 commands =
-    unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail -n auto {posargs}
+    unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
     functional: pytest test/functional/ {posargs}
     lint: flake8
     lint: yamllint -s test/ molecule/


### PR DESCRIPTION
This reverts commit a657ef867e9155ef8108ad8d61492ed416ffb3f2.

fix #1713 parallel run of unit tests provokes random fails of builds 

#### PR Type

- Bugfix Pull Request

