### PR TITLE
Re-add openssh-client to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ LABEL maintainer "Ansible <info@ansible.com>"
 
 ENV PACKAGES="\
     docker \
+    openssh-client \
     ruby \
     "
+
 ENV BUILD_DEPS="\
     gcc \
     libc-dev \


### PR DESCRIPTION
#### PR Type
- Bugfix Pull Request

Follows https://github.com/ansible/molecule/issues/1813#issuecomment-471035576 where I took a look at https://github.com/ansible/molecule/commit/bce7bfebcaa66c9417f653778f7e4bf03a554af5 to see if we're dropping any packages we shouldn't be. I think this is the only one! Original report for this change was in https://github.com/ansible/molecule/pull/1604.