### PR TITLE
Increase yamllint coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@ test/conftest.py @webknjaz
 .pre-commit-config.yaml @webknjaz
 .pre-commit-hooks.yaml @webknjaz
 .readthedocs.yml @webknjaz
-.travis.yml @webknjaz
+.travis.yml @ssbarnea
 
 MANIFEST.in @webknjaz
 Dockerfile @webknjaz

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,3 @@
+---
 require:
   members: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 formats: all
@@ -8,7 +9,7 @@ build:
 python:
   version: 3.7
   install:
-  - method: pip
-    path: .
-    extra_requirements:
-    - docs
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,587 +9,586 @@ cache:
   bundler: true
   pip: true
   directories:
-  - $HOME/.cache/pre-commit
-  - $HOME/.pre-commit
-  - $HOME/.rvm
-  - $HOME/virtualenv/python$(python -c 'import platform; print(platform.python_version())')
-  - $HOME/Library/Caches/Homebrew
+    - $HOME/.cache/pre-commit
+    - $HOME/.pre-commit
+    - $HOME/.rvm
+    - $HOME/virtualenv/python$(python -c 'import platform; print(platform.python_version())')
+    - $HOME/Library/Caches/Homebrew
 
 services:
-- docker
+  - docker
 
 language: python
 
 .mixtures:  # is not used by Travis CI, but helps avoid duplication
-- &if-cron-or-manual-run-or-tagged
-  if: type IN (cron, api) OR tag IS present
-- &py-27
-  python: "2.7"
-- &py-36
-  python: "3.6"
-- &py-37
-  python: "3.7"
-- &reset-prerequisites
-  addons: {}
-  before_install:
-  - pip install tox-venv tox-tags
-  before_script: []
-  services: []
-- &lint
-  <<: *py-37
-  <<: *reset-prerequisites
-- &env-functional
-  TESTS_TYPE: functional
-- &env-functional-shard_1
-  <<: *env-functional
-  PYTEST_ADDOPTS: >-
-    '-m shard_1_of_3'
-- &env-functional-shard_2
-  <<: *env-functional
-  PYTEST_ADDOPTS: >-
-    '-m shard_2_of_3'
-- &env-functional-shard_3
-  <<: *env-functional
-  PYTEST_ADDOPTS: >-
-    '-m shard_3_of_3'
+  - &if-cron-or-manual-run-or-tagged
+    if: type IN (cron, api) OR tag IS present
+  - &py-27
+    python: "2.7"
+  - &py-36
+    python: "3.6"
+  - &py-37
+    python: "3.7"
+  - &reset-prerequisites
+    addons: {}
+    before_install:
+      - pip install tox-venv tox-tags
+    before_script: []
+    services: []
+  - &lint
+    <<: *py-37
+    <<: *reset-prerequisites
+  - &env-functional
+    TESTS_TYPE: functional
+  - &env-functional-shard_1
+    <<: *env-functional
+    PYTEST_ADDOPTS: >-
+      '-m shard_1_of_3'
+  - &env-functional-shard_2
+    <<: *env-functional
+    PYTEST_ADDOPTS: >-
+      '-m shard_2_of_3'
+  - &env-functional-shard_3
+    <<: *env-functional
+    PYTEST_ADDOPTS: >-
+      '-m shard_3_of_3'
 
 jobs:
   fast_finish: true
 
   allow_failures:
