### PR TITLE
Assure cleanup of python precompiled files with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,14 +28,18 @@ extras =
     lxc
     openstack
     vagrant
+commands_pre =
+    find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -not -path '*/__pycache__/*' -name '*.py[c|o]' -delete
 commands =
     unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
     functional: pytest test/functional/ {posargs}
     lint: flake8
     lint: yamllint -s test/ molecule/
+whitelist_externals =
+    find
 
 [testenv:lint]
-deps = 
+deps =
     -rlint-requirements.txt
 extras = []
 skip_install = true


### PR DESCRIPTION
Sometimes leftovers files like `.py[co]` or `__pycache__` can break tox execution.

Use of `PYTHONDONTWRITEBYTECODE=1` in `tox.ini` is not enough because this
prevents processed started by tox to create these files. Still, if user
run code without it they could also be created and affecting tox
execution later.

By doing a clean-up step we assure that this does not affect test
execution.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

#### PR Type

- Bugfix Pull Request
