### PR TITLE
tox.ini rework: regroup things in the testenv section

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 mock==2.0.0
 pur==5.2.1
 pytest==3.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -54,14 +54,14 @@ commands =
     unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
 skip_install =
   # install Python dist dependencies in following environments:
-  {functional,unit}: false
+  {doc,functional,unit}: false
   # don't install any Python dist dependencies in following environments:
-  {build-docker,doc,format,lint,metadata-validation,pur}: true
+  {build-docker,format,lint,metadata-validation,pur}: true
 usedevelop =
   # don't install Molecule in following environments:
-  {build-docker,doc,format,lint,metadata-validation,pur}: false
+  {build-docker,format,lint,metadata-validation,pur}: false
   # install Molecule in following environments:
-  {unit,functional}: true
+  {doc,unit,functional}: true
 whitelist_externals =
     find
 # Enabling sitepackages is needed in order to avoid encountering exceptions

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ minversion = 3.7.0
 envlist =
     build-docker
     doc
-    format-check
-    format-enforce
+    format-{check,enforce}
     lint
     metadata-validation
     py{27,35,36,37}-ansible{25,26,27}-{functional,unit}
@@ -23,7 +22,7 @@ deps =
     ansible27: ansible>=2.7,<2.8
     ansibledevel: git+https://github.com/ansible/ansible.git
     build-docker: pbr
-    format: yapf>=0.25.0,<2
+    format-{check,enforce}: yapf>=0.25.0,<2
     {functional,unit}: -rtest-requirements.txt
     lint: -rlint-requirements.txt
     metadata-validation: collective.checkdocs

--- a/tox.ini
+++ b/tox.ini
@@ -1,44 +1,67 @@
 [tox]
 minversion = 3.7.0
 envlist =
-    lint
-    py{27,35,36,37}-ansible{25,26,27}-{functional,unit}
-    format-check
+    build-docker
     doc
+    format-check
+    format-enforce
+    lint
+    metadata-validation
+    py{27,35,36,37}-ansible{25,26,27}-{functional,unit}
 skipdist = True
 skip_missing_interpreters = True
 
 [testenv]
-usedevelop = True
+
 passenv = *
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
-    -rrequirements.txt
-    -rtest-requirements.txt
     ansible24: ansible>=2.4,<2.5
     ansible25: ansible>=2.5,<2.6
     ansible26: ansible>=2.6,<2.7
     ansible27: ansible>=2.7,<2.8
     ansibledevel: git+https://github.com/ansible/ansible.git
+    build-docker: pbr
+    format: yapf>=0.25.0,<2
+    {functional,unit}: -rtest-requirements.txt
+    lint: -rlint-requirements.txt
+    metadata-validation: collective.checkdocs
+    metadata-validation: twine
 extras =
-    azure
-    docker
-    docs
-    ec2
-    gce
-    linode
-    lxc
-    openstack
-    vagrant
-    windows
+    {functional,unit}: azure
+    {functional,unit}: docker
+    doc: docs
+    {functional,unit}: ec2
+    {functional,unit}: gce
+    {functional,unit}: linode
+    {functional,unit}: lxc
+    {functional,unit}: openstack
+    {functional,unit}: vagrant
+    {functional,unit}: windows
 commands_pre =
     find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
 commands =
-    unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
+    doc: python setup.py build_sphinx -n -W --builder=html
+    format-check: yapf -d -r molecule/ test/
+    format-enforce: yapf -i -r molecule/ test/
     functional: pytest test/functional/ {posargs}
     lint: flake8
     lint: yamllint -s test/ molecule/
+    metadata-validation: python -m setup checkdocs check --metadata --restructuredtext --strict --verbose
+    metadata-validation: twine check .tox/dist/*
+    pur: pur -r requirements.txt
+    unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
+skip_install =
+  # install Python dist dependencies in following environments:
+  {functional,unit}: false
+  # don't install any Python dist dependencies in following environments:
+  {build-docker,doc,format,lint,metadata-validation,pur}: true
+usedevelop =
+  # don't install Molecule in following environments:
+  {build-docker,doc,format,lint,metadata-validation,pur}: false
+  # install Molecule in following environments:
+  {unit,functional}: true
 whitelist_externals =
     find
 # Enabling sitepackages is needed in order to avoid encountering exceptions
@@ -47,63 +70,15 @@ whitelist_externals =
 # in virtualenvs. Details: https://github.com/ansible/molecule/issues/1724
 sitepackages = true
 
-[testenv:lint]
-deps =
-    -rlint-requirements.txt
-extras =
-skip_install = true
-usedevelop = false
-
-[testenv:format]
-commands =
-    yapf -i -r molecule/ test/
-deps = yapf>=0.25.0,<2
-extras =
-skip_install = true
-usedevelop = false
-
-[testenv:format-check]
-commands =
-    yapf -d -r molecule/ test/
-deps = {[testenv:format]deps}
-extras = {[testenv:format]extras}
-skip_install = true
-usedevelop = false
-
-[testenv:doc]
+[doc]
+# basepython can't be put in the testenv section
 # doc requires py3 due to use of f'' strings and using only python3 as
 # basepython risks using python3.4 which is not supported.
 basepython = python3.7
-passenv = *
-commands =
-    python setup.py build_sphinx -n -W --builder=html
-extras =
-    docs
-
-[testenv:pur]
-commands=
-    pur -r requirements.txt
-
-[testenv:metadata-validation]
-deps =
-    collective.checkdocs
-    twine
-usedevelop = False
-# Ref: https://twitter.com/di_codes/status/1044358639081975813
-commands =
-    python -m setup checkdocs check --metadata --restructuredtext --strict --verbose
-    twine check .tox/dist/*
 
 [testenv:build-docker]
 # skip under Windows
 platform = ^darwin|^linux
-# `usedevelop = True` overrided `skip_install` instruction, it's unwanted
-usedevelop = False
-# don't install Molecule in this env
-skip_install = True
-# don't install any Python dist deps
-deps =
-  pbr
 #  setuptools_scm
 # reset pre-commands
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -54,14 +54,14 @@ commands =
     unit: pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
 skip_install =
   # install Python dist dependencies in following environments:
-  {doc,functional,unit}: false
+  {doc,functional,metadata-validation,unit}: false
   # don't install any Python dist dependencies in following environments:
-  {build-docker,format,lint,metadata-validation,pur}: true
+  {build-docker,format,lint,pur}: true
 usedevelop =
   # don't install Molecule in following environments:
   {build-docker,format,lint,metadata-validation,pur}: false
   # install Molecule in following environments:
-  {doc,unit,functional}: true
+  {doc,functional,unit}: true
 whitelist_externals =
     find
 # Enabling sitepackages is needed in order to avoid encountering exceptions


### PR DESCRIPTION
This is a proposal to tidy up the `tox` configuration.

The rationale I followed was following: to avoid duplication of statements, regroup everything that can be regrouped in the `testenv` section. I hope this is also increasing readability of the `tox.ini` file.

I also moved the call to a second requirement file inside of the `test-requiremenst.txt` file.

I am not sure if this approach is consensual among `tox` users, so please tell me if this is going in the right direction, or absolutely not.

Signed-off-by: Fabrice Flore-Thebault <themr0c@users.noreply.github.com>

#### PR Type

- Feature Pull Request