-  - <<: *py-37
-    env:
+    - <<: *py-37
+      env:
       ANSIBLE_VERSION: "28"
       TESTS_TYPE: unit
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "28"
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "28"
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "28"
-  - <<: *py-36
-    env:
-      ANSIBLE_VERSION: "28"
-      TESTS_TYPE: unit
-  - <<: *py-36
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "28"
-  - <<: *py-36
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "28"
-  - <<: *py-36
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "28"
-  - <<: *py-27
-    env:
-      ANSIBLE_VERSION: "28"
-      TESTS_TYPE: unit
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "28"
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "28"
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "28"
-
-  - <<: *py-37
-    env:
-      ANSIBLE_VERSION: devel
-      TESTS_TYPE: unit
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: devel
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: devel
-  - <<: *py-36
-    env:
-      ANSIBLE_VERSION: devel
-      TESTS_TYPE: unit
-  - <<: *py-36
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-36
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: devel
-  - <<: *py-36
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: devel
-  - <<: *py-27
-    env:
-      ANSIBLE_VERSION: devel
-      TESTS_TYPE: unit
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: devel
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "28"
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "28"
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "28"
+    - <<: *py-36
+      env:
+        ANSIBLE_VERSION: "28"
+        TESTS_TYPE: unit
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "28"
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "28"
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "28"
+    - <<: *py-27
+      env:
+        ANSIBLE_VERSION: "28"
+        TESTS_TYPE: unit
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "28"
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "28"
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "28"
+    - <<: *py-37
+      env:
+        ANSIBLE_VERSION: devel
+        TESTS_TYPE: unit
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: devel
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
+    - <<: *py-36
+      env:
+        ANSIBLE_VERSION: devel
+        TESTS_TYPE: unit
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: devel
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      env:
+        ANSIBLE_VERSION: devel
+        TESTS_TYPE: unit
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
 
   include:
-  - <<: *lint
-    name: linting the code
-    env:
-      TOXENV: lint
+    - <<: *lint
+      name: linting the code
+      env:
+        TOXENV: lint
 
-  - <<: *lint
-    name: checking the code style
-    env:
-      TOXENV: format-check
+    - <<: *lint
+      name: checking the code style
+      env:
+        TOXENV: format-check
 
-  - <<: *lint
-    name: checking the docs build
-    env:
-      TOXENV: doc
+    - <<: *lint
+      name: checking the docs build
+      env:
+        TOXENV: doc
 
-  - <<: *lint
-    name: checking the Python distribution package metadata consistency
-    if: repo == "ansible/molecule" AND type IN (cron, pull_request)  # Only run if PR or cron
-    env:
-      TOXENV: metadata-validation
+    - <<: *lint
+      name: checking the Python distribution package metadata consistency
+      if: repo == "ansible/molecule" AND type IN (cron, pull_request)  # Only run if PR or cron
+      env:
+        TOXENV: metadata-validation
 
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "28"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.8, Python 3.7
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: "28"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.8, Python 3.7
 
-  - <<: *py-37
-    env:
-      ANSIBLE_VERSION: "27"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.7, Python 3.7
+    - <<: *py-37
+      env:
+        ANSIBLE_VERSION: "27"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.7, Python 3.7
 
-  - <<: *py-37
-    env:
-      ANSIBLE_VERSION: "26"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.6, Python 3.7
+    - <<: *py-37
+      env:
+        ANSIBLE_VERSION: "26"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.6, Python 3.7
 
-  - <<: *py-37
-    env:
-      ANSIBLE_VERSION: "25"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.5, Python 3.7
+    - <<: *py-37
+      env:
+        ANSIBLE_VERSION: "25"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.5, Python 3.7
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "28"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.8, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: "28"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.8, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "27"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.7, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: "27"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.7, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "26"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.6, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: "26"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.6, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "25"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.5, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: "25"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.5, Python 3.6
 
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: "28"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.8, Python 2.7
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: "28"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.8, Python 2.7
 
-  - <<: *py-27
-    env:
-      ANSIBLE_VERSION: "27"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.7, Python 2.7
+    - <<: *py-27
+      env:
+        ANSIBLE_VERSION: "27"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.7, Python 2.7
 
-  - <<: *py-27
-    env:
-      ANSIBLE_VERSION: "26"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.6, Python 2.7
+    - <<: *py-27
+      env:
+        ANSIBLE_VERSION: "26"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.6, Python 2.7
 
