### PR TITLE
Improve supports_* driver checks (use Ansible logic)

### DIFF
--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -25,6 +25,7 @@
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)
       register: platforms
+      no_log: item.failed
 
     - name: Discover local Docker images
       docker_image_facts:
@@ -102,3 +103,4 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: item.failed

--- a/test/resources/playbooks/docker/destroy.yml
+++ b/test/resources/playbooks/docker/destroy.yml
@@ -23,6 +23,7 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: item.failed
 
     - name: Delete docker network(s)
       docker_network:


### PR DESCRIPTION
#### PR Type
- CI Improvement

Something for https://github.com/ansible/molecule/issues/1752.
Closes https://github.com/ansible/molecule/issues/1758.

It's now possible to just run `tox -e functional` and get a clean docker run.

Since we're tied to Ansible, let's use the logic there too for checking dependencies.
Regarding environment variables, let's just check for the ones that our `create.yml` require.

Also, let's show logs for failed functional docker tests. It's just more useful and there are no credentials there, we control them and we need better feedback when they fail on the CI.