### PR TITLE
Avoid linting failure with flake8-docstrings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .venv/,.tox/,dist/,build/,doc/,.eggs/,molecule/provisioner/ansible/plugins/libraries/goss.py
 format = pylint
-ignore = E741,W503,W504
+ignore = E741,W503,W504,H


### PR DESCRIPTION
If user install flake8-docstrings even on system python, our linting would fail as we started to use --systen-site-packages with tox.
This disables the docstring tests and allow us to pass.

In the future we may want to add this and fix these errors but now we need to assure that results are consistent regarless the
presence or absence of that extension.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>