-  - <<: *py-27
-    env:
-      ANSIBLE_VERSION: "25"
-      TESTS_TYPE: unit
-    name: unit tests, Ansible 2.5, Python 2.7
+    - <<: *py-27
+      env:
+        ANSIBLE_VERSION: "25"
+        TESTS_TYPE: unit
+      name: unit tests, Ansible 2.5, Python 2.7
 
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 1/3, Ansible 2.8, Python 3.7
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 1/3, Ansible 2.8, Python 3.7
 
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 2/3, Ansible 2.8, Python 3.7
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 2/3, Ansible 2.8, Python 3.7
 
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 3/3, Ansible 2.8, Python 3.7
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 3/3, Ansible 2.8, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 1/3, Ansible 2.7, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 1/3, Ansible 2.7, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 2/3, Ansible 2.7, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 2/3, Ansible 2.7, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 3/3, Ansible 2.7, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 3/3, Ansible 2.7, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 1/3, Ansible 2.6, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 1/3, Ansible 2.6, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 2/3, Ansible 2.6, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 2/3, Ansible 2.6, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 3/3, Ansible 2.6, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 3/3, Ansible 2.6, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 1/3, Ansible 2.5, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 1/3, Ansible 2.5, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 2/3, Ansible 2.5, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 2/3, Ansible 2.5, Python 3.7
 
-  - <<: *py-37
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 3/3, Ansible 2.5, Python 3.7
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 3/3, Ansible 2.5, Python 3.7
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 1/3, Ansible 2.8, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 1/3, Ansible 2.8, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 2/3, Ansible 2.8, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 2/3, Ansible 2.8, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 3/3, Ansible 2.8, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 3/3, Ansible 2.8, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 1/3, Ansible 2.7, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 1/3, Ansible 2.7, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 2/3, Ansible 2.7, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 2/3, Ansible 2.7, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 3/3, Ansible 2.7, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 3/3, Ansible 2.7, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 1/3, Ansible 2.6, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 1/3, Ansible 2.6, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 2/3, Ansible 2.6, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 2/3, Ansible 2.6, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 3/3, Ansible 2.6, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 3/3, Ansible 2.6, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 1/3, Ansible 2.5, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 1/3, Ansible 2.5, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 2/3, Ansible 2.5, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 2/3, Ansible 2.5, Python 3.6
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 3/3, Ansible 2.5, Python 3.6
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 3/3, Ansible 2.5, Python 3.6
 
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 1/3, Ansible 2.8, Python 2.7
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 1/3, Ansible 2.8, Python 2.7
 
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 2/3, Ansible 2.8, Python 2.7
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 2/3, Ansible 2.8, Python 2.7
 
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "28"
-    name: functional tests shard 3/3, Ansible 2.8, Python 2.7
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 3/3, Ansible 2.8, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 1/3, Ansible 2.7, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 1/3, Ansible 2.7, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 2/3, Ansible 2.7, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 2/3, Ansible 2.7, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "27"
-    name: functional tests shard 3/3, Ansible 2.7, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 3/3, Ansible 2.7, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 1/3, Ansible 2.6, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 1/3, Ansible 2.6, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 2/3, Ansible 2.6, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 2/3, Ansible 2.6, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "26"
-    name: functional tests shard 3/3, Ansible 2.6, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 3/3, Ansible 2.6, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 1/3, Ansible 2.5, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 1/3, Ansible 2.5, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 2/3, Ansible 2.5, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 2/3, Ansible 2.5, Python 2.7
 
-  - <<: *py-27
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: "25"
-    name: functional tests shard 3/3, Ansible 2.5, Python 2.7
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: "25"
+      name: functional tests shard 3/3, Ansible 2.5, Python 2.7
 
