### PR TITLE
Make default scenario name use the parent folder

### DIFF
--- a/doc/source/ci.rst
+++ b/doc/source/ci.rst
@@ -236,8 +236,6 @@ conflict.
       name: ansible
       lint:
         name: ansible-lint
-    scenario:
-      name: default
     verifier:
       name: testinfra
       lint:

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -89,6 +89,11 @@ class Scenario(base.Base):
 
 
 def _role_exists(ctx, param, value):  # pragma: no cover
+    # if role name was not mentioned we assume that current directory is the
+    # one hosting the role and determining the role name.
+    if not value:
+        value = os.path.basename(os.getcwd())
+
     role_directory = os.path.join(os.pardir, value)
     if not os.path.exists(role_directory):
         msg = ("The role '{}' not found. "
@@ -137,7 +142,7 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
 @click.option(
     '--role-name',
     '-r',
-    required=True,
+    required=False,
     callback=_role_exists,
     help='Name of the role to create.')
 @click.option(

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -337,6 +337,8 @@ class Config(object):
             util.sysexit_with_message(msg)
 
     def _get_defaults(self):
+        scenario_name = (os.path.basename(os.path.dirname(self.molecule_file))
+                         or 'default')
         return {
             'dependency': {
                 'name': 'galaxy',
@@ -394,7 +396,7 @@ class Config(object):
             },
             'scenario': {
                 'name':
-                'default',
+                scenario_name,
                 'check_sequence': [
                     'cleanup',
                     'destroy',

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -46,8 +46,6 @@ provisioner:
   name: {{ cookiecutter.provisioner_name }}
   lint:
     name: {{ cookiecutter.provisioner_lint_name }}
-scenario:
-  name: {{ cookiecutter.scenario_name }}
 verifier:
   name: {{ cookiecutter.verifier_name }}
   lint:

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -36,12 +36,15 @@ class Scenario(object):
     for testing the role in a particular way.  The default scenario is named
     ``default``, and every role should contain a default scenario.
 
+    Unless mentioned explicitly, the scenario name will be the directory name
+    hosting the files.
+
     Any option set in this section will override the defaults.
 
     .. code-block:: yaml
 
         scenario:
-          name: default
+          name: default  # optional
           create_sequence:
             - create
             - prepare

--- a/test/scenarios/idempotence/molecule/raises/molecule.yml
+++ b/test/scenarios/idempotence/molecule/raises/molecule.yml
@@ -17,8 +17,9 @@ provisioner:
     destroy: ../../../../resources/playbooks/docker/destroy.yml
   lint:
     name: ansible-lint
-scenario:
-  name: raises
+# commented on purpose to validate that molecule will inherit it from parent folder name:
+# scenario:
+#   name: raises
 verifier:
   name: testinfra
   lint:

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -448,6 +448,13 @@ def test_interpolate_raises_on_failed_interpolation(patched_logger_critical,
     patched_logger_critical.assert_called_once_with(msg)
 
 
+def test_get_defaults(config_instance, mocker):
+    mocker.patch.object(config_instance, 'molecule_file',
+                        '/path/to/test_scenario_name/molecule.yml')
+    defaults = config_instance._get_defaults()
+    assert defaults['scenario']['name'] == 'test_scenario_name'
+
+
 def test_preflight(mocker, config_instance, patched_logger_info):
     m = mocker.patch('molecule.model.schema_v2.pre_validate')
     m.return_value = None


### PR DESCRIPTION
#### PR Type

- Bugfix Pull Request

Changes the default scenario name from being just hardcoded 'default'
to be the directory name hosting the molecule.yml file.

This change will allow us to reuse (symlink) molecule.yml file across
scenarios and roles because we will not longer be forced to define
this field in each of them.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>
Related-Bug: #1744
