### PR TITLE
configure scenario action in execute_subcommand

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -115,6 +115,11 @@ def execute_cmdline_scenarios(scenario_name, args, command_args):
 def execute_subcommand(config, subcommand):
     command_module = getattr(molecule.command, subcommand)
     command = getattr(command_module, util.camelize(subcommand))
+    # knowledge of the current action is used by some provisioners
+    # to ensure they behave correctly during certain sequence steps,
+    # particulary the setting of ansible options in create/destroy,
+    # and is also used for reporting in execute_cmdline_scenarios
+    config.action = subcommand
 
     return command(config).execute()
 
@@ -129,10 +134,6 @@ def execute_scenario(scenario):
     """
 
     for action in scenario.sequence:
-        # knowledge of the current action is used by some provisioners
-        # to ensure they behave correctly during certain sequence steps,
-        # and is also used for reporting in execute_cmdline_scenarios
-        scenario.config.action = action
         execute_subcommand(scenario.config, action)
 
     # pruning only if a 'destroy' step was in the sequence allows for normal

--- a/test/unit/command/test_base.py
+++ b/test/unit/command/test_base.py
@@ -191,7 +191,11 @@ def test_execute_cmdline_scenarios_nodestroy(config_instance,
 
 
 def test_execute_subcommand(config_instance):
+    # scenario's config.action is mutated in-place for every sequence action,
+    # so make sure that is currently set to the executed action
+    assert config_instance.action != 'list'
     assert base.execute_subcommand(config_instance, 'list')
+    assert config_instance.action == 'list'
 
 
 def test_execute_scenario(mocker, _patched_execute_subcommand):
@@ -204,9 +208,6 @@ def test_execute_scenario(mocker, _patched_execute_subcommand):
     base.execute_scenario(scenario)
 
     assert _patched_execute_subcommand.call_count == len(scenario.sequence)
-    # scenario.config.action is mutated in-place for every sequence action,
-    # so make sure that is currently set to the last executed action
-    assert scenario.config.action == scenario.sequence[-1]
     assert not scenario.prune.called
 
 
@@ -220,9 +221,6 @@ def test_execute_scenario_destroy(mocker, _patched_execute_subcommand):
     base.execute_scenario(scenario)
 
     assert _patched_execute_subcommand.call_count == len(scenario.sequence)
-    # scenario.config.action is mutated in-place for every sequence action,
-    # so make sure that is currently set to the last executed action
-    assert scenario.config.action == scenario.sequence[-1]
     assert scenario.prune.called
 
 


### PR DESCRIPTION
The ansible-playbook provisioner uses the config.action to decide
whether or not to pass provisioner args to sequence steps. By default it
does not do this for `create` and `destroy` steps. In the case where
`destroy` (and now also `cleanup`) is called as a result of an error in
a test sequence, molecule was not setting the scenario's config.action
correctly. My recent changes to the command runners didn't address this
problem, but it should be a irelatively simple fix now that they're applied:

Centralize the setting of the config action into
`molecule.command.base.execute_subcommand`.

#### PR Type

- Bugfix Pull Request

fixes #1906

Tested with tox -e {lint,unit,functional}