### PR TITLE
Avoid using incompatible python with doc

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,11 @@ skip_install = true
 tags =
     format
 usedevelop = false
+
 [testenv:doc]
+# doc requires py3 due to use of f'' strings and using only python3 as
+# basepython risks using python3.4 which is not supported.
+basepython = python3.7
 passenv = *
 commands =
     python setup.py build_sphinx -n -W --builder=html


### PR DESCRIPTION
Not mentioning basepython on tox doc environment risks allowing it
to use py27 which will translate to instant failure while encountering
the f'' strings.

Also using a 'python3' value for basepython would produce failures
on some systems where tox will pick python3.4 and use it, failing
while installing dependencies.

The only known way to avoid this issue with tox is to mention a
hardcoded full version of python which is known as supported, assuring
that we control the experience.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

#### PR Type

- Bugfix Pull Request
