### PR TITLE
Allow ansible-devel CI jobs to fail for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,56 @@ language: python
 jobs:
   fast_finish: true
 
+  allow_failures:
+  - <<: *py-37
+    env:
+      ANSIBLE_VERSION: devel
+      TESTS_TYPE: unit
+  - <<: *py-37
+    env:
+      <<: *env-functional-shard_1
+      ANSIBLE_VERSION: devel
+  - <<: *py-37
+    env:
+      <<: *env-functional-shard_2
+      ANSIBLE_VERSION: devel
+  - <<: *py-37
+    env:
+      <<: *env-functional-shard_3
+      ANSIBLE_VERSION: devel
+  - <<: *py-36
+    env:
+      ANSIBLE_VERSION: devel
+      TESTS_TYPE: unit
+  - <<: *py-36
+    env:
+      <<: *env-functional-shard_1
+      ANSIBLE_VERSION: devel
+  - <<: *py-36
+    env:
+      <<: *env-functional-shard_2
+      ANSIBLE_VERSION: devel
+  - <<: *py-36
+    env:
+      <<: *env-functional-shard_3
+      ANSIBLE_VERSION: devel
+  - <<: *py-27
+    env:
+      ANSIBLE_VERSION: devel
+      TESTS_TYPE: unit
+  - <<: *py-27
+    env:
+      <<: *env-functional-shard_1
+      ANSIBLE_VERSION: devel
+  - <<: *py-27
+    env:
+      <<: *env-functional-shard_1
+      ANSIBLE_VERSION: devel
+  - <<: *py-27
+    env:
+      <<: *env-functional-shard_3
+      ANSIBLE_VERSION: devel
+
   include:
   - <<: *lint
     name: linting the code


### PR DESCRIPTION
Puts all `ansible-devel` jobs into the `allowed_failures`. See example build:

> https://travis-ci.com/ansible/molecule/builds/100236656

Follows a decision in the WG. I hope I've interpreted this correctly.

> ACTION: decentral1se to make `devel` none voting (gundalow, 19:14:00)
> https://meetbot.fedoraproject.org/teams/ansible_molecule_working_group/ansible_molecule_working_group.2019-02-06-19.00.html

The advantage here is a more stable CI. We don't need to be so bleeding edge right now.

#### PR Type
- CI Pull Request
