### PR TITLE
Mitigate against PyYaml CVE-2017-18342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Jinja2==2.10
 pbr==5.1.1
 pexpect==4.6.0
 psutil==5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
-PyYAML==3.13
+PyYAML>=5.1  # MIT
 sh==1.12.14
 six==1.11.0
 tabulate==0.8.2


### PR DESCRIPTION
While we already use only safe_load on molecule we are better-of
forcing use of a version on PyYaml which is not affected by this
security issue.

Fixes: #1806
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request

