### PR TITLE
Don't truncate error log and disable line length checks

### DIFF
--- a/molecule/util.py
+++ b/molecule/util.py
@@ -102,7 +102,7 @@ def run_command(cmd, debug=False):
         print_environment_vars(cmd._partial_call_args.get('env', {}))
         print_debug('COMMAND', str(cmd))
         print()
-    return cmd()
+    return cmd(_truncate_exc=False)
 
 
 def os_walk(directory, pattern, excludes=[]):

--- a/test/scenarios/host_group_vars/molecule/default/playbook.yml
+++ b/test/scenarios/host_group_vars/molecule/default/playbook.yml
@@ -10,7 +10,8 @@
       changed_when: false
 
     - name: Group vars group_var for group example from molecule.yml
-      command: echo "{{ host_group_vars_example_group_one_molecule_yml }} {{ host_group_vars_example_group_two_molecule_yml }}"
+      command: |-
+        echo "{{ host_group_vars_example_group_one_molecule_yml }} {{ host_group_vars_example_group_two_molecule_yml }}"
       changed_when: false
 
     - name: Group vars from group_vars existing directory


### PR DESCRIPTION
#### PR Type

* Bugfix Pull Request

  * Don't truncate error log; attached files are available for reviewers to compare ([stdout_not_truncated.log](https://github.com/ansible/molecule/files/2815528/stdout_not_truncated.log), [stdout_truncated.log](https://github.com/ansible/molecule/files/2815529/stdout_truncated.log))
  * `test_host_group_vars` test: Fix `Lines should be no longer than 120 chars` (`ansible-lint`) error
     Can be tested using: `tox -e py27-ansible24-functional -- -k test_host_group_vars test/functional/docker/test_scenarios.py` (closes #1712)