### PR TITLE
Modify sequences to run dependency first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 History
 *******
 
+Unreleased
+==========
+
+* `dependency` step is now run by default before any playbook sequence step, including
+  `create` and `destroy`. This allows the use of roles in all sequence step playbooks.
+
 2.20
 ====
 

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -27,6 +27,7 @@ import os
 import six
 
 import molecule.command
+import molecule.scenarios
 from molecule import config
 from molecule import logger
 from molecule import util
@@ -95,11 +96,66 @@ class Base(object):
         self._config.provisioner.manage_inventory()
 
 
+def execute_cmdline_scenarios(scenario_name, args, command_args):
+    """
+    Execute scenario sequences based on parsed command-line arguments.
+
+    This is useful for subcommands that run scenario sequences, which
+    excludes subcommands such as ``list``, ``login``, and ``matrix``.
+
+    ``args`` and ``command_args`` are combined using :func:`get_configs`
+    to generate the scenario(s) configuration.
+
+    :param scenario_name: Name of scenario to run, or ``None`` to run all.
+    :param args: ``args`` dict from ``click`` command context
+    :param command_args: dict of command argumentss, including the target
+                         subcommand to execute
+    :returns: None
+
+    """
+    scenarios = molecule.scenarios.Scenarios(
+        get_configs(args, command_args), scenario_name)
+    scenarios.print_matrix()
+    for scenario in scenarios:
+        try:
+            execute_scenario(scenario)
+        except SystemExit:
+            # if the command has a 'destroy' arg, like test does,
+            # handle that behavior here.
+            if command_args.get('destroy') == 'always':
+                msg = ('An error occurred during the {} sequence action: '
+                       "'{}'. Cleaning up.").format(scenario.config.subcommand,
+                                                    scenario.config.action)
+                LOG.warn(msg)
+                execute_subcommand(scenario.config, 'cleanup')
+                execute_subcommand(scenario.config, 'destroy')
+                util.sysexit()
+            else:
+                raise
+
+
 def execute_subcommand(config, subcommand):
     command_module = getattr(molecule.command, subcommand)
     command = getattr(command_module, util.camelize(subcommand))
 
     return command(config).execute()
