### PR TITLE
Example for ignoring files/paths when using yamllint

### DIFF
--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -69,6 +69,16 @@ class Yamllint(base.Base):
           env:
             FOO: bar
 
+    Paths can be ignored.
+
+    .. code-block:: yaml
+
+        lint:
+          name: yamllint
+          options:
+            config-data:
+              ignore: path_to_ignore
+
     .. _`yamllint`: https://github.com/adrienverge/yamllint
     .. _`yamllint rules`: https://yamllint.readthedocs.io/en/stable/rules.html
     .. _`cookiecutter template`: https://github.com/ansible/molecule/blob/ma\


### PR DESCRIPTION
Update to show an example of how to ignore a file or path with yamllint

Note:  Running ```make html``` locally is giving me the error ```No module named 'molecule.driver.linode``` which seems unrelated so I haven't been able to test.

#### PR Type

- Docs Pull Request
