### PR TITLE
Disallow non-unique instance names for platforms

### DIFF
--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -115,6 +115,28 @@ def test_platforms_docker(_config):
     assert {} == schema_v2.validate(_config)
 
 
+@pytest.mark.parametrize(
+    '_config', ['_model_platforms_docker_section_data'], indirect=True)
+def test_platforms_unique_names(_config):
+    instance_name = _config['platforms'][0]['name']
+    _config['platforms'] += [{
+        'name': instance_name  # duplicate platform name
+    }]
+
+    expected_validation_errors = {
+        'platforms': [{
+            0: [{
+                'name': ["'{}' is not unique".format(instance_name)]
+            }],
+            1: [{
+                'name': ["'{}' is not unique".format(instance_name)]
+            }]
+        }]
+    }
+
+    assert expected_validation_errors == schema_v2.validate(_config)
+
+
 @pytest.fixture
 def _model_platforms_docker_errors_section_data():
     return {


### PR DESCRIPTION
#### PR Type
- Bugfix Pull Request

I ran into an issue where I named my instances the same (by accident)
and then when I ran `molecule create` I had 2 when I expected 3 containers
created. I realised we are missing validation for this.

References:
  * http://docs.python-cerberus.org/en/stable/customize.html#custom-rules