### PR TITLE
Move colorama init to a location outside the logger.

### DIFF
--- a/molecule/logger.py
+++ b/molecule/logger.py
@@ -34,8 +34,6 @@ def should_do_markup():
     return sys.stdout.isatty() and os.environ.get('TERM') != 'dumb'
 
 
-colorama.init(autoreset=True, strip=not should_do_markup())
-
 SUCCESS = 100
 OUT = 101
 

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -22,12 +22,15 @@ import os
 
 import click
 import click_completion
+import colorama
 
 import molecule
 from molecule import command
 from molecule.config import MOLECULE_DEBUG
+from molecule.logger import should_do_markup
 
 click_completion.init()
+colorama.init(autoreset=True, strip=not should_do_markup())
 
 LOCAL_CONFIG = os.path.expanduser('~/.config/molecule/config.yml')
 ENV_FILE = '.env.yml'


### PR DESCRIPTION
Having the colorama init inside the logger file causes a cascading
init for every subsystem under molecule inlcuding pytest and testinfra.
This causes ansible-runner (a future change for testinfra) to loose
track of the stdout because colorama is hijacking it.

This is a fix for future changes that will probably be rolling out upstream in testinfra: https://github.com/philpep/testinfra/pull/428

#### PR Type

- Bugfix Pull Request

