### PR TITLE
allow for become_method and become_pass variables with the delegated driver

### DIFF
--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -51,8 +51,8 @@ class Delegated(base.Base):
           instance: instance_name
           port: ssh_port_as_string
           user: ssh_user
-          become_method: su
-          become_pass: mypass
+          become_method: valid_ansible_become_method
+          become_pass: password_if_required
 
         - address: winrm_endpoint
           instance: instance_name

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -42,7 +42,7 @@ class Delegated(base.Base):
     However, the developer must adhere to the instance-config API.  The
     developer's create playbook must provide the following instance-config
     data, and the developer's destroy playbook must reset the instance-config.
-    Both `become` keys are optional.
+    Both `become` keys are optional and can be used independently.
 
     .. code-block:: yaml
 

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -42,7 +42,7 @@ class Delegated(base.Base):
     However, the developer must adhere to the instance-config API.  The
     developer's create playbook must provide the following instance-config
     data, and the developer's destroy playbook must reset the instance-config.
-    Both `ansible_become` keys are optional
+    Both `become` keys are optional.
 
     .. code-block:: yaml
 
@@ -177,9 +177,11 @@ class Delegated(base.Base):
                 conn_dict['ansible_user'] = d.get('user')
                 conn_dict['ansible_host'] = d.get('address')
                 conn_dict['ansible_port'] = d.get('port')
-                conn_dict['ansible_become_method'] = d.get('become_method')
-                conn_dict['ansible_become_pass'] = d.get('become_pass')
                 conn_dict['ansible_connection'] = d.get('connection', 'smart')
+                if d.get('become_method'):
+                    conn_dict['ansible_become_method'] = d.get('become_method')
+                if d.get('become_pass'):
+                    conn_dict['ansible_become_pass'] = d.get('become_pass')
                 if d.get('identity_file'):
                     conn_dict['ansible_private_key_file'] = d.get(
                         'identity_file')

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -42,6 +42,7 @@ class Delegated(base.Base):
     However, the developer must adhere to the instance-config API.  The
     developer's create playbook must provide the following instance-config
     data, and the developer's destroy playbook must reset the instance-config.
+    Both `ansible_become` keys are optional
 
     .. code-block:: yaml
 
@@ -50,6 +51,8 @@ class Delegated(base.Base):
           instance: instance_name
           port: ssh_port_as_string
           user: ssh_user
+          become_method: su
+          become_pass: mypass
 
         - address: winrm_endpoint
           instance: instance_name
@@ -174,6 +177,8 @@ class Delegated(base.Base):
                 conn_dict['ansible_user'] = d.get('user')
                 conn_dict['ansible_host'] = d.get('address')
                 conn_dict['ansible_port'] = d.get('port')
+                conn_dict['ansible_become_method'] = d.get('become_method')
+                conn_dict['ansible_become_pass'] = d.get('become_pass')
                 conn_dict['ansible_connection'] = d.get('connection', 'smart')
                 if d.get('identity_file'):
                     conn_dict['ansible_private_key_file'] = d.get(

--- a/test/unit/driver/test_delegated.py
+++ b/test/unit/driver/test_delegated.py
@@ -168,6 +168,8 @@ def test_login_options_when_managed(mocker, _instance):
         'address': '172.16.0.2',
         'user': 'cloud-user',
         'port': 22,
+        'become_method': 'su',
+        'become_pass': 'password',
         'identity_file': '/foo/bar',
     }
 
@@ -176,6 +178,8 @@ def test_login_options_when_managed(mocker, _instance):
         'address': '172.16.0.2',
         'user': 'cloud-user',
         'port': 22,
+        'become_method': 'su',
+        'become_pass': 'password',
         'identity_file': '/foo/bar',
     }
     assert x == _instance.login_options('foo')
@@ -199,6 +203,8 @@ def test_ansible_connection_options_when_managed(mocker, _instance):
         'address': '172.16.0.2',
         'user': 'cloud-user',
         'port': 22,
+        'become_method': 'su',
+        'become_pass': 'password',
         'identity_file': '/foo/bar',
     }
 
@@ -209,6 +215,10 @@ def test_ansible_connection_options_when_managed(mocker, _instance):
         22,
         'ansible_user':
         'cloud-user',
+        'ansible_become_method':
+        'su',
+        'ansible_become_pass':
+        'password',
         'ansible_private_key_file':
         '/foo/bar',
         'ansible_connection':


### PR DESCRIPTION
When using the delegated driver, it should be possible to set different become methods and passwords for every instance if required.