### PR TITLE
Avoid including asset folder in sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .tox/
 .vagrant/
 .pytest_cache/
+build/
+dist/
 doc/build/
 htmlcov/
 pytestdebug.log

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE README.rst
+include requirements.txt
+include test-requirements.txt
+include lint-requirements.txt
+prune asset
+prune tests


### PR DESCRIPTION
Adding `asset` folder to sdist produces a >4MB file instead of ~240kb
for now reason and this is not needed for molecule usage.

Adds dist/ and build/ folders to .gitignore as it is not normal
to have untracked files after packaging the module.

Fixes: #1761
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

#### PR Type

- Bugfix Pull Request
