### PR TITLE
[DNM] Added minimal setuptools version setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ import setuptools
 setuptools.setup(
     packages=setuptools.find_packages(),
     pbr=True,
-    setup_requires=['pbr']
+    setup_requires=['pbr', 'setuptools>=12']
+    # setuptools due https://github.com/ansible/molecule/issues/1859
 )


### PR DESCRIPTION
Some of our dependencies require a minimal version of setuptools and
we need to be sure that this is installed before requirements are
installed.

Fixes: #1859

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>