### PR TITLE
Remove context-less comment from test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,6 @@ pytest-helpers-namespace==2019.1.8
 pytest-mock==1.10.0
 pytest-verbose-parametrize==1.4.0
 pytest-xdist==1.26.0
-# The error was: KeyError: 'created_at'
 shade==1.22.2
 twine
 wheel==0.30.0


### PR DESCRIPTION
I went looking through the git history to try to better understand what this is and why it's here, but honestly did not spend a lot of time on that. If this comment should be expended to provide meaningful context, let me know. Otherwise, it looks like the sort of thing that should be deleted.

#### PR Type

- Remove a Comment With No Context Pull Request