### PR TITLE
Avoid duplicate builds on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 conditions: v1
 dist: xenial
 
+# avoid building other branches to avoid duplicate builds on PRs
+branches:
+  only:
+    - master
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 git:
   depth: 200
 


### PR DESCRIPTION
Avoid building branches other than master and tags in order to avoid
duplicate builds on PRs.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>