### PR TITLE
Use tox-tags from pypi instead of git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ language: python
 - &reset-prerequisites
   addons: {}
   before_install:
-  - pip install tox-venv
+  - pip install tox-venv tox-tags
   before_script: []
   services: []
 - &lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -468,7 +468,7 @@ addons:
     - lxd-client
 before_install:
 - export TOXENV=$(echo $TOXENV_TMPL | envsubst)
-- pip install tox-venv
+- pip install tox-venv tox-tags
 install:
 - tox --notest | tee ~/.tox-venv-install.log
 - >

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,4 +11,4 @@ shade==1.22.2
 twine
 wheel==0.30.0
 yapf>=0.25.0,<2
-https://github.com/AndreLouisCaron/tox-tags/archive/master.zip#egg=tox-tags
+tox-tags>=0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 minversion = 3.7.0
+requires = tox-tags
 envlist =
     lint
     py{27,35,36,37}-ansible{25,26,27}-{functional,unit}


### PR DESCRIPTION
Replace use of git dependency which is problematic and a security risk,
with package from pypi.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>