### PR TITLE
Assure MOLECULE_DEBUG value is used

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -21,6 +21,7 @@
 import os
 
 import anyconfig
+from ansible.module_utils.parsing.convert_bool import boolean
 import six
 
 from molecule import interpolation
@@ -50,6 +51,7 @@ from molecule.verifier import inspec
 from molecule.verifier import testinfra
 
 LOG = logger.get_logger(__name__)
+MOLECULE_DEBUG = boolean(os.environ.get('MOLECULE_DEBUG', 'False'))
 MOLECULE_DIRECTORY = 'molecule'
 MOLECULE_FILE = 'molecule.yml'
 MERGE_STRATEGY = anyconfig.MS_DICTS
@@ -111,7 +113,7 @@ class Config(object):
 
     @property
     def debug(self):
-        return self.args.get('debug', False)
+        return self.args.get('debug', MOLECULE_DEBUG)
 
     @property
     def env_file(self):

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -30,6 +30,7 @@ import click_completion
 import molecule
 from molecule import command
 from molecule import util
+from molecule.config import MOLECULE_DEBUG
 
 click_completion.init()
 
@@ -87,7 +88,7 @@ def _allowed(ctx, param, value):  # pragma: no cover
 @click.group()
 @click.option(
     '--debug/--no-debug',
-    default=False,
+    default=MOLECULE_DEBUG,
     callback=_allowed,
     help='Enable or disable debug mode. Default is disabled.')
 @click.option(


### PR DESCRIPTION
Previously the value of MOLECULE_DEBUG environment variable was ignored
because configuration was taking precedence.

Fixes: https://github.com/ansible/molecule/issues/1673