### PR TITLE
Bump to latest testinfra release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ PyYAML==3.13
 sh==1.12.14
 six==1.11.0
 tabulate==0.8.2
-testinfra==1.16.0
+testinfra==1.19.0
 tree-format==0.1.2


### PR DESCRIPTION
Closes https://github.com/ansible/molecule/issues/1750

This might turn up some bugs and shouldn't deprioritise any other CI/v2.20 release schedule issues but since I saw a new user running into an issue in the report in https://github.com/ansible/molecule/issues/1750, I thought I'd get PR this out now.

#### PR Type
- Requirements Bump

/cc @beenje