-  # The following set of jobs is running tests against devel branch
-  # of ansible/ansible:
+    # The following set of jobs is running tests against devel branch
+    # of ansible/ansible:
 
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: devel
-      TESTS_TYPE: unit
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: devel
-  - <<: *py-37
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: devel
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: devel
+        TESTS_TYPE: unit
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: devel
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
 
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: devel
-      TESTS_TYPE: unit
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_2
-      ANSIBLE_VERSION: devel
-  - <<: *py-36
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: devel
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: devel
+        TESTS_TYPE: unit
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_2
+        ANSIBLE_VERSION: devel
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
 
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      ANSIBLE_VERSION: devel
-      TESTS_TYPE: unit
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_1
-      ANSIBLE_VERSION: devel
-  - <<: *py-27
-    <<: *if-cron-or-manual-run-or-tagged
-    env:
-      <<: *env-functional-shard_3
-      ANSIBLE_VERSION: devel
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        ANSIBLE_VERSION: devel
+        TESTS_TYPE: unit
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_1
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
 
-  - &deploy-job
-    <<: *py-37
-    <<: *reset-prerequisites
-    stage: Deploy
-    name: Publishing current Git tagged version of dist to PyPI
-    if: repo == "ansible/molecule" AND tag IS present
-    env:
-      TOXENV: metadata-validation,build-dists
-    before_deploy:
-    - echo > setup.py
-    deploy: &deploy-step
-      provider: pypi
-      user: ansible-molecule
-      password:
-        secure: >
-          HPBkDwncLYLEzxirPfNB88GYFWZ/wA1jMgCd4wT7SgKQlIyRSCT6KXMfoOUVMH/uwaLggoURaGtmD/qnrfXj+bG15nBCCOaIZdXzODln/PwDFAYT8ZspzRPzQOfncdk4WTsVbwpiGgpdm+TxGGBz8yedvVXiTwmwLCGC0FsAE8Wp8krNH1Kwqp3OaZeePakIbEj0UXgCTnAol3ZgVWWy+6bfDBb/aLiGXjsAIb7sY6HzwvQUr43xFO7tReaGO23mGwgIy/tNstXarwxezlw6FlGe5KJGvE/a4yAPuWg9kuJt5MqwbCJzhP38SeH4Gc6x0o6jPT/+NbvLV1ck1Qbz5gCYmXlOzucDP+P5t8E3g+zJbNbCR00k1BpG3MIEzrHeyp/hCdDYnGB3TVnlj+L4Y/yoUdCq9FJI8xHLbj/fMe5vxBMMsvDbt2JJReavi3WB2pv2nHtivkKj/Kow4FRm+Kp3WH4x5NlZDjV5gsUbwPcN1kIpb09sPZE2wYugvCTOiExt7mdd0JMMcgxuR1jGgGxqRARQeqjz14VVNsrVIIrMh8JX8u7Rl9sqmU4UuLGTxnq2cwyBmYzJ0gmDgN3TvQ96n9D2sP0YQj35v7RY5vsdYsfLucLdTfTajP9OL4Bw+ogXMJrArIq+j+7uJyTFqNdAN+Y6nX7WV0W6rp8aA1I=
-      distributions: dists
-      skip-cleanup: true
-      on:
-        all_branches: true
+    - &deploy-job
+      <<: *py-37
+      <<: *reset-prerequisites
+      stage: Deploy
+      name: Publishing current Git tagged version of dist to PyPI
+      if: repo == "ansible/molecule" AND tag IS present
+      env:
+        TOXENV: metadata-validation,build-dists
+      before_deploy:
+        - echo > setup.py
+      deploy: &deploy-step
+        provider: pypi
+        user: ansible-molecule
+        password:
+          secure: >
+            HPBkDwncLYLEzxirPfNB88GYFWZ/wA1jMgCd4wT7SgKQlIyRSCT6KXMfoOUVMH/uwaLggoURaGtmD/qnrfXj+bG15nBCCOaIZdXzODln/PwDFAYT8ZspzRPzQOfncdk4WTsVbwpiGgpdm+TxGGBz8yedvVXiTwmwLCGC0FsAE8Wp8krNH1Kwqp3OaZeePakIbEj0UXgCTnAol3ZgVWWy+6bfDBb/aLiGXjsAIb7sY6HzwvQUr43xFO7tReaGO23mGwgIy/tNstXarwxezlw6FlGe5KJGvE/a4yAPuWg9kuJt5MqwbCJzhP38SeH4Gc6x0o6jPT/+NbvLV1ck1Qbz5gCYmXlOzucDP+P5t8E3g+zJbNbCR00k1BpG3MIEzrHeyp/hCdDYnGB3TVnlj+L4Y/yoUdCq9FJI8xHLbj/fMe5vxBMMsvDbt2JJReavi3WB2pv2nHtivkKj/Kow4FRm+Kp3WH4x5NlZDjV5gsUbwPcN1kIpb09sPZE2wYugvCTOiExt7mdd0JMMcgxuR1jGgGxqRARQeqjz14VVNsrVIIrMh8JX8u7Rl9sqmU4UuLGTxnq2cwyBmYzJ0gmDgN3TvQ96n9D2sP0YQj35v7RY5vsdYsfLucLdTfTajP9OL4Bw+ogXMJrArIq+j+7uJyTFqNdAN+Y6nX7WV0W6rp8aA1I=
+        distributions: dists
+        skip-cleanup: true
+        "on":
+          all_branches: true
 
