### PR TITLE
Added ability to control no_log behavior

### DIFF
--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     resource_group_name: molecule
     location: westus

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     resource_group_name: molecule
   tasks:

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     # Developer must implement.
 

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     # Developer must implement.
 

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_user: ubuntu
     ssh_port: 22

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - block:
         - name: Populate instance config

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_port: 22
     ssh_user: "{{ lookup('env', 'USER') }}"

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       gce:

--- a/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_user: root
     ssh_port: 22

--- a/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - block:
         - name: Populate instance config

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Create molecule instance(s)
       lxc_container:

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxc_container:

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_user: cloud-user
     ssh_port: 22

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       os_server:

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -547,6 +547,9 @@ class Ansible(base.Base):
                     "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                     'molecule_instance_config':
                     "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                    'molecule_no_log':
+                    "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                    "molecule_yml.provisioner.log|default(False) | bool }}"
                 }
 
                 # All group

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Log into a Docker registry
       docker_login:

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       docker_container:

--- a/molecule/provisioner/ansible/playbooks/lxd/create.yml
+++ b/molecule/provisioner/ansible/playbooks/lxd/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Create default source variable
       set_fact:

--- a/molecule/provisioner/ansible/playbooks/lxd/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/lxd/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxd_container:

--- a/molecule/provisioner/ansible/playbooks/vagrant/create.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Create molecule instance(s)
       molecule_vagrant:

--- a/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       molecule_vagrant:

--- a/test/resources/playbooks/azure/create.yml
+++ b/test/resources/playbooks/azure/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     resource_group_name: molecule
     location: westus

--- a/test/resources/playbooks/azure/destroy.yml
+++ b/test/resources/playbooks/azure/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     resource_group_name: molecule
   tasks:

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Log into a Docker registry
       docker_login:

--- a/test/resources/playbooks/docker/destroy.yml
+++ b/test/resources/playbooks/docker/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       docker_container:

--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_user: ubuntu
     ssh_port: 22

--- a/test/resources/playbooks/ec2/destroy.yml
+++ b/test/resources/playbooks/ec2/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     resource_group_name: molecule
   tasks:

--- a/test/resources/playbooks/gce/create.yml
+++ b/test/resources/playbooks/gce/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_port: 22
     ssh_user: "{{ lookup('env', 'USER') }}"

--- a/test/resources/playbooks/gce/destroy.yml
+++ b/test/resources/playbooks/gce/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       gce:

--- a/test/resources/playbooks/linode/create.yml
+++ b/test/resources/playbooks/linode/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_user: root
     ssh_port: 22

--- a/test/resources/playbooks/linode/destroy.yml
+++ b/test/resources/playbooks/linode/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - block:
         - name: Populate instance config

--- a/test/resources/playbooks/lxc/create.yml
+++ b/test/resources/playbooks/lxc/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Create molecule instance(s)
       lxc_container:

--- a/test/resources/playbooks/lxc/destroy.yml
+++ b/test/resources/playbooks/lxc/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxc_container:

--- a/test/resources/playbooks/lxd/create.yml
+++ b/test/resources/playbooks/lxd/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Create default source variable
       set_fact:

--- a/test/resources/playbooks/lxd/destroy.yml
+++ b/test/resources/playbooks/lxd/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxd_container:

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_user: cloud-user
     ssh_port: 22

--- a/test/resources/playbooks/openstack/destroy.yml
+++ b/test/resources/playbooks/openstack/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       os_server:

--- a/test/resources/playbooks/vagrant/create.yml
+++ b/test/resources/playbooks/vagrant/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Create molecule instance(s)
       molecule_vagrant:

--- a/test/resources/playbooks/vagrant/destroy.yml
+++ b/test/resources/playbooks/vagrant/destroy.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Destroy molecule instance(s)
       molecule_vagrant:

--- a/test/scenarios/side_effect/molecule/default/side_effect.yml
+++ b/test/scenarios/side_effect/molecule/default/side_effect.yml
@@ -2,7 +2,7 @@
 - name: Side Effect
   hosts: all
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Kill ntpd on target
       command: pkill ntpd

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -358,6 +358,9 @@ def test_inventory_property(_instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         },
         'all': {
@@ -382,6 +385,9 @@ def test_inventory_property(_instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         },
         'foo': {
@@ -424,6 +430,9 @@ def test_inventory_property(_instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         },
         'baz': {
@@ -454,6 +463,9 @@ def test_inventory_property(_instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         }
     }
@@ -503,6 +515,9 @@ def test_inventory_property_handles_missing_groups(temp_dir, _instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         }
     }
@@ -844,6 +859,9 @@ def test_write_inventory(temp_dir, _instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         },
         'all': {
@@ -868,6 +886,9 @@ def test_write_inventory(temp_dir, _instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         },
         'foo': {
@@ -910,6 +931,9 @@ def test_write_inventory(temp_dir, _instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         },
         'baz': {
@@ -940,6 +964,9 @@ def test_write_inventory(temp_dir, _instance):
                 "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
                 'molecule_instance_config':
                 "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
+                'molecule_no_log':
+                "{{ lookup('env', 'MOLECULE_NO_LOG') or not "
+                "molecule_yml.provisioner.log|default(False) | bool }}",
             }
         }
     }


### PR DESCRIPTION
User can override this behaviour by defining MOLECULE_NO_LOG variable to true of false. When defined that value would override any value of `provider.log` mentioned inside molecule.yaml.

When variable is not defined, the value from molecule.yml file will be used.

When none of these are defined, logging will be disables (keeps behavior consistent with old versions).

This matches Ansible behavior where environment variables do take precedence over values defined in playbooks.

Fixes: #1666
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>