### PR TITLE
Unpin molecule requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 -r lint-requirements.txt
 ansible-lint>=4.0.2,<5
-anyconfig==0.9.7
-cerberus==1.2
-click==6.7
-click-completion==0.3.1
-colorama==0.3.9
-cookiecutter==1.6.0
+anyconfig>=0.9.7
+cerberus>=1.2
+click>=6.7
+click-completion>=0.3.1
+colorama>=0.3.9
+cookiecutter>=1.6.0
 idna<2.8  # because indirect dependency "requests" conflict with it now
-python-gilt==1.2.1
-Jinja2==2.10
-pbr==5.1.1
-pexpect==4.6.0
-psutil==5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
-PyYAML==3.13
-sh==1.12.14
-six==1.11.0
-tabulate==0.8.2
-testinfra==1.19.0
-tree-format==0.1.2
+python-gilt>=1.2.1
+Jinja2>=2.10
+pbr>=5.1.1
+pexpect>=4.6.0
+psutil>=5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
+PyYAML>=3.13
+sh>=1.12.14
+six>=1.11.0
+tabulate>=0.8.2
+testinfra>=1.19.0
+tree-format>=0.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ gce =
 linode =
     linode-python; python_version<"3.0"
 lxc =
-    lxc-python2; python_version<"3.0"
+    lxc-python2; python_version<"3.0" and platform_system=="Linux"
 openstack =
     shade
 vagrant =

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,14 +1,14 @@
-mock==2.0.0
-pur==5.2.1
-pytest==3.6.0
-pytest-cov==2.6.0
-pytest-helpers-namespace==2019.1.8
-pytest-mock==1.10.0
-pytest-verbose-parametrize==1.4.0
-pytest-xdist==1.26.0
+mock>=2.0.0
+pur>=5.2.1
+pytest>=3.6.0,<4.0.0  # until pytest-verbose-parametrize supports it
+pytest-cov>=2.6.0
+pytest-helpers-namespace>=2019.1.8
+pytest-mock>=1.10.0
+pytest-verbose-parametrize>=1.4.0
+pytest-xdist>=1.26.0
 # The error was: KeyError: 'created_at'
-shade==1.22.2
+shade>=1.22.2
 twine
-wheel==0.30.0
+wheel>=0.30.0
 yapf>=0.25.0,<2
 https://github.com/AndreLouisCaron/tox-tags/archive/master.zip#egg=tox-tags

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,9 @@ extras =
     windows
 commands_pre =
     find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
+    # temporary ignoring the exit code of pip check until we address azure
+    # extra conflicts: https://github.com/ansible/ansible/issues/53761
+    - pip check
 commands =
     unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
     functional: pytest test/functional/ {posargs}


### PR DESCRIPTION
Also adds a `pip check` execution for testing that there are no
conflicts after instalation of all requirements.

Temporary the exit code returned by `pip check` is ignored as we have
a known conflict caused by `ansible[azure]` dependency.

Avoids installing lxc on MacOS(Darwin) to avoid test failures as lxc
does not even compile on that platform.

Forces pytest<4.0.0 because one plugin does not support it yet but
includes comment so we can fix that as soon the plugin is updated.

Fixes: #1831
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>
