### PR TITLE
Avoid python libselinux bindings being hidden by tox

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,2 @@
+libselinux-python [platform:redhat]
+python3-libselinux [platform:fedora]

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -40,7 +40,7 @@ Pip
 :std:doc:`pip <pip:usage>` is the only supported installation method.
 
 Keep in mind that on selinux supporting systems, if you install into a virtual
-environment, you may face https://github.com/ansible/ansible/issues/34340 even
+environment, you may face :gh:`issue <ansible/ansible/issues/34340>` even
 if selinux is not enabled or is configured to be permissive.
 
 It is your reponsability to assure that soft dependencies of Ansible are

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -39,6 +39,13 @@ Pip
 
 :std:doc:`pip <pip:usage>` is the only supported installation method.
 
+Keep in mind that on selinux supporting systems, if you install into a virtual
+environment, you may face https://github.com/ansible/ansible/issues/34340 even
+if selinux is not enabled or is configured to be permissive.
+
+It is your reponsability to assure that soft dependencies of Ansible are
+available on your controller or host machines.
+
 Requirements
 ------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,11 @@ commands =
     lint: yamllint -s test/ molecule/
 whitelist_externals =
     find
+# Enabling sitepackages is needed in order to avoid encountering exceptions
+# caused by missing selinux python bindinds in ansible modules like template.
+# Selinux python bindings are binary and they cannot be installed using pip
+# in virtualenvs. Details: https://github.com/ansible/molecule/issues/1724
+sitepackages = true
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Adds libselinux python extensions to the default Dockerfile template
used by molecule in order to avoid failure to build it on selinux
systems.

Fixes: https://github.com/ansible/molecule/issues/1724
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>
