### PR TITLE
Fix all links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,5 +34,5 @@ should happen if providing a bug report.
 # Actual Behaviour
 
 Please give some details of what is actually happening.
-Include a [minimum complete verifiable example](http://stackoverflow.com/help/mcve) with
+Include a [minimum complete verifiable example](https://stackoverflow.com/help/mcve) with
 output of running `molecule --debug`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -493,15 +493,15 @@ Breaking Changes
   `ansible-playbook` command.
 * Roles are linted with :gh:`Yamllint <adrienverge/yamllint>` vs v1's custom linter.
 
-.. _`GCE Driver`: http://molecule.readthedocs.io/en/latest/configuration.html#gce
-.. _`EC2 Driver`: http://molecule.readthedocs.io/en/latest/configuration.html#ec2
-.. _`Goss Verifier`: http://molecule.readthedocs.io/en/latest/configuration.html#goss
-.. _`LXC Driver`: http://molecule.readthedocs.io/en/latest/configuration.html#lxc
-.. _`LXD Driver`: http://molecule.readthedocs.io/en/latest/configuration.html#lxd
-.. _`OpenStack Driver`: http://molecule.readthedocs.io/en/latest/configuration.html#openstack
-.. _`Porting Guide`: http://molecule.readthedocs.io/en/latest/porting.html
-.. _`Scenarios`: http://molecule.readthedocs.io/en/latest/configuration.html#scenario
-.. _`Delegated Driver`: http://molecule.readthedocs.io/en/latest/configuration.html#delegated
+.. _`GCE Driver`: https://molecule.readthedocs.io/en/latest/configuration.html#gce
+.. _`EC2 Driver`: https://molecule.readthedocs.io/en/latest/configuration.html#ec2
+.. _`Goss Verifier`: https://molecule.readthedocs.io/en/latest/configuration.html#goss
+.. _`LXC Driver`: https://molecule.readthedocs.io/en/latest/configuration.html#lxc
+.. _`LXD Driver`: https://molecule.readthedocs.io/en/latest/configuration.html#lxd
+.. _`OpenStack Driver`: https://molecule.readthedocs.io/en/latest/configuration.html#openstack
+.. _`Porting Guide`: https://molecule.readthedocs.io/en/latest/porting.html
+.. _`Scenarios`: https://molecule.readthedocs.io/en/latest/configuration.html#scenario
+.. _`Delegated Driver`: https://molecule.readthedocs.io/en/latest/configuration.html#delegated
 
 1.25.1
 ======
@@ -601,7 +601,7 @@ Breaking Changes
 * The `host_vars` and `group_vars` section of molecule.yml no longer accepts a
   list, rather a dict similar to Ansible's `vars usage`_.
 
-.. _`vars usage`: http://docs.ansible.com/ansible/playbooks_variables.html#variables-defined-in-a-playbook
+.. _`vars usage`: https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#defining-variables-in-a-playbook
 
 1.19.3
 ======

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -131,4 +131,4 @@ To bring in updated upstream modules.  Update `gilt.yml` and execute the followi
   $ gilt overlay
 
 .. _`Ansible Goss`: https://github.com/indusbox/goss-ansible
-.. _`Gilt`: http://gilt.readthedocs.io
+.. _`Gilt`: https://gilt.readthedocs.io

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ supports.
    system to manage instances.
 
 .. _`playbooks`: https://docs.ansible.com/ansible/latest/playbooks.html
-.. _`role`: http://docs.ansible.com/ansible/latest/playbooks_roles.html
+.. _`role`: https://docs.ansible.com/ansible/latest/playbooks_roles.html
 
 Quick Start
 ===========

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -25,7 +25,7 @@ Release
 
 Molecule follows `Semantic Versioning`_.
 
-.. _`Semantic Versioning`: http://semver.org
+.. _`Semantic Versioning`: https://semver.org
 
 Tag the release and push to github.com
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -5,7 +5,7 @@ FAQ
 Why does Molecule make so many shell calls?
 ===========================================
 
-Ansible provides a python API.  However, it is not intended for
+Ansible provides a Python API.  However, it is not intended for
 `direct consumption`_.  We wanted to focus on making Molecule useful, so our
 efforts were spent consuming Ansible's CLI.
 
@@ -16,7 +16,7 @@ through their respective CLI.
 
     This decision may be reevaluated later.
 
-.. _`direct consumption`: http://docs.ansible.com/ansible/dev_guide/developing_api.html
+.. _`direct consumption`: https://docs.ansible.com/ansible/latest/dev_guide/developing_api.html
 
 Why does Molecule only support Ansible versions 2.2 and later?
 ==============================================================
@@ -59,7 +59,7 @@ Are there similar tools to Molecule?
 * `ansible-test`_ (`abandoned`_?)
 * `RoleSpec`_
 
-.. _`Testing Strategies`: http://docs.ansible.com/ansible/test_strategies.html
+.. _`Testing Strategies`: https://docs.ansible.com/ansible/latest/reference_appendices/test_strategies.html
 .. _`ansible-test`: https://github.com/nylas/ansible-test
 .. _`abandoned`: https://github.com/nylas/ansible-test/issues/14
 .. _`RoleSpec`: https://github.com/nickjj/rolespec

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -69,7 +69,7 @@ class AnsibleGalaxy(base.Base):
           env:
             FOO: bar
 
-    .. _`Ansible Galaxy`: http://docs.ansible.com/ansible/galaxy.html
+    .. _`Ansible Galaxy`: https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html
     """
 
     def __init__(self, config):

--- a/molecule/dependency/gilt.py
+++ b/molecule/dependency/gilt.py
@@ -61,7 +61,7 @@ class Gilt(base.Base):
           env:
             FOO: bar
 
-    .. _`Gilt`: http://gilt.readthedocs.io
+    .. _`Gilt`: https://gilt.readthedocs.io
     """
 
     def __init__(self, config):

--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -34,7 +34,7 @@ class Azure(base.Base):
     Molecule leverages Ansible's `azure_module`_, by mapping variables
     from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
-    .. _`azure_module`: http://docs.ansible.com/ansible/latest/guide_azure.html
+    .. _`azure_module`: https://docs.ansible.com/ansible/latest/guide_azure.html
 
     .. code-block:: yaml
 

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -36,7 +36,7 @@ class Docker(base.Base):
     Molecule leverages Ansible's `docker_container`_ module, by mapping
     variables from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
-    .. _`docker_container`: http://docs.ansible.com/ansible/latest/docker_container_module.html
+    .. _`docker_container`: https://docs.ansible.com/ansible/latest/docker_container_module.html
     .. _`Docker Security Configuration`: https://docs.docker.com/engine/reference/run/#security-configuration
 
     .. code-block:: yaml

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -34,7 +34,7 @@ class EC2(base.Base):
     Molecule leverages Ansible's `ec2_module`_, by mapping variables from
     ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
-    .. _`ec2_module`: http://docs.ansible.com/ansible/latest/ec2_module.html
+    .. _`ec2_module`: https://docs.ansible.com/ansible/latest/ec2_module.html
 
     .. code-block:: yaml
 

--- a/molecule/driver/gce.py
+++ b/molecule/driver/gce.py
@@ -38,7 +38,7 @@ class GCE(base.Base):
     Molecule leverages Ansible's `gce_module`_, by mapping variables from
     ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
-    .. _`gce_module`: http://docs.ansible.com/ansible/latest/gce_module.html
+    .. _`gce_module`: https://docs.ansible.com/ansible/latest/gce_module.html
 
     .. code-block:: yaml
 

--- a/molecule/driver/lxc.py
+++ b/molecule/driver/lxc.py
@@ -32,7 +32,7 @@ class LXC(base.Base):
     Molecule leverages Ansible's `lxc_container`_ module, by mapping variables
     from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
-    .. _`lxc_container`: http://docs.ansible.com/ansible/latest/lxc_container_module.html
+    .. _`lxc_container`: https://docs.ansible.com/ansible/latest/lxc_container_module.html
 
     .. code-block:: yaml
 

--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -34,7 +34,7 @@ class LXD(base.Base):
     The `lxd_container`_ module leverages the LXD API. Usefull information
     about, for example the source variable can be found in the `LXD API documentation`.
 
-    .. _`lxd_container`: http://docs.ansible.com/ansible/latest/lxd_container_module.html
+    .. _`lxd_container`: https://docs.ansible.com/ansible/latest/lxd_container_module.html
     .. _`LXD API documentation`: https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1
 
     .. code-block:: yaml

--- a/molecule/driver/openstack.py
+++ b/molecule/driver/openstack.py
@@ -34,7 +34,7 @@ class Openstack(base.Base):
     Molecule leverages Ansible's `openstack_module`_, by mapping variables
     from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
 
-    .. _`openstack_module`: http://docs.ansible.com/ansible/latest/os_server_module.html
+    .. _`openstack_module`: https://docs.ansible.com/ansible/latest/os_server_module.html
 
     .. code-block:: yaml
 

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -278,7 +278,7 @@ class Ansible(base.Base):
             ansible_ssh_user: foo
             ansible_ssh_common_args: -o IdentitiesOnly=no
 
-    .. _`variables defined in a playbook`: http://docs.ansible.com/ansible/playbooks_variables.html#variables-defined-in-a-playbook
+    .. _`variables defined in a playbook`: https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#defining-variables-in-a-playbook
     """  # noqa
 
     def __init__(self, config):

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -87,7 +87,7 @@ class Testinfra(base.Base):
             - ../path/to/test_2.py
             - ../path/to/directory/*
 
-    .. _`Testinfra`: http://testinfra.readthedocs.io
+    .. _`Testinfra`: https://testinfra.readthedocs.io
     """
 
     def __init__(self, config):


### PR DESCRIPTION
Lots of domains redirect to https, so use that preferred URL.
Ensure for docs.ansible.com/ansible we are using /latest/

#### PR Type

- Docs Pull Request
