### PR TITLE
Gather facts to enable `ansible_hostname`

### DIFF
--- a/test/scenarios/verifier/molecule/goss/verify.yml
+++ b/test/scenarios/verifier/molecule/goss/verify.yml
@@ -1,7 +1,7 @@
 ---
 - name: Verify
   hosts: all
-  gather_facts: false
+  gather_facts: true  # required
   become: true
   vars:
     goss_version: v0.3.6


### PR DESCRIPTION
Resolves error in https://travis-ci.com/ansible/molecule/jobs/191750671. This happened because we released an 'optimisation' PR that didn't take this into account from the PR which dealt with the Goss related change. Anyway, it's resolved now as far as I can tell from testing it locally. Green CI once again!