### PR TITLE
Avoid failure to lint due to fstrings in docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,8 @@ whitelist_externals =
 sitepackages = true
 
 [testenv:lint]
+# f'' is used inside docs
+basepython = python3
 deps =
     flake8>=3.6.0,<4
     yamllint>=1.11.1,<2


### PR DESCRIPTION
`tox -e lint` would fail to lint the docs when python2 is picked because
internal use of fstrings.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>