### PR TITLE
Update Jinja2 to address CVE-2019-10906

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ install_requires =
     colorama == 0.3.9
     cookiecutter == 1.6.0
     python-gilt >= 1.2.1, < 2
-    Jinja2 == 2.10
+    Jinja2 >= 2.10.1
     pexpect >= 4.6.0, < 5
     psutil == 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
     PyYAML == 3.13


### PR DESCRIPTION
Fixes #1976 ,

Updates Jinja2 to mitigate CVE-2019-10906. Since it's a point release and only addresses the security fix (https://github.com/pallets/jinja/releases/tag/2.10.1), it should be a fairly safe upgrade.

#### PR Type

- Bugfix Pull Request : Minor dependency update
