### PR TITLE
Fix custom dockerfile usage

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -39,7 +39,7 @@
         path: "{{ molecule_ephemeral_directory }}"
         name: "molecule_local/{{ item.item.image }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
-        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        dockerfile: "{{ item.invocation.module_args.dest }}"
         force: "{{ item.item.force | default(true) }}"
         pull: "{{ item.item.pull | default(omit) }}"
         buildargs: "{{ item.item.buildargs | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -39,7 +39,7 @@
         path: "{{ molecule_ephemeral_directory }}"
         name: "molecule_local/{{ item.item.image }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
-        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        dockerfile: "{{ item.invocation.module_args.dest }}"
         force: "{{ item.item.force | default(true) }}"
         pull: "{{ item.item.pull | default(omit) }}"
         buildargs: "{{ item.item.buildargs | default(omit) }}"


### PR DESCRIPTION
Fixes recent bug which prevented the use of the new dockerfile param
that pointed to custom locations of Dockerfile.

It was not identified initially because we did not use the dockerfile param in any test.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

#### PR Type

- Bugfix Pull Request

Fixes bug introduced in https://github.com/ansible/molecule/pull/1769
