### PR TITLE
Enable use of pre-commit for linting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@ test/conftest.py @webknjaz
 .gitattributes @webknjaz
 .gitignore @webknjaz
 .git_archival.txt @webknjaz
-.pre-commit-config.yaml @webknjaz
-.pre-commit-hooks.yaml @webknjaz
+.pre-commit-config.yaml @webknjaz @ssbarnea
+.pre-commit-hooks.yaml @webknjaz @ssbarnea
 .readthedocs.yml @webknjaz
 .travis.yml @ssbarnea
 
@@ -17,4 +17,4 @@ pytest.ini @webknjaz
 pyproject.toml @webknjaz
 setup.cfg @webknjaz
 setup.py @webknjaz
-tox.ini @webknjaz
+tox.ini @webknjaz @ssbarnea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: check-byte-order-marker
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: debug-statements
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.7
+    hooks:
+      - id: flake8
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.15.0
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]
+        entry: yamllint --strict

--- a/molecule/cookiecutter/scenario/driver/digitalocean/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/digitalocean/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ molecule_no_log }}" 
+  no_log: "{{ molecule_no_log }}"
   vars:
     ssh_user: root
     ssh_port: 22

--- a/test/resources/invalid_role_template/bad_format/README.md
+++ b/test/resources/invalid_role_template/bad_format/README.md
@@ -1,3 +1,3 @@
 This is a custom readme that's inside the invalid role template.
 When trying to use the role command with this template, an exception should be raised,
-as the name of the parent folder is wrongly written. 
+as the name of the parent folder is wrongly written.

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 minversion = 3.9.0
 envlist =
-    flake8
-    yamllint
+    lint
     py{27,35,36,37}-ansible{25,26,27,28}-{functional,unit}
     format-check
     doc
@@ -57,7 +56,11 @@ commands =
 whitelist_externals =
     find
 
-[testenv:lint-base]
+[testenv:lint]
+commands =
+    # to run a single linter you can do "pre-commit run flake8"
+    python -m pre_commit run {posargs:--all}
+deps = pre-commit
 extras =
 skip_install = true
 usedevelop = false
@@ -66,55 +69,18 @@ usedevelop = false
 commands =
     python -m yapf -i -r molecule/ test/
 deps = yapf>=0.25.0,<0.27  # pyup: < 0.27 # disable updates, conflicts with flake8 as per https://github.com/ansible/molecule/pull/1915
-extras = {[testenv:lint-base]extras}
-skip_install = {[testenv:lint-base]skip_install}
-usedevelop = {[testenv:lint-base]usedevelop}
+skip_install = {[testenv:lint]skip_install}
+usedevelop = {[testenv:lint]usedevelop}
 
 [testenv:format-check]
 description = Run yapf check
 commands =
     python -m yapf -d -r molecule/ test/
 deps = {[testenv:format]deps}
-extras = {[testenv:lint-base]extras}
-skip_install = {[testenv:lint-base]skip_install}
-usedevelop = {[testenv:lint-base]usedevelop}
+extras = {[testenv:lint]extras}
+skip_install = {[testenv:lint]skip_install}
+usedevelop = {[testenv:lint]usedevelop}
 
-[testenv:flake8]
-description = Run flake8 check
-# f'' is used inside docs
-basepython = python3
-deps =
-    flake8>=3.6.0,<4
-extras = {[testenv:lint-base]extras}
-skip_install = {[testenv:lint-base]skip_install}
-usedevelop = {[testenv:lint-base]usedevelop}
-commands =
-    python -m flake8
-
-[testenv:yamllint]
-description = Run yamllint check
-deps =
-    yamllint>=1.15.0,<2
-extras = {[testenv:lint-base]extras}
-skip_install = {[testenv:lint-base]skip_install}
-usedevelop = {[testenv:lint-base]usedevelop}
-commands =
-    python -m yamllint -s test/ molecule/
-
-[testenv:lint]
-description = Run all linter checks
-basepython = {[testenv:flake8]basepython}
-deps =
-    {[testenv:flake8]deps}
-    {[testenv:format-check]deps}
-    {[testenv:yamllint]deps}
-extras = {[testenv:lint-base]extras}
-skip_install = {[testenv:lint-base]skip_install}
-usedevelop = {[testenv:lint-base]usedevelop}
-commands =
-    {[testenv:flake8]commands}
-    {[testenv:format-check]commands}
-    {[testenv:yamllint]commands}
 
 [testenv:doc]
 description = Invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
pre-commit is framework used to orchestrating execution of many small
utilities (usually linters) which is also used by tox itself and should
not be seen as a replacement for it.

Despite its name pre-commit does not require installation of a git hook
in order to be used, this being an optional feature of the tool.

Among benefits we can count:

* lower disk footprint as cached linters are reused across repos
* must faster (even on CI due to ~/.cache/pre-commit)
* avoids conflicts between linters, each of them being isolated
* can run only changed files (w/o --all-files flag)
* pinned dependencies by design
* one line bumping support `pre-commit autoupdate`
* optional git hook (pre-commit install)
* allows user to run a single linter if they want

This change does not require any workflow changes for developers, as
`tox -e lint` will still run the linters.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

#### PR Type
- Feature Pull Request
