### PR TITLE
Do Not Merge: debug logs for flaky functional tests

### DIFF
--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -25,6 +25,7 @@
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)
       register: platforms
+      no_log: not item.failed
 
     - name: Discover local Docker images
       docker_image_facts:
@@ -102,3 +103,4 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed

--- a/test/resources/playbooks/docker/destroy.yml
+++ b/test/resources/playbooks/docker/destroy.yml
@@ -23,6 +23,7 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: not item.failed
 
     - name: Delete docker network(s)
       docker_network:


### PR DESCRIPTION
#### PR Type
- CI FIx

Working on https://github.com/ansible/molecule/issues/1799.

We probably want `no_log:False` on your debug logs anyway for Docker tests (no creds anywhere).