### PR TITLE
Assure removal of __pycache__ before each tox run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ extras =
     vagrant
     windows
 commands_pre =
-    find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -not -path '*/__pycache__/*' -name '*.py[c|o]' -delete
+    find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
 commands =
     unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
     functional: pytest test/functional/ {posargs}


### PR DESCRIPTION
Avoid bug where presence of __pycache__ folders in source tree could
break test execution.

Now __pycache__ is wiped before each run, previously only .py[co]
files were removed.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request
