### PR TITLE
Avoid installing lxc on non Linux platforms

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ gce =
 linode =
     linode-python; python_version<"3.0"
 lxc =
-    lxc-python2; python_version<"3.0"
+    lxc-python2; python_version<"3.0" and platform_system=="Linux"
 openstack =
     shade
 vagrant =


### PR DESCRIPTION
Avoid unittesting errors caused by the failed attempt to compile
lxc library on unsupported platforms.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>