### PR TITLE
Change selinux workaround to avoid use of sitepackages during normal testing

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -65,6 +65,13 @@ available on your controller or host machines.
   highly recommended to upgrade user setuptools even when using a proper
   virtualenv as shown above.
 
+Keep in mind that on selinux supporting systems, if you install into a virtual
+environment, you may face https://github.com/ansible/ansible/issues/34340 even
+if selinux is not enabled or is configured to be permissive.
+
+It is your reponsability to assure that soft dependencies of Ansible are
+available on your controller or host machines.
+
 Requirements
 ------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ deps =
     #git+https://github.com/manahl/pytest-plugins.git@54ca3c0#egg=pytest-verbose-parametrize&subdirectory=pytest-verbose-parametrize
     pytest-xdist<1.28.0  # pyup: < 1.28 # blocked by `pytest`
     shade==1.31.0
+    # https://github.com/ansible/molecule/issues/1724
+    selinux; platform_system=='Linux'
     yapf>=0.25.0,<0.27  # pyup: < 0.27 # disable updates, conflicts with flake8 as per https://github.com/ansible/molecule/pull/1915
 
     ansible25: ansible>=2.5,<2.6
@@ -55,11 +57,6 @@ commands =
     lint: python -m yamllint -s .
 whitelist_externals =
     find
-# Enabling sitepackages is needed in order to avoid encountering exceptions
-# caused by missing selinux python bindinds in ansible modules like template.
-# Selinux python bindings are binary and they cannot be installed using pip
-# in virtualenvs. Details: https://github.com/ansible/molecule/issues/1724
-sitepackages = true
 
 [testenv:lint]
 # f'' is used inside docs


### PR DESCRIPTION
Instead of using sitepackages in order to avoid the missing selinux inside them, we now install the selinux pure-python shim wheel which dynamically loads the bindings from their system location.

This allows us to avoid problems related to use of sitepackages with tox, where conflicts can occur or less easy to see use of wrong version of the tools.

This change does not change molecule runtime requirements as selinux is soft-dependecy of ansible which requires it only when using docker.

#### PR Type

- Bugfix Pull Request

