### PR TITLE
Assures that author is listed on PYPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,10 @@ dists = clean --all sdist bdist_wheel
 
 [metadata]
 name = molecule
+author = Ansible by Red Hat
+author-email = info@ansible.com
 maintainer = Ansible by Red Hat
-maintainer_email = info@ansible.com
+maintainer-email = info@ansible.com
 summary = Molecule aids in the development and testing of Ansible roles.
 license = MIT
 description-file = README.rst


### PR DESCRIPTION
Populates missing field from setup.cfg that is used by PYPI to display
metadata about the package.

Fixes: #1616
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request

