### PR TITLE
Allow custom dockerfile location

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -47,6 +47,7 @@ class Docker(base.Base):
           - name: instance
             hostname: instance
             image: image_name:tag
+            dockerfile: Dockerfile.j2
             pull: True|False
             pre_build_image: True|False
             registry:

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -613,6 +613,9 @@ platforms_docker_schema = {
                 'image': {
                     'type': 'string',
                 },
+                'dockerfile': {
+                    'type': 'string',
+                },
                 'pull': {
                     'type': 'boolean',
                 },

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -20,7 +20,7 @@
 
     - name: Create Dockerfiles from image names
       template:
-        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
+        src: "{{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}"
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -20,7 +20,7 @@
 
     - name: Create Dockerfiles from image names
       template:
-        src: Dockerfile.j2
+        src: "{{ item.dockerfile | default('Dockerfile.j2') }}"
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -145,6 +145,7 @@ def _model_platforms_docker_errors_section_data():
             'hostname': int(),
             'image': int(),
             'pull': int(),
+            'dockerfile': bool(),
             'pre_build_image': int(),
             'registry': {
                 'url': int(),
@@ -214,6 +215,7 @@ def test_platforms_docker_has_errors(_config):
                 }],
                 'image': ['must be of string type'],
                 'pull': ['must be of boolean type'],
+                'dockerfile': ['must be of string type'],
                 'pre_build_image': ['must be of boolean type'],
                 'hostname': ['must be of string type'],
                 'security_opts': [{


### PR DESCRIPTION
Instead of always looking for Dockerfile.j2 in the scenario directory
allow user to define its location relatively to that folder.

Enables reuse of file across multiple scenarios without the need
to use symlinks.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Feature Pull Request
