### PR TITLE
doc: avoid MOLECULE_EPHEMERAL_DIRECTORY with tox

### DIFF
--- a/doc/source/ci.rst
+++ b/doc/source/ci.rst
@@ -183,7 +183,8 @@ To view the factor generated tox environments.
 
 If using the `--parallel functionality`_ of Tox (version 3.7 onwards), Molecule
 must be made aware of the parallel testing by setting a
-``MOLECULE_EPHEMERAL_DIRECTORY`` environment variable per environment.
+``MOLECULE_EPHEMERAL_DIRECTORY`` environment variable per environment. In addition,
+we export a ``TOX_ENVNAME`` environment variable, it's the name of our tox env.
 
 .. code-block:: ini
 
@@ -200,14 +201,16 @@ must be made aware of the parallel testing by setting a
     commands =
         molecule test
     setenv =
-        MOLECULE_EPHEMERAL_DIRECTORY={envname}
+        TOX_ENVNAME={envname}
+        MOLECULE_EPHEMERAL_DIRECTORY=/tmp/{envname}
 
 If you are utilizing the Openstack driver you will have to make sure that your
 ``envname`` variable does not contain any invalid characters, particularly
 ``-``.
 
-You also must include the ``MOLECULE_EPHEMERAL_DIRECTORY`` variable in the
-``molecule.yml`` configuration file.
+You also must include the ``TOX_ENVNAME`` variable in name of each platform in
+``molecule.yml`` configuration file. This way, ther names won't create any
+conflict.
 
 .. code-block:: yaml
 
@@ -219,9 +222,9 @@ You also must include the ``MOLECULE_EPHEMERAL_DIRECTORY`` variable in the
     lint:
       name: yamllint
     platforms:
-      - name: instance1-$MOLECULE_EPHEMERAL_DIRECTORY
+      - name: instance1-$TOX_ENVNAME
         image: mariadb
-      - name: instance2-$MOLECULE_EPHEMERAL_DIRECTORY
+      - name: instance2-$TOX_ENVNAME
         image: retr0h/centos7-systemd-ansible:latest
         privileged: True
         command: /usr/sbin/init


### PR DESCRIPTION
If an `MOLECULE_EPHEMERAL_DIRECTORY` environment variable is defined
before `molecule` startup, it will be used to compute the
`ephemeral_directory` variable[1].

In config, `ephemeral_directory` is used to overwrite
`MOLECULE_EPHEMERAL_DIRECTORY`[2].

As a result:
- `MOLECULE_EPHEMERAL_DIRECTORY` is different
- it can content a /, which is not a good fit in a docker or VM name

This commit promotes a new environment variables called `TOX_ENVNAME` to
avoid any conflict.

[1]: https://github.com/ansible/molecule/blob/master/molecule/scenario.py#L182-L186
[2]: https://github.com/ansible/molecule/blob/master/molecule/config.py#L193


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Docs Pull Request