### PR TITLE
Extend Git clone depth to allow pbr to calculate non-duplicated prerelease versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ conditions: v1
 dist: xenial
 
 git:
-  depth: 100
+  depth: 150
 
 cache:
   bundler: true


### PR DESCRIPTION
Supercedes https://github.com/ansible/molecule/pull/1755.

As explained in the following review https://github.com/ansible/molecule/pull/1755#pullrequestreview-205294580.

Closes https://github.com/ansible/molecule/issues/1730.