### PR TITLE
allow overriding pytest functional arguments with posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ extras =
     vagrant
 commands =
     unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
-    functional: pytest test/functional/ {posargs}
+    functional: pytest {posargs:test/functional/}
     lint: flake8
     lint: yamllint -s test/ molecule/
 


### PR DESCRIPTION
It is useful to run a single test from the command line with, for instance:

    tox -e ansibledevel-functional -- -k 'test_command_init_role[docker]' test/functional/test_command.py

The `test/functional/` pytest argument is made a default used when there are no [posargs](https://tox.readthedocs.io/en/latest/config.html#substitutions-for-positional-arguments-in-commands) instead of being hardcoded and always used. If all pytest invocations include `test/functional/` there is no way for the user to restrict the tests being run to a single file.

#### PR Type

- Feature Pull Request
