### PR TITLE
Remove manual version checks for Ansible/Python. Rely on dist metadata.

### DIFF
--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -18,18 +18,13 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-import distutils
-import distutils.version
 import os
-import sys
 
-import ansible
 import click
 import click_completion
 
 import molecule
 from molecule import command
-from molecule import util
 from molecule.config import MOLECULE_DEBUG
 
 click_completion.init()
@@ -38,58 +33,10 @@ LOCAL_CONFIG = os.path.expanduser('~/.config/molecule/config.yml')
 ENV_FILE = '.env.yml'
 
 
-def _get_python_version():  # pragma: no cover
-    return sys.version_info
-
-
-def _get_ansible_version():  # pragma: no cover
-    return ansible.__version__
-
-
-def _supported_python2_version():  # pragma: no cover
-    return _get_python_version()[:2] == (2, 7)
-
-
-def _supported_python3_version():  # pragma: no cover
-    return _get_python_version() >= (3, 6)
-
-
-def _supported_ansible_version():  # pragma: no cover
-    if (distutils.version.LooseVersion(_get_ansible_version()) <=
-            distutils.version.LooseVersion('2.4')):
-        msg = ("Ansible version '{}' not supported.  "
-               'Molecule only supports Ansible versions '
-               "'>= 2.4'.").format(_get_ansible_version())
-        util.sysexit_with_message(msg)
-
-    if _supported_python2_version():
-        pass
-    elif _supported_python3_version():
-        if (distutils.version.LooseVersion(_get_ansible_version()) <
-                distutils.version.LooseVersion('2.4')):
-            msg = ("Ansible version '{}' not supported.  "
-                   'Molecule only supports Ansible versions '
-                   "'>=2.5' with Python version '{}'").format(
-                       _get_ansible_version(), _get_python_version())
-            util.sysexit_with_message(msg)
-    else:
-        msg = ("Python version '{}' not supported.  "
-               'Molecule only supports Python versions '
-               "'2.7' and '>= 3.6'.").format(_get_python_version())
-        util.sysexit_with_message(msg)
-
-
-def _allowed(ctx, param, value):  # pragma: no cover
-    _supported_ansible_version()
-
-    return value
-
-
 @click.group()
 @click.option(
     '--debug/--no-debug',
     default=MOLECULE_DEBUG,
-    callback=_allowed,
     help='Enable or disable debug mode. Default is disabled.')
 @click.option(
     '--base-config',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -r lint-requirements.txt
+ansible>=2.5
 ansible-lint>=4.0.2,<5
 anyconfig==0.9.7
 cerberus==1.2

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ setenv =
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
-    ansible24: ansible>=2.4,<2.5
     ansible25: ansible>=2.5,<2.6
     ansible26: ansible>=2.6,<2.7
     ansible27: ansible>=2.7,<2.8


### PR DESCRIPTION
#### PR Type
- Bugfix Pull Request

As detailed in https://github.com/ansible/molecule/pull/1883#issuecomment-477924577, let's just rely on dist metadata for telling the user if they have mismatching versions of Python or Ansible when using Molecule. Therefore, I remove all the manual version checking code and add a `ansible>=2.5,<3` constraint via `pbr`. We already specify Python versioning with `requires-python`.