### PR TITLE
Add etc_hosts option for Molecule docker instances

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -90,6 +90,9 @@ class Docker(base.Base):
               FOO: bar
             restart_policy: on-failure
             restart_retries: 1
+            etc_hosts:
+              my-server1.example.com: 172.17.0.1
+              my-server2.example.com: 172.17.0.1
             buildargs:
                 http_proxy: http://proxy.example.com:8080/
 
@@ -114,7 +117,7 @@ class Docker(base.Base):
         - name: instance
           image: centos:7
           privileged: true
-          volume_mounts:
+          volumes:
             - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
           command: "/usr/sbin/init"
           environment:

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -721,6 +721,12 @@ platforms_docker_schema = {
                 'restart_retries': {
                     'type': 'integer',
                 },
+                'etc_hosts': {
+                    'type': 'dict',
+                    'keyschema': {
+                        'type': 'string',
+                    }
+                },
                 'networks': {
                     'type': 'list',
                     'schema': {

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -90,6 +90,7 @@
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"
+        etc_hosts: "{{ item.etc_hosts | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -91,6 +91,7 @@
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"
+        etc_hosts: "{{ item.etc_hosts | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -91,6 +91,10 @@ def _model_platforms_docker_section_data():
             'on-failure',
             'restart_retries':
             1,
+            'etc_hosts': {
+                'my-server1.example.com': '172.17.0.1',
+                'my-server2.example.com': '172.17.0.1',
+            },
             'networks': [
                 {
                     'name': 'foo',
@@ -200,6 +204,7 @@ def _model_platforms_docker_errors_section_data():
             ],
             'network_mode': int(),
             'purge_networks': int(),
+            'etc_hosts': str(),
         }]
     }
 
@@ -262,6 +267,7 @@ def test_platforms_docker_has_errors(_config):
                 'env': ['must be of dict type'],
                 'restart_policy': ['must be of string type'],
                 'restart_retries': ['must be of integer type'],
+                'etc_hosts': ['must be of dict type'],
             }]
         }]
     }


### PR DESCRIPTION
Molecule tested docker instances cannot utilize
etc_hosts option of Ansible's docker_container
module as it's not implemented by Molecule's
docker driver's create.yml playbook.

This change implements option for Molecule user
to provide etc_hosts configuration in molecule.yml
file's platforms section.

Signed-off-by: Samuli Silvius <samuli.silvius@gmail.com>


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Feature Pull Request
