### PR TITLE
RFC: Use only one tox environment for linting: lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,11 +113,6 @@ jobs:
       TOXENV: lint
 
   - <<: *lint
-    name: checking the code style
-    env:
-      TOXENV: format-check
-
-  - <<: *lint
     name: checking the docs build
     env:
       TOXENV: doc

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ minversion = 3.7.0
 envlist =
     lint
     py{27,35,36,37}-ansible{25,26,27}-{functional,unit}
-    format-check
     doc
 skipdist = True
 skip_missing_interpreters = True
@@ -40,7 +39,9 @@ commands =
     lint: flake8
     lint: yamllint -s test/ molecule/
 whitelist_externals =
+    bash
     find
+    yapf
 
 [testenv:lint]
 deps =
@@ -50,25 +51,9 @@ skip_install = true
 tags =
     lint
 usedevelop = false
-
-[testenv:format]
 commands =
     yapf -i -r molecule/ test/
-deps = yapf>=0.25.0,<2
-extras =
-skip_install = true
-tags =
-    format
-usedevelop = false
-[testenv:format-check]
-commands =
-    yapf -d -r molecule/ test/
-deps = {[testenv:format]deps}
-extras = {[testenv:format]extras}
-skip_install = true
-tags =
-    format
-usedevelop = false
+    bash -c 'test -z \"$(git status --porcelain | tee /dev/fd/2)\"'
 
 [testenv:doc]
 # doc requires py3 due to use of f'' strings and using only python3 as


### PR DESCRIPTION
Simplifies linting changes and avoid confusions around what needs to
be run before unittests.

Any further linting improvements should be included inside the same
tox environment.

Last command verifies that no untracked files are left or not uncommited
files are left, assuring that lint succeeds only if all changes
were commited.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request

