### PR TITLE
More descriptive identifiers in scenario unit tests

### DIFF
--- a/test/unit/test_scenario.py
+++ b/test/unit/test_scenario.py
@@ -57,13 +57,13 @@ def test_ephemeral_directory_property(_instance):
     scenario_name = _instance.name
     project_scenario_directory = os.path.join('molecule', project_directory,
                                               scenario_name)
-    x = os.path.join(tempfile.gettempdir(), project_scenario_directory)
+    e_dir = os.path.join(tempfile.gettempdir(), project_scenario_directory)
 
-    assert x == _instance.ephemeral_directory
+    assert e_dir == _instance.ephemeral_directory
 
 
 def test_check_sequence_property(_instance):
-    x = [
+    sequence = [
         'destroy',
         'dependency',
         'create',
@@ -73,27 +73,27 @@ def test_check_sequence_property(_instance):
         'destroy',
     ]
 
-    assert x == _instance.check_sequence
+    assert sequence == _instance.check_sequence
 
 
 def test_converge_sequence_property(_instance):
-    x = [
+    sequence = [
         'dependency',
         'create',
         'prepare',
         'converge',
     ]
 
-    assert x == _instance.converge_sequence
+    assert sequence == _instance.converge_sequence
 
 
 def test_create_sequence_property(_instance):
-    x = [
+    sequence = [
         'create',
         'prepare',
     ]
 
-    assert x == _instance.create_sequence
+    assert sequence == _instance.create_sequence
 
 
 def test_dependency_sequence_property(_instance):
@@ -125,7 +125,7 @@ def test_syntax_sequence_property(_instance):
 
 
 def test_test_sequence_property(_instance):
-    x = [
+    sequence = [
         'lint',
         'destroy',
         'dependency',
@@ -139,7 +139,7 @@ def test_test_sequence_property(_instance):
         'destroy',
     ]
 
-    assert x == _instance.test_sequence
+    assert sequence == _instance.test_sequence
 
 
 def test_verify_sequence_property(_instance):
@@ -165,16 +165,16 @@ def test_setup_creates_ephemeral_directory(_instance):
 
 
 def test_ephemeral_directory():
-    x = os.path.join(tempfile.gettempdir(), 'foo/bar')
+    e_dir = os.path.join(tempfile.gettempdir(), 'foo/bar')
 
-    assert x == scenario.ephemeral_directory('foo/bar')
+    assert e_dir == scenario.ephemeral_directory('foo/bar')
 
 
 def test_ephemeral_directory_overriden_via_env_var(monkeypatch):
     monkeypatch.setenv('MOLECULE_EPHEMERAL_DIRECTORY', 'foo/bar')
-    x = os.path.join(tempfile.gettempdir(), 'foo/bar')
+    e_dir = os.path.join(tempfile.gettempdir(), 'foo/bar')
 
-    assert x == scenario.ephemeral_directory('foo/bar')
+    assert e_dir == scenario.ephemeral_directory('foo/bar')
 
 
 def test_ephemeral_directory_overriden_via_env_var_uses_absolute_path(

--- a/test/unit/test_scenarios.py
+++ b/test/unit/test_scenarios.py
@@ -82,7 +82,7 @@ def test_print_matrix(mocker, patched_logger_info, patched_logger_out,
     msg = 'Test matrix'
     patched_logger_info(msg)
 
-    x = u"""
+    matrix_out = u"""
 ├── default
 │   ├── lint
 │   ├── destroy
@@ -108,7 +108,7 @@ def test_print_matrix(mocker, patched_logger_info, patched_logger_out,
     ├── verify
     └── destroy
 """
-    assert x == patched_logger_out.mock_calls[0][1][0]
+    assert matrix_out == patched_logger_out.mock_calls[0][1][0]
     assert mocker.call('') == patched_logger_out.mock_calls[1]
 
 
@@ -142,7 +142,7 @@ def test_filter_for_scenario(_instance):
 
 
 def test_get_matrix(_instance):
-    x = {
+    matrix = {
         'default': {
             'lint': ['lint'],
             'idempotence': ['idempotence'],
@@ -229,4 +229,4 @@ def test_get_matrix(_instance):
         }
     }
 
-    assert x == _instance._get_matrix()
+    assert matrix == _instance._get_matrix()


### PR DESCRIPTION
This is a readability improvement inspired by [a conversation](https://github.com/ansible/molecule/pull/1739#discussion_r258418404) in #1734, in which it was suggested to use a better identifier name than `x` for use in assertions.

While not an exhaustive change, it is hopefully incremental change for the better.