### PR TITLE
Add a colon (documentation)

### DIFF
--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -60,7 +60,7 @@ class Vagrant(base.Base):
 
         driver:
           name: vagrant
-        platforms
+        platforms:
           - name: instance-1
             instance_raw_config_args:
               - "vm.network 'forwarded_port', guest: 80, host: 8080"


### PR DESCRIPTION
A colon was missing in the documentation which may confuse users.

#### PR Type
- Docs Pull Request
