### PR TITLE
Assure no_log is false on failed tasks

### DIFF
--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -67,6 +67,7 @@
       until: azure_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
 
     # Mandatory configuration for Molecule to function.

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -85,6 +85,7 @@
       until: ec2_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -31,6 +31,7 @@
       until: gce_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 

--- a/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -40,6 +40,7 @@
       until: linode_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -97,6 +97,7 @@
       until: os_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -25,6 +25,7 @@
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)
       register: platforms
+      no_log: platforms is success
 
     - name: Discover local Docker images
       docker_image_facts:
@@ -33,6 +34,7 @@
       with_items: "{{ platforms.results }}"
       when: not item.pre_build_image | default(false)
       register: docker_images
+      no_log: docker_images is success
 
     - name: Build an Ansible compatible image
       docker_image:
@@ -47,6 +49,8 @@
       when:
         - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
         - not item.item.pre_build_image | default(false)
+      register: result
+      no_log: result is success
 
     - name: Create docker network(s)
       docker_network:
@@ -54,6 +58,8 @@
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+      register: result
+      no_log: result is success
 
     - name: Determine the CMD directives
       set_fact:
@@ -102,3 +108,4 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed

--- a/test/resources/playbooks/azure/create.yml
+++ b/test/resources/playbooks/azure/create.yml
@@ -66,6 +66,7 @@
       until: azure_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
 
     # Mandatory configuration for Molecule to function.

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -25,6 +25,7 @@
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)
       register: platforms
+      no_log: not item.failed
 
     - name: Discover local Docker images
       docker_image_facts:
@@ -102,3 +103,4 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed

--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -84,6 +84,7 @@
       until: ec2_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 

--- a/test/resources/playbooks/gce/create.yml
+++ b/test/resources/playbooks/gce/create.yml
@@ -30,6 +30,7 @@
       until: gce_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 

--- a/test/resources/playbooks/linode/create.yml
+++ b/test/resources/playbooks/linode/create.yml
@@ -39,6 +39,7 @@
       until: linode_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -96,6 +96,7 @@
       until: os_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     # Mandatory configuration for Molecule to function.
 


### PR DESCRIPTION
Improves user experience by displaying the errors that caused key
tasks to fail.

Avoids adding extra verbosity by using no_log on successes.

Fixes: #1666
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request

