### PR TITLE
Backported fix that prevented run with python 3.5

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -22,10 +22,7 @@
 import distutils.spawn
 import os
 import shutil
-import sys
-from distutils.version import LooseVersion
 
-import ansible
 import pexpect
 import pytest
 import sh

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -31,7 +31,6 @@ from ..conftest import (
     change_dir_to,
     needs_inspec,
     needs_rubocop,
-    skip_unsupported_matrix,
 )
 
 
@@ -53,7 +52,6 @@ def driver_name(request):
     return request.param
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('side_effect', 'docker', 'default'),
@@ -72,7 +70,6 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('cleanup', 'docker', 'default'),
@@ -93,7 +90,6 @@ def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
 
 @needs_inspec
 @needs_rubocop
-@skip_unsupported_matrix
 def test_command_init_role_inspec(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, 'test-init')
     options = {
@@ -108,7 +104,6 @@ def test_command_init_role_inspec(temp_dir):
         sh.molecule('test')
 
 
-@skip_unsupported_matrix
 def test_command_init_scenario_inspec(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, 'test-init')
     options = {
@@ -132,7 +127,6 @@ def test_command_init_scenario_inspec(temp_dir):
         assert os.path.isdir(scenario_directory)
 
 
-@skip_unsupported_matrix
 def test_command_init_role_goss(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, 'test-init')
     options = {
@@ -246,7 +240,6 @@ def test_command_init_scenario_without_default_scenario_raises(temp_dir):
         assert msg in str(e.value.stderr)
 
 
-@skip_unsupported_matrix
 def test_command_init_role_with_template(temp_dir):
     role_name = 'test-init'
     role_directory = os.path.join(temp_dir.strpath, role_name)
@@ -264,7 +257,6 @@ def test_command_init_role_with_template(temp_dir):
         sh.molecule('test')
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('overrride_driver', 'docker', 'default'),
@@ -284,7 +276,6 @@ def test_command_test_overrides_driver(scenario_to_test, with_scenario,
     pytest.helpers.run_command(cmd)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('driver/docker', 'docker', 'default'),
@@ -305,7 +296,6 @@ def test_command_test_builds_local_molecule_image(
     pytest.helpers.test(driver_name, scenario_name)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('test_destroy_strategy', 'docker', 'default'),
@@ -332,7 +322,6 @@ def test_command_test_destroy_strategy_always(scenario_to_test, with_scenario,
     assert 0 != e.value.exit_code
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('test_destroy_strategy', 'docker', 'default'),
@@ -358,7 +347,6 @@ def test_command_test_destroy_strategy_never(scenario_to_test, with_scenario,
     assert 0 != e.value.exit_code
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('host_group_vars', 'docker', 'default'),
@@ -381,7 +369,6 @@ def test_host_group_vars(scenario_to_test, with_scenario, scenario_name):
     assert re.search(r'\[example_1\].*?ok: \[instance\]', out, re.DOTALL)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('idempotence', 'docker', 'raises'),
@@ -404,7 +391,6 @@ def test_idempotence_raises(scenario_to_test, with_scenario, scenario_name):
     assert 2 == e.value.exit_code
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('interpolation', 'docker', 'default'),
@@ -429,7 +415,6 @@ def test_interpolation(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd, env=env)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('verifier', 'docker', 'testinfra'),
@@ -460,7 +445,6 @@ def test_command_verify_testinfra(scenario_to_test, with_scenario,
     pytest.helpers.run_command(cmd)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('verifier', 'docker', 'goss'),
@@ -490,7 +474,6 @@ def test_command_verify_goss(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('verifier', 'docker', 'inspec'),
@@ -520,7 +503,6 @@ def test_command_verify_inspec(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
-@skip_unsupported_matrix
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('plugins', 'docker', 'default'),

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -24,10 +24,6 @@ import tempfile
 import pytest
 import sh
 
-from .conftest import skip_unsupported_matrix
-
-pytestmark = skip_unsupported_matrix
-
 
 @pytest.fixture
 def scenario_to_test(request):

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ usedevelop = false
 [testenv:format]
 commands =
     yapf -i -r molecule/ test/
-deps = yapf>=0.25.0,<2
+deps = yapf>=0.25.0,<0.27
 extras =
 skip_install = true
 tags =


### PR DESCRIPTION
Contains cherrypicks from master for fixing the CI so we can release a hotfix that brings back the ability to run with python3.5

