### PR TITLE
Do not fail the deploy build when version exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -432,6 +432,7 @@ jobs:
           HPBkDwncLYLEzxirPfNB88GYFWZ/wA1jMgCd4wT7SgKQlIyRSCT6KXMfoOUVMH/uwaLggoURaGtmD/qnrfXj+bG15nBCCOaIZdXzODln/PwDFAYT8ZspzRPzQOfncdk4WTsVbwpiGgpdm+TxGGBz8yedvVXiTwmwLCGC0FsAE8Wp8krNH1Kwqp3OaZeePakIbEj0UXgCTnAol3ZgVWWy+6bfDBb/aLiGXjsAIb7sY6HzwvQUr43xFO7tReaGO23mGwgIy/tNstXarwxezlw6FlGe5KJGvE/a4yAPuWg9kuJt5MqwbCJzhP38SeH4Gc6x0o6jPT/+NbvLV1ck1Qbz5gCYmXlOzucDP+P5t8E3g+zJbNbCR00k1BpG3MIEzrHeyp/hCdDYnGB3TVnlj+L4Y/yoUdCq9FJI8xHLbj/fMe5vxBMMsvDbt2JJReavi3WB2pv2nHtivkKj/Kow4FRm+Kp3WH4x5NlZDjV5gsUbwPcN1kIpb09sPZE2wYugvCTOiExt7mdd0JMMcgxuR1jGgGxqRARQeqjz14VVNsrVIIrMh8JX8u7Rl9sqmU4UuLGTxnq2cwyBmYzJ0gmDgN3TvQ96n9D2sP0YQj35v7RY5vsdYsfLucLdTfTajP9OL4Bw+ogXMJrArIq+j+7uJyTFqNdAN+Y6nX7WV0W6rp8aA1I=
       distributions: dists
       skip-cleanup: true
+      skip_existing: true
       on:
         all_branches: true
 


### PR DESCRIPTION
#### PR Type
- CI Fix

Closes https://github.com/ansible/molecule/issues/1730.

I have a suspicion that the real cause might be something else but this works for now. See:

> 12:35 < decentral1se> webknjaz: any idea why https://travis-ci.com/ansible/molecule/jobs/178776158#L1718 is happening?
> 12:36 < decentral1se> I only see https://test.pypi.org/project/molecule/2.19.1.dev96/ on test.pypi
> 12:36 < decentral1se> IIUC, that CI run should have been uploading 2.19.1.dev99?


References:
  * https://travis-ci.com/ansible/molecule/jobs/178776158#L1718
  * https://github.com/travis-ci/dpl#pypi