### PR TITLE
Add `override_command` command to platforms definition

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
@@ -14,5 +14,3 @@ RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y pyth
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
 {%- endraw %}
-
-CMD ["sh", "-c", "while true; do sleep 10000; done"]

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -55,6 +55,7 @@ class Docker(base.Base):
                 username: $USERNAME
                 password: $PASSWORD
                 email: user@example.com
+            override_command: True|False
             command: sleep infinity
             privileged: True|False
             security_opts:
@@ -87,6 +88,12 @@ class Docker(base.Base):
             restart_retries: 1
             buildargs:
                 http_proxy: http://proxy.example.com:8080/
+
+    If specifying the `CMD`_ directive in your ``Dockerfile.j2`` or consuming a
+    built image which declares a ``CMD`` directive, then you must set
+    ``override_command: False``. Otherwise, Molecule takes care to honour the
+    value of the ``command`` key or uses the default of ``bash -c "while true;
+    do sleep 10000; done"`` to run the container until it is provisioned.
 
     When attempting to utilize a container image with `systemd`_ as your init
     system inside the container to simulate a real machine, make sure to set
@@ -133,6 +140,7 @@ class Docker(base.Base):
 
     .. _`Docker`: https://www.docker.com
     .. _`systemd`: https://www.freedesktop.org/wiki/Software/systemd/
+    .. _`CMD`: https://docs.docker.com/engine/reference/builder/#cmd
     """  # noqa
 
     def __init__(self, config):

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -633,6 +633,10 @@ platforms_docker_schema = {
                         },
                     }
                 },
+                'override_command': {
+                    'type': 'boolean',
+                    'nullable': True,
+                },
                 'command': {
                     'type': 'string',
                     'nullable': True,

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -55,6 +55,12 @@
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 
+    - name: Determine the CMD directive
+      set_fact:
+        command_directive: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      when: item.override_command | default(true)
+
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
@@ -64,7 +70,7 @@
         state: started
         recreate: false
         log_driver: json-file
-        command: "{{ item.command | default(omit) }}"
+        command: "{{ command_directive | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"

--- a/test/resources/playbooks/docker/Dockerfile.j2
+++ b/test/resources/playbooks/docker/Dockerfile.j2
@@ -15,5 +15,3 @@ RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y pyth
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
-
-CMD ["sh", "-c", "while true; do sleep 10000; done"]

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -55,6 +55,12 @@
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 
+    - name: Determine the CMD directive
+      set_fact:
+        command_directive: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      when: item.override_command | default(true)
+
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
@@ -64,7 +70,7 @@
         state: started
         recreate: false
         log_driver: json-file
-        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        command: "{{ command_directive | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -48,6 +48,8 @@ def _model_platforms_docker_section_data():
                     'email': 'user@example.com',
                 },
             },
+            'override_command':
+            False,
             'command':
             'sleep infinity',
             'privileged':
@@ -126,6 +128,7 @@ def _model_platforms_docker_errors_section_data():
                     'email': int(),
                 },
             },
+            'override_command': int(),
             'command': int(),
             'privileged': str(),
             'security_opts': [
@@ -189,6 +192,7 @@ def test_platforms_docker_has_errors(_config):
                     0: ['must be of string type']
                 }],
                 'privileged': ['must be of boolean type'],
+                'override_command': ['must be of boolean type'],
                 'command': ['must be of string type'],
                 'registry': [{
                     'url': ['must be of string type'],


### PR DESCRIPTION
#### PR Type
- Bugfix Pull Request

Closes https://github.com/ansible/molecule/issues/1763.

This adds a `override_command` key to the platforms definition. It
defaults to true. A user who wants to override the `CMD` directive from
their `Dockerfile.j2` can specify `override_command: False` to have it
honoured.

This allows 3 use cases to be covered:

  * Getting the zero configuration default of `bash -c ...`
  * Overriding the `CMD` directive from the `command` key
  * Overriding the `CMD` directive from the `Dockerfile.j2` and setting `override_command: false`

See also:

  * https://github.com/ansible/molecule/pull/1615
  * https://github.com/ansible/molecule/issues/1614
  * https://github.com/ansible/molecule/issues/1441

I've done some manual testing against this as well for the above use cases.

I'd really appreciate review/testing from @fabianvf and @beenje!
