### PR TITLE
Add driver sanity checks (only Docker for now ...)

### DIFF
--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -136,3 +136,7 @@ class Azure(base.Base):
 
         return next(item for item in instance_config_dict
                     if item['instance'] == instance_name)
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -119,6 +119,19 @@ class Base(object):
         """
         pass
 
+    @abc.abstractmethod
+    def sanity_checks(self):
+        """
+        Sanity checks to ensure the driver can do work successfully. For
+        example, when using the Docker driver, we want to know that the Docker
+        daemon is running and we have the correct Docker Python dependency.
+        Each driver implementation can decide what is the most stable sanity
+        check for itself.
+
+        :returns: None
+        """
+        pass
+
     @property
     def options(self):
         return self._config.config['driver']['options']

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -202,3 +202,7 @@ class Delegated(base.Base):
 
         return next(item for item in instance_config_dict
                     if item['instance'] == instance_name)
+
+    def sanity_checks(self):
+        # Note(decentral1se): Cannot implement driver specifics are unknown
+        pass

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -136,3 +136,7 @@ class EC2(base.Base):
 
         return next(item for item in instance_config_dict
                     if item['instance'] == instance_name)
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/driver/gce.py
+++ b/molecule/driver/gce.py
@@ -140,3 +140,7 @@ class GCE(base.Base):
 
         return next(item for item in instance_config_dict
                     if item['instance'] == instance_name)
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/driver/linode.py
+++ b/molecule/driver/linode.py
@@ -151,3 +151,7 @@ class Linode(base.Base):
                                                    instance_name),
                 item['instance'] == '{}-{}'.format(item['linode_id'],
                                                    instance_name))))
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/driver/lxc.py
+++ b/molecule/driver/lxc.py
@@ -84,3 +84,7 @@ class LXC(base.Base):
 
     def ansible_connection_options(self, instance_name):
         return {'ansible_connection': 'lxc'}
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -105,3 +105,7 @@ class LXD(base.Base):
 
     def ansible_connection_options(self, instance_name):
         return {'ansible_connection': 'lxd'}
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/driver/openstack.py
+++ b/molecule/driver/openstack.py
@@ -136,3 +136,7 @@ class Openstack(base.Base):
 
         return next(item for item in instance_config_dict
                     if item['instance'] == instance_name)
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -210,3 +210,7 @@ class Vagrant(base.Base):
 
         return next(item for item in instance_config_dict
                     if item['instance'] == instance_name)
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass

--- a/molecule/provisioner/ansible_playbook.py
+++ b/molecule/provisioner/ansible_playbook.py
@@ -89,6 +89,7 @@ class AnsiblePlaybook(object):
             self.bake()
 
         try:
+            self._config.driver.sanity_checks()
             cmd = util.run_command(
                 self._ansible_command, debug=self._config.debug)
             return cmd.stdout.decode('utf-8')

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -29,6 +29,7 @@ VALID_KEYS = [
     'converged',
     'driver',
     'prepared',
+    'sanity_checked',
 ]
 
 
@@ -96,6 +97,10 @@ class State(object):
     def prepared(self):
         return self._data.get('prepared')
 
+    @property
+    def sanity_checked(self):
+        return self._data.get('sanity_checked')
+
     @marshal
     def reset(self):
         self._data = self._default_data()
@@ -127,6 +132,7 @@ class State(object):
             'created': False,
             'driver': None,
             'prepared': None,
+            'sanity_checked': False,
         }
 
     def _load_file(self):

--- a/test/unit/driver/test_docker.py
+++ b/test/unit/driver/test_docker.py
@@ -114,7 +114,7 @@ def test_ssh_connection_options_property(_instance):
     assert [] == _instance.ssh_connection_options
 
 
-def test_status(mocker, _instance):
+def test_status(_instance):
     result = _instance.status()
 
     assert 2 == len(result)
@@ -140,3 +140,11 @@ def test_created(_instance):
 
 def test_converged(_instance):
     assert 'false' == _instance._converged()
+
+
+def test_sanity_checks_missing_docker_dependency(mocker, _instance):
+    target = 'ansible.module_utils.docker_common.HAS_DOCKER_PY'
+    mocker.patch(target, False)
+
+    with pytest.raises(SystemExit):
+        _instance.sanity_checks()


### PR DESCRIPTION
Based on point in https://github.com/ansible/molecule/issues/1666#issuecomment-454588682.

Main goals of this change are: implement sanity checks that stop the sequence before anything happens if the driver is missing anything it needs to successfully run the sequence. This will help users get faster feedback when facing the litany of issues that come with using a driver (for the first time, especially ...).