### PR TITLE
Assure that we deploy only on master pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -427,7 +427,7 @@ jobs:
     <<: *reset-prerequisites
     stage: Deploy
     name: Publishing current Git tagged version of dist to PyPI
-    if: repo == "ansible/molecule" AND tag IS present AND type == push
+    if: repo == "ansible/molecule" AND tag IS present
     env:
       TOXENV: metadata-validation
     deploy: &deploy-step

--- a/.travis.yml
+++ b/.travis.yml
@@ -427,7 +427,7 @@ jobs:
     <<: *reset-prerequisites
     stage: Deploy
     name: Publishing current Git tagged version of dist to PyPI
-    if: repo == "ansible/molecule" AND tag IS present
+    if: repo == "ansible/molecule" AND tag IS present AND type == push
     env:
       TOXENV: metadata-validation
     deploy: &deploy-step
@@ -442,7 +442,7 @@ jobs:
         all_branches: true
 
   - <<: *deploy-job
-    if: repo == "ansible/molecule" AND type NOT IN (cron, pull_request)  # Always run, except if PR or cron
+    if: repo == "ansible/molecule" AND type == push AND branch == "master"  # publish only pushes to master
     name: Publishing current (unstable) Git revision of dist to Test PyPI
     deploy:
       <<: *deploy-step


### PR DESCRIPTION
Avoids case where deploy would fail because a previous build already
deployed a package with the same name.

PYPI servers never allow a published packages from being overriden due
to security concerns. We need to be sure that we never attempt to upload
the same version.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>
