### PR TITLE
Further bump the git clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ conditions: v1
 dist: xenial
 
 git:
-  depth: 150
+  depth: 200
 
 cache:
   bundler: true


### PR DESCRIPTION
As a result of observation in https://github.com/ansible/molecule/issues/1730#issuecomment-465264335.

Don't want to see any failing builds right now :)

Releases coming soon and then I will drop this value back down to 100 so we are getting our original performance optimisation.

Signed-off-by: Luke Murphy <lukewm@riseup.net>