-  - <<: *deploy-job
-    if: >-  # publish only pushes to master and tags; only if upstream
-      repo == "ansible/molecule" AND
-      (
+    - <<: *deploy-job
+      if: >-  # publish only pushes to master and tags; only if upstream
+        repo == "ansible/molecule" AND
         (
-          type == push AND
-          branch == "master"
-        ) OR
-        tag IS present
-      )
-    name: Publishing current (unstable) Git revision of dist to Test PyPI
-    deploy:
-      <<: *deploy-step
-      server: https://test.pypi.org/legacy/
+          (
+            type == push AND
+            branch == "master"
+          ) OR
+          tag IS present
+        )
+      name: Publishing current (unstable) Git revision of dist to Test PyPI
+      deploy:
+        <<: *deploy-step
+        server: https://test.pypi.org/legacy/
 
 env:
   global:
@@ -597,18 +596,18 @@ env:
 addons:
   apt:
     packages:
-    - lxc
-    - lxc-dev
-    - lxd
-    - lxd-client
+      - lxc
+      - lxc-dev
+      - lxd
+      - lxd-client
 before_install:
-- export TOXENV=$(echo $TOXENV_TMPL | envsubst)
-- pip install tox-venv tox-tags
+  - export TOXENV=$(echo $TOXENV_TMPL | envsubst)
+  - pip install tox-venv tox-tags
 install:
-- tox --notest | tee ~/.tox-venv-install.log
-- >
-  ! grep 'ERROR: ' ~/.tox-venv-install.log .tox/*/log/*.log
+  - tox --notest | tee ~/.tox-venv-install.log
+  - >
+    ! grep 'ERROR: ' ~/.tox-venv-install.log .tox/*/log/*.log
 before_script:
-- gem install inspec rubocop
+  - gem install inspec rubocop
 script:
-- tox
+  - tox

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,9 @@ extends: default
 ignore: |
   *.molecule/
   molecule/cookiecutter/
+  .tox
+  # HACK: https://github.com/pyupio/pyup/issues/346
+  .pyup.yml
 
 rules:
   braces:

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
     unit: python -m pytest test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
     functional: python -m pytest test/functional/ {posargs}
     lint: python -m flake8
-    lint: python -m yamllint -s test/ molecule/
+    lint: python -m yamllint -s .
 whitelist_externals =
     find
 # Enabling sitepackages is needed in order to avoid encountering exceptions
@@ -65,7 +65,7 @@ sitepackages = true
 basepython = python3
 deps =
     flake8>=3.6.0,<4
-    yamllint>=1.11.1,<2
+    yamllint>=1.15.0,<2
 extras =
 skip_install = true
 usedevelop = false


### PR DESCRIPTION
Makes yamllinting execution to cover files that previously were not
linted in order to assure consistent formatting.

This also enables people to run yamllint without extra parameters
and avoid getting errors.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

#### PR Type

- Bugfix Pull Request

