### PR TITLE
Fix the CI: remove comment that Tox cannot parse correctly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     pytest-verbose-parametrize==1.4.0
     pytest-xdist==1.26.0
     shade==1.22.2
-    yapf>=0.25.0,<0.27  # pyup: < 0.27 # disable updates, conflicts with flake8 as per https://github.com/ansible/molecule/pull/1915
+    yapf>=0.25.0,<0.27
 
     ansible25: ansible>=2.5,<2.6
     ansible26: ansible>=2.6,<2.7
@@ -69,7 +69,7 @@ usedevelop = false
 [testenv:format]
 commands =
     yapf -i -r molecule/ test/
-deps = yapf>=0.25.0,<0.27  # pyup: < 0.27 # disable updates, conflicts with flake8 as per https://github.com/ansible/molecule/pull/1915
+deps = yapf>=0.25.0,<0.27
 extras =
 skip_install = true
 usedevelop = false


### PR DESCRIPTION
An interim fix for https://github.com/ansible/molecule/issues/1973. I am fine with pushing out working pyup updates for now (because it will try to update this package) and instead get our CI running again. All our CI builds are broken because of this, so I think we should prioritise solving this now.