### PR TITLE
Add abstract method place holder for DO driver

### DIFF
--- a/molecule/driver/digitalocean.py
+++ b/molecule/driver/digitalocean.py
@@ -136,3 +136,7 @@ class DigitalOcean(base.Base):
 
         return next(item for item in instance_config_dict
                     if item['instance'] == instance_name)
+
+    def sanity_checks(self):
+        # FIXME(decentral1se): Implement sanity checks
+        pass


### PR DESCRIPTION
#### PR Type
- CI Pull Request

Aims to fix latest CI failures due to the latest code churn. The digital ocean driver did not implement sanity checks (because they did not exist as a concept) and then when I merged the sanity check PR, we started to get this error.

Failures over at:

> https://travis-ci.com/ansible/molecule/builds/107718304

Refs:
* https://github.com/ansible/molecule/pull/1882