### PR TITLE
Adapt functional testing to recent lint updates

### DIFF
--- a/test/functional/.ansible-lint
+++ b/test/functional/.ansible-lint
@@ -1,0 +1,9 @@
+# ansible-lint config for functional testing, used to bypass expected metadata
+# errors in molecule-generated roles. Loaded via the metadata_lint_update
+# pytest helper. For reference, see "E7xx - metadata" in:
+#  https://docs.ansible.com/ansible-lint/rules/default_rules.html
+skip_list:
+  # metadata/701 - Role info should contain platforms
+  - '701'
+  # metadata/703 - Should change default metadata: <field>"
+  - '703'

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -21,6 +21,7 @@
 
 import distutils.spawn
 import os
+import shutil
 import sys
 from distutils.version import LooseVersion
 
@@ -113,6 +114,7 @@ def init_role(temp_dir, driver_name):
         'role-name': 'test-init'
     })
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
         options = {
@@ -131,6 +133,7 @@ def init_scenario(temp_dir, driver_name):
         'role-name': 'test-init'
     })
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
         # Create scenario
@@ -152,6 +155,27 @@ def init_scenario(temp_dir, driver_name):
         }
         cmd = sh.molecule.bake('test', **options)
         pytest.helpers.run_command(cmd)
+
+
+@pytest.helpers.register
+def metadata_lint_update(role_directory):
+    # By default, ansible-lint will fail on newly-created roles because the
+    # fields in this file have not been changed from their defaults. This is
+    # good because molecule should create this file using the defaults, and
+    # users should receive feedback to change these defaults. However, this
+    # blocks the testing of 'molecule init' itself, so ansible-lint should
+    # be configured to ignore these metadata lint errors.
+    ansible_lint_src = os.path.join(
+        os.path.dirname(util.abs_path(__file__)), '.ansible-lint')
+    shutil.copy(ansible_lint_src, role_directory)
+
+    # Explicitly lint here to catch any unexpected lint errors before
+    # continuining functional testing. Ansible lint is run at the root
+    # of the role directory and pointed at the role directory to ensure
+    # the customize ansible-lint config is used.
+    with change_dir_to(role_directory):
+        cmd = sh.ansible_lint.bake('.')
+    pytest.helpers.run_command(cmd)
 
 
 @pytest.helpers.register

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -83,6 +83,7 @@ def test_command_init_role_inspec(temp_dir):
     }
     cmd = sh.molecule.bake('init', 'role', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
         sh.molecule('test')
@@ -90,13 +91,14 @@ def test_command_init_role_inspec(temp_dir):
 
 @skip_unsupported_matrix
 def test_command_init_scenario_inspec(temp_dir):
+    role_directory = os.path.join(temp_dir.strpath, 'test-init')
     options = {
         'role_name': 'test-init',
     }
     cmd = sh.molecule.bake('init', 'role', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
-    role_directory = os.path.join(temp_dir.strpath, 'test-init')
     with change_dir_to(role_directory):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, 'test-scenario')
@@ -120,19 +122,21 @@ def test_command_init_role_goss(temp_dir):
     }
     cmd = sh.molecule.bake('init', 'role', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
         sh.molecule('test')
 
 
 def test_command_init_scenario_goss(temp_dir):
+    role_directory = os.path.join(temp_dir.strpath, 'test-init')
     options = {
         'role_name': 'test-init',
     }
     cmd = sh.molecule.bake('init', 'role', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
-    role_directory = os.path.join(temp_dir.strpath, 'test-init')
     with change_dir_to(role_directory):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, 'test-scenario')
@@ -148,13 +152,14 @@ def test_command_init_scenario_goss(temp_dir):
 
 
 def test_command_init_scenario_with_invalid_role_raises(temp_dir):
+    role_directory = os.path.join(temp_dir.strpath, 'test-role')
     options = {
         'role_name': 'test-role',
     }
     cmd = sh.molecule.bake('init', 'role', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
-    role_directory = os.path.join(temp_dir.strpath, 'test-role')
     with change_dir_to(role_directory):
         options = {
             'scenario_name': 'default',
@@ -170,13 +175,14 @@ def test_command_init_scenario_with_invalid_role_raises(temp_dir):
 
 
 def test_command_init_scenario_as_default_without_default_scenario(temp_dir):
+    role_directory = os.path.join(temp_dir.strpath, 'test-role')
     options = {
         'role_name': 'test-role',
     }
     cmd = sh.molecule.bake('init', 'role', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
-    role_directory = os.path.join(temp_dir.strpath, 'test-role')
     with change_dir_to(role_directory):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, 'default')
@@ -195,13 +201,14 @@ def test_command_init_scenario_as_default_without_default_scenario(temp_dir):
 # NOTE(retr0h): Molecule does not allow the creation of a role without
 # a default scenario.  This tests roles not created by a newer Molecule.
 def test_command_init_scenario_without_default_scenario_raises(temp_dir):
+    role_directory = os.path.join(temp_dir.strpath, 'test-role')
     options = {
         'role_name': 'test-role',
     }
     cmd = sh.molecule.bake('init', 'role', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
-    role_directory = os.path.join(temp_dir.strpath, 'test-role')
     with change_dir_to(role_directory):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, 'default')
@@ -226,12 +233,13 @@ def test_command_init_role_with_template(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, role_name)
 
     options = {
-        'url': 'https://github.com/retr0h/cookiecutter-molecule.git',
+        'url': 'https://github.com/ansible/molecule-cookiecutter.git',
         'no_input': True,
         'role_name': role_name,
     }
     cmd = sh.molecule.bake('init', 'template', **options)
     pytest.helpers.run_command(cmd)
+    pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
         sh.molecule('test')

--- a/test/unit/command/init/test_template.py
+++ b/test/unit/command/init/test_template.py
@@ -29,7 +29,7 @@ from molecule.command.init import template
 def _command_args():
     return {
         'role_name': 'test-role',
-        'url': 'https://github.com/retr0h/cookiecutter-molecule.git',
+        'url': 'https://github.com/ansible/molecule-cookiecutter.git',
         'no_input': True,
         'subcommand': __name__,
     }


### PR DESCRIPTION
Starting in ansible-lint 4.0, the role metadata is now being linted
to ensure the metadata file has been updated by the role author prior
to submission to ansible galaxy. This is a "good thing", but
unfortunately breaks molecule CI.

This solution attempts to retain the behavior of reporting these lint
errors to users, but adds behavior to functional tests to independently
lint and fix this file prior to testing it with molecule.

I have also updated references to the cookiecutter template to use the
new location in the github 'ansible' namespace.

re #1747
I think the lint errors coming out of both the embedded cookiecutter templates used by `molecule init` and the `molecule-cookiecutter` repo used in testing, are correct, and should be preserved. Leaving these in place will prevent users from forgetting to update `meta/main.yml` in a role when developing a role created using `molecule init`. This change attempts to ensure that those lint errors continue to be raised on a default role, and then patches them out to allow CI to proceed.

#### PR Type

- Bugfix Pull Request

#### Testing info

Limited functional testing was done using ansible 2.7 on py2.7 and py3.7:
```
$ tox -e py27-ansible27-functional,py37-ansible27-functional -- -k docker
...
  py27-ansible27-functional: commands succeeded
  py37-ansible27-functional: commands succeeded
  congratulations :)
```

Linting and formatting were also checked:
```
$ tox -e format-check -e lint
...
  format-check: commands succeeded
  lint: commands succeeded
  congratulations :)
```

No unit tests were harmed in the making of this PR:

```
$ tox -e py27-ansible27-unit,py37-ansible27-unit
...
  py27-ansible27-unit: commands succeeded
  py37-ansible27-unit: commands succeeded
  congratulations :)
```