### PR TITLE
Allow user to define custom molecule glob patterns

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -32,7 +32,7 @@ from molecule import logger
 from molecule import util
 
 LOG = logger.get_logger(__name__)
-MOLECULE_GLOB = 'molecule/*/molecule.yml'
+MOLECULE_GLOB = os.environ.get('MOLECULE_GLOB', 'molecule/*/molecule.yml')
 MOLECULE_DEFAULT_SCENARIO_NAME = 'default'
 
 


### PR DESCRIPTION
#### PR Type

- Bugfix Pull Request

By defining MOLECULE_GLOB, user can now change the folders where
molecule would look for configuration files.

If not defined it will continue to use the same default value.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>
Related-Bug: #1744