+
+
+def execute_scenario(scenario):
+    """
+    Execute each command in the given scenario's configured sequence.
+
+    :param scenario: The scenario to execute.
+    :returns: None
+
+    """
+
+    for action in scenario.sequence:
+        # knowledge of the current action is used by some provisioners
+        # to ensure they behave correctly during certain sequence steps,
+        # and is also used for reporting in execute_cmdline_scenarios
+        scenario.config.action = action
+        execute_subcommand(scenario.config, action)
 
 
 def get_configs(args, command_args, ansible_args=()):

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -91,10 +90,4 @@ def check(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/cleanup.py
+++ b/molecule/command/cleanup.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -100,10 +99,4 @@ def cleanup(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -103,10 +102,4 @@ def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args, ansible_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -22,7 +22,6 @@ import click
 
 from molecule import config
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -115,10 +114,4 @@ def create(ctx, scenario_name, driver_name):  # pragma: no cover
         'driver_name': driver_name,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -88,10 +87,4 @@ def dependency(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -22,7 +22,6 @@ import click
 
 from molecule import config
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -128,10 +127,4 @@ def destroy(ctx, scenario_name, driver_name, __all):  # pragma: no cover
     if __all:
         scenario_name = None
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -94,7 +94,6 @@ class Destroy(base.Base):
 
         self._config.provisioner.destroy()
         self._config.state.reset()
-        self.prune()
 
 
 @click.command()

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -23,7 +23,6 @@ import re
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule import util
 from molecule.command import base
 
@@ -157,10 +156,4 @@ def idempotence(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -97,10 +96,4 @@ def lint(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -22,7 +22,6 @@ import click
 
 from molecule import config
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -134,10 +133,4 @@ def prepare(ctx, scenario_name, driver_name, force):  # pragma: no cover
         'force': force,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/side_effect.py
+++ b/molecule/command/side_effect.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -96,10 +95,4 @@ def side_effect(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -88,10 +87,4 @@ def syntax(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -22,8 +22,6 @@ import click
 
 from molecule import config
 from molecule import logger
-from molecule import scenarios
-from molecule import util
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -125,20 +123,4 @@ def test(ctx, scenario_name, driver_name, __all, destroy):  # pragma: no cover
     if __all:
         scenario_name = None
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        try:
-            for action in scenario.sequence:
-                scenario.config.action = action
-                base.execute_subcommand(scenario.config, action)
-        except SystemExit:
-            if destroy == 'always':
-                msg = ('An error occurred during the test sequence '
-                       "action: '{}'. Cleaning up.").format(action)
-                LOG.warn(msg)
-                base.execute_subcommand(scenario.config, 'cleanup')
-                base.execute_subcommand(scenario.config, 'destroy')
-                util.sysexit()
-            raise
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -21,7 +21,6 @@
 import click
 
 from molecule import logger
-from molecule import scenarios
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -88,10 +87,4 @@ def verify(ctx, scenario_name):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    s = scenarios.Scenarios(
-        base.get_configs(args, command_args), scenario_name)
-    s.print_matrix()
-    for scenario in s:
-        for action in scenario.sequence:
-            scenario.config.action = action
-            base.execute_subcommand(scenario.config, action)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -400,9 +400,9 @@ class Config(object):
                 'name':
                 scenario_name,
                 'check_sequence': [
+                    'dependency',
                     'cleanup',
                     'destroy',
-                    'dependency',
                     'create',
                     'prepare',
                     'converge',
@@ -418,18 +418,20 @@ class Config(object):
                     'converge',
                 ],
                 'create_sequence': [
+                    'dependency',
                     'create',
                     'prepare',
                 ],
                 'destroy_sequence': [
+                    'dependency',
                     'cleanup',
                     'destroy',
                 ],
                 'test_sequence': [
                     'lint',
+                    'dependency',
                     'cleanup',
                     'destroy',
-                    'dependency',
                     'syntax',
                     'create',
                     'prepare',

--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -61,7 +61,8 @@ class Azure(base.Base):
         Molecule does not merge lists, when overriding the developer must
         provide all options.
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -132,7 +132,8 @@ class Docker(base.Base):
         $ export USERNAME=foo
         $ export PASSWORD=bar
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -61,7 +61,8 @@ class EC2(base.Base):
         Molecule does not merge lists, when overriding the developer must
         provide all options.
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/gce.py
+++ b/molecule/driver/gce.py
@@ -65,7 +65,8 @@ class GCE(base.Base):
         Molecule does not merge lists, when overriding the developer must
         provide all options.
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/linode.py
+++ b/molecule/driver/linode.py
@@ -69,7 +69,8 @@ class Linode(base.Base):
         Molecule does not merge lists, when overriding the developer must
         provide all options.
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/lxc.py
+++ b/molecule/driver/lxc.py
@@ -43,7 +43,8 @@ class LXC(base.Base):
 
         $ pip install molecule[lxc]
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -64,7 +64,8 @@ class LXD(base.Base):
               - default
             force_stop: True|False
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/openstack.py
+++ b/molecule/driver/openstack.py
@@ -61,7 +61,8 @@ class Openstack(base.Base):
         Molecule does not merge lists, when overriding the developer must
         provide all options.
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -110,7 +110,8 @@ class Vagrant(base.Base):
         Molecule does not merge lists, when overriding the developer must
         provide all options.
 
-    Provide the files Molecule will preserve upon each subcommand execution.
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
 
     .. code-block:: yaml
 

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -19,10 +19,12 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+import fnmatch
 import tempfile
 
 from molecule import logger
 from molecule import scenarios
+from molecule import util
 
 LOG = logger.get_logger(__name__)
 
@@ -88,6 +90,34 @@ class Scenario(object):
         """
         self.config = config
         self._setup()
+
+    def prune(self):
+        """
+        Prune the scenario ephemeral directory files and returns None.
+
+        "safe files" will not be pruned, including the ansible configuration
+        and inventory used by this scenario, the scenario state file, and
+        files declared as "safe_files" in the ``driver`` configuration
+        declared in ``molecule.yml``.
+
+        :return: None
+        """
+        LOG.info('Pruning extra files from scenario ephemeral directory')
+        safe_files = [
+            self.config.provisioner.config_file,
+            self.config.provisioner.inventory_file,
+            self.config.state.state_file,
+        ] + self.config.driver.safe_files
+        files = util.os_walk(self.ephemeral_directory, '*')
+        for f in files:
+            if not any(sf for sf in safe_files if fnmatch.fnmatch(f, sf)):
+                os.remove(f)
+
+        # Remove empty directories.
+        for dirpath, dirs, files in os.walk(
+                self.ephemeral_directory, topdown=False):
+            if not dirs and not files:
+                os.removedirs(dirpath)
 
     @property
     def name(self):

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -48,11 +48,13 @@ class Scenario(object):
         scenario:
           name: default  # optional
           create_sequence:
+            - dependency
             - create
             - prepare
           check_sequence:
-            - destroy
             - dependency
+            - cleanup
+            - destroy
             - create
             - prepare
             - converge
@@ -64,12 +66,14 @@ class Scenario(object):
             - prepare
             - converge
           destroy_sequence:
+            - dependency
             - cleanup
             - destroy
           test_sequence:
             - lint
-            - destroy
             - dependency
+            - cleanup
+            - destroy
             - syntax
             - create
             - prepare

--- a/test/unit/command/test_base.py
+++ b/test/unit/command/test_base.py
@@ -82,6 +82,11 @@ def _patched_print_matrix(mocker):
 
 
 @pytest.fixture
+def _patched_prune(mocker):
+    return mocker.patch('molecule.scenario.Scenario.prune')
+
+
+@pytest.fixture
 def _patched_sysexit(mocker):
     return mocker.patch('molecule.util.sysexit')
 
@@ -92,36 +97,6 @@ def test_config_private_member(_instance):
 
 def test_init_calls_setup(_patched_base_setup, _instance):
     _patched_base_setup.assert_called_once_with()
-
-
-def test_prune(_instance):
-    ephemeral_directory = _instance._config.scenario.ephemeral_directory
-    inventory_directory = _instance._config.scenario.inventory_directory
-
-    foo_file = os.path.join(inventory_directory, 'foo')
-    bar_file = os.path.join(inventory_directory, 'bar')
-    baz_directory = os.path.join(inventory_directory, 'baz')
-    state_file = os.path.join(ephemeral_directory, 'state.yml')
-    inventory_file = os.path.join(inventory_directory, 'ansible_inventory.yml')
-    config_file = os.path.join(ephemeral_directory, 'ansible.cfg')
-    role_directory = os.path.join(ephemeral_directory, 'roles')
-    empty_role_directory = os.path.join(role_directory, 'foo')
-
-    os.mkdir(baz_directory)
-    os.mkdir(role_directory)
-    os.mkdir(empty_role_directory)
-    for f in [foo_file, bar_file, state_file]:
-        util.write_file(f, '')
-
-    _instance.prune()
-
-    assert not os.path.isfile(foo_file)
-    assert not os.path.isfile(bar_file)
-    assert os.path.isfile(state_file)
-    assert os.path.isfile(config_file)
-    assert os.path.isfile(inventory_file)
-    assert not os.path.isdir(baz_directory)
-    assert not os.path.isdir(role_directory)
 
 
 def test_print_info(mocker, patched_logger_info, _instance):
@@ -163,12 +138,13 @@ def test_execute_cmdline_scenarios(config_instance, _patched_print_matrix,
 
 
 def test_execute_cmdline_scenarios_destroy(
-        config_instance, _patched_execute_scenario,
+        config_instance, _patched_execute_scenario, _patched_prune,
         _patched_execute_subcommand, _patched_sysexit):
     # Ensure execute_cmdline_scenarios handles errors correctly when 'destroy'
     # is 'always':
     # - cleanup and destroy subcommands are run when execute_scenario
     #   raises SystemExit
+    # - scenario is pruned
     scenario_name = 'default'
     args = {}
     command_args = {
@@ -184,14 +160,17 @@ def test_execute_cmdline_scenarios_destroy(
     # which is the called subcommand. 'cleanup' and 'destroy' should be called.
     assert _patched_execute_subcommand.call_args_list[0][0][1] == 'cleanup'
     assert _patched_execute_subcommand.call_args_list[1][0][1] == 'destroy'
+    assert _patched_prune.called
     assert _patched_sysexit.called
 
 
-def test_execute_cmdline_scenarios_nodestroy(
-        config_instance, _patched_execute_scenario, _patched_sysexit):
+def test_execute_cmdline_scenarios_nodestroy(config_instance,
+                                             _patched_execute_scenario,
+                                             _patched_prune, _patched_sysexit):
     # Ensure execute_cmdline_scenarios handles errors correctly when 'destroy'
     # is 'always':
     # - destroy subcommand is not run when execute_scenario raises SystemExit
+    # - scenario is not pruned
     # - caught SystemExit is reraised
     scenario_name = 'default'
     args = {}
@@ -207,6 +186,7 @@ def test_execute_cmdline_scenarios_nodestroy(
         base.execute_cmdline_scenarios(scenario_name, args, command_args)
 
     assert _patched_execute_scenario.called
+    assert not _patched_prune.called
     assert not _patched_sysexit.called
 
 
@@ -217,6 +197,7 @@ def test_execute_subcommand(config_instance):
 def test_execute_scenario(mocker, _patched_execute_subcommand):
     # call a spoofed scenario with a sequence that does not include destroy:
     # - execute_subcommand should be called once for each sequence item
+    # - prune should not be called, since the sequence has no destroy step
     scenario = mocker.Mock()
     scenario.sequence = ('a', 'b', 'c')
 
@@ -226,6 +207,23 @@ def test_execute_scenario(mocker, _patched_execute_subcommand):
     # scenario.config.action is mutated in-place for every sequence action,
     # so make sure that is currently set to the last executed action
     assert scenario.config.action == scenario.sequence[-1]
+    assert not scenario.prune.called
+
+
+def test_execute_scenario_destroy(mocker, _patched_execute_subcommand):
+    # call a spoofed scenario with a sequence that includes destroy:
+    # - execute_subcommand should be called once for each sequence item
+    # - prune should be called, since the sequence has a destroy step
+    scenario = mocker.Mock()
+    scenario.sequence = ('a', 'b', 'destroy', 'c')
+
+    base.execute_scenario(scenario)
+
+    assert _patched_execute_subcommand.call_count == len(scenario.sequence)
+    # scenario.config.action is mutated in-place for every sequence action,
+    # so make sure that is currently set to the last executed action
+    assert scenario.config.action == scenario.sequence[-1]
+    assert scenario.prune.called
 
 
 def test_get_configs(config_instance):

--- a/test/unit/command/test_destroy.py
+++ b/test/unit/command/test_destroy.py
@@ -33,17 +33,11 @@ def _patched_destroy_setup(mocker):
     return mocker.patch('molecule.command.destroy.Destroy._setup')
 
 
-@pytest.fixture
-def _patched_destroy_prune(mocker):
-    return mocker.patch('molecule.command.destroy.Destroy.prune')
-
-
 # NOTE(retr0h): The use of the `patched_config_validate` fixture, disables
 # config.Config._validate from executing.  Thus preventing odd side-effects
 # throughout patched.assert_called unit tests.
-def test_execute(mocker, _patched_destroy_prune, patched_logger_info,
-                 patched_config_validate, _patched_ansible_destroy,
-                 config_instance):
+def test_execute(mocker, patched_logger_info, patched_config_validate,
+                 _patched_ansible_destroy, config_instance):
     d = destroy.Destroy(config_instance)
     d.execute()
 
@@ -57,7 +51,6 @@ def test_execute(mocker, _patched_destroy_prune, patched_logger_info,
 
     assert not config_instance.state.converged
     assert not config_instance.state.created
-    _patched_destroy_prune.assert_called_once_with()
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_scenario.py
+++ b/test/unit/test_scenario.py
@@ -26,6 +26,7 @@ import pytest
 
 from molecule import config
 from molecule import scenario
+from molecule import util
 
 
 # NOTE(retr0h): The use of the `patched_config_validate` fixture, disables
@@ -34,6 +35,61 @@ from molecule import scenario
 @pytest.fixture
 def _instance(patched_config_validate, config_instance):
     return scenario.Scenario(config_instance)
+
+
+def test_prune(_instance):
+    e_dir = _instance.ephemeral_directory
+    # prune data also includes files in the scenario inventory dir,
+    # which is "<e_dir>/inventory" by default.
+    # items are created in listed order, directories first, safe before pruned
+    prune_data = {
+        # these files should not be pruned
+        'safe_files': [
+            'state.yml',
+            'ansible.cfg',
+            'inventory/ansible_inventory.yml',
+        ],
+        # these directories should not be pruned
+        'safe_dirs': ['inventory'],
+        # these files should be pruned
+        'pruned_files': [
+            'foo',
+            'bar',
+            'inventory/foo',
+            'inventory/bar',
+        ],
+        # these directories should be pruned, including empty subdirectories
+        'pruned_dirs': [
+            'baz',
+            'roles',
+            'inventory/baz',
+            'roles/foo',
+        ],
+    }
+
+    for directory in prune_data['safe_dirs'] + prune_data['pruned_dirs']:
+        # inventory dir should already exist, and its existence is
+        # required by the assertions below.
+        if directory == 'inventory':
+            continue
+        os.mkdir(os.path.join(e_dir, directory))
+
+    for file in prune_data['safe_files'] + prune_data['pruned_files']:
+        util.write_file(os.path.join(e_dir, file), '')
+
+    _instance.prune()
+
+    for safe_file in prune_data['safe_files']:
+        assert os.path.isfile(os.path.join(e_dir, safe_file))
+
+    for safe_dir in prune_data['safe_dirs']:
+        assert os.path.isdir(os.path.join(e_dir, safe_dir))
+
+    for pruned_file in prune_data['pruned_files']:
+        assert not os.path.isfile(os.path.join(e_dir, pruned_file))
+
+    for pruned_dir in prune_data['pruned_dirs']:
+        assert not os.path.isdir(os.path.join(e_dir, pruned_dir))
 
 
 def test_config_member(_instance):

--- a/test/unit/test_scenario.py
+++ b/test/unit/test_scenario.py
@@ -127,9 +127,9 @@ def test_inventory_directory_property(_instance):
 
 def test_check_sequence_property(_instance):
     sequence = [
+        'dependency',
         'cleanup',
         'destroy',
-        'dependency',
         'create',
         'prepare',
         'converge',
@@ -154,6 +154,7 @@ def test_converge_sequence_property(_instance):
 
 def test_create_sequence_property(_instance):
     sequence = [
+        'dependency',
         'create',
         'prepare',
     ]
@@ -166,7 +167,7 @@ def test_dependency_sequence_property(_instance):
 
 
 def test_destroy_sequence_property(_instance):
-    assert ['cleanup', 'destroy'] == _instance.destroy_sequence
+    assert ['dependency', 'cleanup', 'destroy'] == _instance.destroy_sequence
 
 
 def test_idempotence_sequence_property(_instance):
@@ -192,9 +193,9 @@ def test_syntax_sequence_property(_instance):
 def test_test_sequence_property(_instance):
     sequence = [
         'lint',
+        'dependency',
         'cleanup',
         'destroy',
-        'dependency',
         'syntax',
         'create',
         'prepare',

--- a/test/unit/test_scenarios.py
+++ b/test/unit/test_scenarios.py
@@ -85,9 +85,9 @@ def test_print_matrix(mocker, patched_logger_info, patched_logger_out,
     matrix_out = u"""
 ├── default
 │   ├── lint
+│   ├── dependency
 │   ├── cleanup
 │   ├── destroy
-│   ├── dependency
 │   ├── syntax
 │   ├── create
 │   ├── prepare
@@ -99,9 +99,9 @@ def test_print_matrix(mocker, patched_logger_info, patched_logger_out,
 │   └── destroy
 └── foo
     ├── lint
+    ├── dependency
     ├── cleanup
     ├── destroy
-    ├── dependency
     ├── syntax
     ├── create
     ├── prepare
@@ -159,9 +159,9 @@ def test_get_matrix(_instance):
             ],
             'cleanup': ['cleanup'],
             'check': [
+                'dependency',
                 'cleanup',
                 'destroy',
-                'dependency',
                 'create',
                 'prepare',
                 'converge',
@@ -171,6 +171,7 @@ def test_get_matrix(_instance):
             ],
             'verify': ['verify'],
             'create': [
+                'dependency',
                 'create',
                 'prepare',
             ],
@@ -179,9 +180,9 @@ def test_get_matrix(_instance):
             'dependency': ['dependency'],
             'test': [
                 'lint',
+                'dependency',
                 'cleanup',
                 'destroy',
-                'dependency',
                 'syntax',
                 'create',
                 'prepare',
@@ -192,7 +193,7 @@ def test_get_matrix(_instance):
                 'cleanup',
                 'destroy',
             ],
-            'destroy': ['cleanup', 'destroy']
+            'destroy': ['dependency', 'cleanup', 'destroy']
         },
         'foo': {
             'lint': ['lint'],
@@ -205,9 +206,9 @@ def test_get_matrix(_instance):
                 'converge',
             ],
             'check': [
+                'dependency',
                 'cleanup',
                 'destroy',
-                'dependency',
                 'create',
                 'prepare',
                 'converge',
@@ -217,6 +218,7 @@ def test_get_matrix(_instance):
             ],
             'cleanup': ['cleanup'],
             'create': [
+                'dependency',
                 'create',
                 'prepare',
             ],
@@ -226,9 +228,9 @@ def test_get_matrix(_instance):
             'dependency': ['dependency'],
             'test': [
                 'lint',
+                'dependency',
                 'cleanup',
                 'destroy',
-                'dependency',
                 'syntax',
                 'create',
                 'prepare',
@@ -239,7 +241,7 @@ def test_get_matrix(_instance):
                 'cleanup',
                 'destroy',
             ],
-            'destroy': ['cleanup', 'destroy']
+            'destroy': ['dependency', 'cleanup', 'destroy']
         }
     }
 


### PR DESCRIPTION
In sequences where a playbook is run, run the `dependency` step first so
roles can be declared in scenerio requirements and used in all playbook
steps.


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Feature Pull Request

re #1734 