### PR TITLE
Handle missing `command_directives_dict` gracefully

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -59,7 +59,7 @@
       set_fact:
         command_directives_dict: >-
           {{ command_directives_dict | default({}) |
-            combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
+             combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
           }}
       with_items: "{{ molecule_yml.platforms }}"
       when: item.override_command | default(true)

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -73,7 +73,7 @@
         state: started
         recreate: false
         log_driver: json-file
-        command: "{{ command_directives_dict[item.name] | default(omit) }}"
+        command: "{{ (command_directives_dict | default({}))[item.name] | default(omit) }}"
         pid_mode: "{{ item.pid_mode | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -59,7 +59,7 @@
       set_fact:
         command_directives_dict: >-
           {{ command_directives_dict | default({}) |
-            combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
+             combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
           }}
       with_items: "{{ molecule_yml.platforms }}"
       when: item.override_command | default(true)

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -73,7 +73,7 @@
         state: started
         recreate: false
         log_driver: json-file
-        command: "{{ command_directives_dict[item.name] | default(omit) }}"
+        command: "{{ (command_directives_dict | default({}))[item.name] | default(omit) }}"
         pid_mode: "{{ item.pid_mode | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"


### PR DESCRIPTION
#### PR Type
- Bugfix Pull Request

Will await review from @zeitounator :+1: 

Pushing onto v2.20 as a further bug fix following on from https://github.com/ansible/molecule/issues/1780.

Turns out the fix for this original issue was not so simple after all :sweat_smile: 