### PR TITLE
Coerce `exposed_ports` to string

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -683,6 +683,7 @@ platforms_docker_schema = {
                     'type': 'list',
                     'schema': {
                         'type': 'string',
+                        'coerce': 'exposed_ports'
                     }
                 },
                 'published_ports': {
@@ -969,6 +970,17 @@ class Validator(cerberus.Validator):
         if disallowed:
             msg = 'disallowed user provided config option'
             self._error(field, msg)
+
+    def _normalize_coerce_exposed_ports(self, value):
+        """Coerce ``exposed_ports`` values to string.
+
+        Not all types that can be specified by the user are acceptable and
+        therefore we cannot simply pass a ``'coerce': 'string'`` to the schema
+        definition.
+        """
+        if type(value) == int:
+            return str(value)
+        return value
 
     def _validate_molecule_env_var(self, molecule_env_var, field, value):
         """ Readonly but with a custom error.

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -137,6 +137,13 @@ def test_platforms_unique_names(_config):
     assert expected_validation_errors == schema_v2.validate(_config)
 
 
+@pytest.mark.parametrize(
+    '_config', ['_model_platforms_docker_section_data'], indirect=True)
+def test_platforms_docker_exposed_ports_coerced(_config):
+    _config['platforms'][0]['exposed_ports'] = [9904]
+    assert {} == schema_v2.validate(_config)
+
+
 @pytest.fixture
 def _model_platforms_docker_errors_section_data():
     return {
@@ -171,7 +178,7 @@ def _model_platforms_docker_errors_section_data():
                 int(),
             ],
             'exposed_ports': [
-                int(),
+                bool(),
             ],
             'published_ports': [
                 int(),


### PR DESCRIPTION
Closes https://github.com/ansible/molecule/issues/1781.

#### PR Type
- Bugfix Pull Request

We're probably open to numerous versions of this bug but let's see when the reports come in. 
Will do a full sweep if we get more reports ...

Refs:
  * http://docs.python-cerberus.org/en/stable/normalization-rules.html#value-coercion
  * https://github.com/pyeve/cerberus/issues/316
