### PR TITLE
Pass etc_hosts through to docker_container module if set in molecule config

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -80,6 +80,7 @@ class Docker(base.Base):
               - nofile:262144:262144
             dns_servers:
               - 8.8.8.8
+            etc_hosts: "{'host1.example.com': '10.3.1.5'}"
             networks:
               - name: foo
               - name: bar

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -709,7 +709,10 @@ platforms_docker_schema = {
                     }
                 },
                 'etc_hosts': {
-                    'type': 'string',
+                    'type': ['string', 'dict'],
+                    'keyschema': {
+                        'type': 'string',
+                    }
                 },
                 'env': {
                     'type': 'dict',

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -708,6 +708,9 @@ platforms_docker_schema = {
                         'type': 'string',
                     }
                 },
+                'etc_hosts': {
+                    'type': 'string',
+                },
                 'env': {
                     'type': 'dict',
                     'keyschema': {

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -87,6 +87,7 @@
         network_mode: "{{ item.network_mode | default(omit) }}"
         purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
+        etc_hosts: "{{ item.etc_hosts | default(omit) }}"
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -88,6 +88,7 @@
         network_mode: "{{ item.network_mode | default(omit) }}"
         purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
+        etc_hosts: "{{ item.etc_hosts | default(omit) }}"
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -83,6 +83,8 @@ def _model_platforms_docker_section_data():
             'dns_servers': [
                 '8.8.8.8',
             ],
+            'etc_hosts':
+            "{'host1.example.com': '10.3.1.5'}",
             'env': {
                 'FOO': 'bar',
                 'foo': 'bar',
@@ -190,6 +192,7 @@ def _model_platforms_docker_errors_section_data():
             'dns_servers': [
                 int(),
             ],
+            "etc_hosts": str(),
             'env': str(),
             'restart_policy': int(),
             'restart_retries': str(),
@@ -216,6 +219,7 @@ def test_platforms_docker_has_errors(_config):
                 'dns_servers': [{
                     0: ['must be of string type']
                 }],
+                'etc_hosts': ['must be of string type'],
                 'name': ['must be of string type'],
                 'capabilities': [{
                     0: ['must be of string type']

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -192,7 +192,7 @@ def _model_platforms_docker_errors_section_data():
             'dns_servers': [
                 int(),
             ],
-            "etc_hosts": str(),
+            "etc_hosts": int(),
             'env': str(),
             'restart_policy': int(),
             'restart_retries': str(),
@@ -219,7 +219,6 @@ def test_platforms_docker_has_errors(_config):
                 'dns_servers': [{
                     0: ['must be of string type']
                 }],
-                'etc_hosts': ['must be of string type'],
                 'name': ['must be of string type'],
                 'capabilities': [{
                     0: ['must be of string type']
@@ -263,6 +262,7 @@ def test_platforms_docker_has_errors(_config):
                 'ulimits': [{
                     0: ['must be of string type']
                 }],
+                'etc_hosts': ['must be of [\'string\', \'dict\'] type'],
                 'env': ['must be of dict type'],
                 'restart_policy': ['must be of string type'],
                 'restart_retries': ['must be of integer type'],


### PR DESCRIPTION
Continue #1571

Different from the origin one, the etc_hosts is string type. See [here](https://stackoverflow.com/questions/39224679/ansible-docker-container-etc-hosts-with-variable-key)
For example,
```
platforms:
  - name: xenial
    image: ubuntu:xenial
    etc_hosts: >
      {
        "{{ domain_1 }}": "{{ domain_1_ip }}",
        "domain_2" : "{{ domain_2_ip }}",
        "domain_3" : "{{ domain_3_ip }}"
      }
```

#### PR Type

- Feature Pull Request
