### PR TITLE
Pin yapf to <0.27 (0.26)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ usedevelop = false
 [testenv:format]
 commands =
     yapf -i -r molecule/ test/
-deps = yapf>=0.25.0,<2
+deps = yapf>=0.25.0,<0.27
 extras =
 skip_install = true
 usedevelop = false


### PR DESCRIPTION
Format checking is failing with yapf 0.27, but if yapf 0.27's changes are
applied, linting fails. We need to deal with that, but CI should not
continue to be broken while that discussion takes place, so I suggest
pinning yapf to keep CI working while we come to a consensus on what to
do about yapf.


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Bugfix Pull Request

I haven't filed the bug about yapf yet, that's the next thing...

Before this change:

```
$ tox -r -e format-check
ERROR:   format-check: commands failed
```

After this change:

```
$ tox -r -e format-check
  format-check: commands succeeded
  congratulations :)
```
