### PR TITLE
Use sys_platform instead of platform_system

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ gce =
 linode =
     linode-python; python_version<"3.0"
 lxc =
-    lxc-python2; python_version<"3.0" and platform_system=="Linux"
+    lxc-python2; python_version<"3.0" and sys_platform=="linux2"
 openstack =
     shade
 vagrant =


### PR DESCRIPTION
This is more compatible as a marker and so will break fewer people

Fix this error:
```
Collecting molecule~=2.19 (from -r molecule/requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/94/88/67ca9dfbaa1252625fde90e37808ce432c82e1af646a93ccf1cb60f1e6e5/molecule-2.20.0-py2.py3-none-any.whl (192kB)
    100% |████████████████████████████████| 194kB 6.2MB/s 
Exception:
Traceback (most recent call last):
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/basecommand.py", line 209, in main
    status = self.run(options, args)
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/commands/install.py", line 299, in run
    requirement_set.prepare_files(finder)
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/req/req_set.py", line 360, in prepare_files
    ignore_dependencies=self.ignore_dependencies))
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/req/req_set.py", line 647, in _prepare_file
    set(req_to_install.extras) - set(dist.extras)
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2810, in extras
    return [dep for dep in self._dep_map if dep]
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2853, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2886, in _compute_dependencies
    common = frozenset(reqs_for_extra(None))
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2883, in reqs_for_extra
    if req.marker_fn(override={'extra':extra}):
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pip/_vendor/_markerlib/markers.py", line 113, in marker_fn
    return eval(compiled_marker, environment)
  File "<environment marker>", line 1, in <module>
NameError: name 'platform_system' is not defined
```

Same as https://github.com/kennethreitz/requests/pull/4007/commits/800a074b5d7adbbcaf96a5e6b3754c560f6768ff.

#### PR Type

- Bugfix Pull Request
