### PR TITLE
Fix `command: ...` to support multiple platforms

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -55,9 +55,12 @@
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 
-    - name: Determine the CMD directive
+    - name: Determine the CMD directives
       set_fact:
-        command_directive: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        command_directives_dict: >-
+          {{ command_directives_dict | default({}) |
+            combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
+          }}
       with_items: "{{ molecule_yml.platforms }}"
       when: item.override_command | default(true)
 
@@ -70,7 +73,7 @@
         state: started
         recreate: false
         log_driver: json-file
-        command: "{{ command_directive | default(omit) }}"
+        command: "{{ command_directives_dict[item.name] | default(omit) }}"
         pid_mode: "{{ item.pid_mode | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -55,9 +55,12 @@
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 
-    - name: Determine the CMD directive
+    - name: Determine the CMD directives
       set_fact:
-        command_directive: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        command_directives_dict: >-
+          {{ command_directives_dict | default({}) |
+            combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
+          }}
       with_items: "{{ molecule_yml.platforms }}"
       when: item.override_command | default(true)
 
@@ -70,7 +73,7 @@
         state: started
         recreate: false
         log_driver: json-file
-        command: "{{ command_directive | default(omit) }}"
+        command: "{{ command_directives_dict[item.name] | default(omit) }}"
         pid_mode: "{{ item.pid_mode | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"


### PR DESCRIPTION
Closes https://github.com/ansible/molecule/issues/1780.

I manually tested the following:

```
platforms:
  - name: instance-1
    image: centos:7

  - name: instance-2
    image: centos:7
    command: "bash -c 'while true; do sleep 20000; done'"

  - name: instance-3
    image: centos:7
    override_command: False
```

Where my `Dockerfile.j2` file had the following:

```
CMD ["sh", "-c", "while true; do sleep 10000; done"]
```

And after a `molecule create`, I got:

```
(.venv) ➜  testrolelatest (fix-override-command) ✗ docker ps --no-trunc
CONTAINER ID                                                       IMAGE                     COMMAND                                        CREATED             STATUS              PORTS               NAMES
e6f23f65fb0a352504ecad956938b25905a7541900aa8f3a806848c7d7de784e   molecule_local/centos:7   "sh -c 'while true; do sleep 30000; done'"     6 seconds ago       Up 5 seconds                            instance-3
45f698f04447e1531e65880987f6910dc6b85c00bff0c637820a671314b45058   molecule_local/centos:7   "bash -c 'while true; do sleep 20000; done'"   7 seconds ago       Up 6 seconds                            instance-2
13dc5814db942a19dec510e87e078169e55449ae250af809a7dc7aeae0df9d58   molecule_local/centos:7   "bash -c 'while true; do sleep 10000; done'"   8 seconds ago       Up 7 seconds                            instance-1
```

What do you reckon @zeitounator? Your fix was good! :smile_cat: 

#### PR Type
- Bugfix Pull Request