### PR TITLE
Execute cleanup on lint failure (#1902)

### DIFF
--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -110,8 +110,8 @@ class Test(base.Base):
           'Molecule run (always).'))
 def test(ctx, scenario_name, driver_name, __all, destroy):  # pragma: no cover
     """
-    Test (lint, destroy, dependency, syntax, create, prepare, converge,
-          idempotence, side_effect, verify, destroy).
+    Test (lint, cleanup, destroy, dependency, syntax, create, prepare,
+          converge, idempotence, side_effect, verify, cleanup, destroy).
     """
 
     args = ctx.obj.get('args')
@@ -138,6 +138,7 @@ def test(ctx, scenario_name, driver_name, __all, destroy):  # pragma: no cover
                 msg = ('An error occurred during the test sequence '
                        "action: '{}'. Cleaning up.").format(action)
                 LOG.warn(msg)
+                base.execute_subcommand(scenario.config, 'cleanup')
                 base.execute_subcommand(scenario.config, 'destroy')
                 util.sysexit()
             raise

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -328,6 +328,7 @@ def test_command_test_destroy_strategy_always(scenario_to_test, with_scenario,
            'Cleaning up.')
     assert msg in str(e.value.stdout)
 
+    assert 'Action: \'cleanup\'' in str(e.value.stdout)
     assert 'PLAY [Destroy]' in str(e.value.stdout)
     assert 0 != e.value.exit_code
 


### PR DESCRIPTION
Explicitly call `cleanup` on linting errors right before calling `destroy`.
This fixes bug #1902.

This could be improved by somehow linking the destroy task to the
cleanup task, making sure that calling destroy always calls cleanup
first it is defined.

The test just validates that the `Action: cleanup` appears in the output 
on linting error. It leverages the existing test by adding an additional
assert. 

#### PR Type

Bugfix Pull Request

