### PR TITLE
Add tty option to docker provisioner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 * `dependency` step is now run by default before any playbook sequence step, including
   `create` and `destroy`. This allows the use of roles in all sequence step playbooks.
 * Removed validation regex for docker registry passwords, all ``string`` values are now valid.
+* Add ``tty`` option to the Docker driver.
 
 2.20
 ====

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -59,6 +59,7 @@ class Docker(base.Base):
                 email: user@example.com
             override_command: True|False
             command: sleep infinity
+            tty: True|False
             pid_mode: host
             privileged: True|False
             security_opts:
@@ -117,6 +118,7 @@ class Docker(base.Base):
           volume_mounts:
             - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
           command: "/usr/sbin/init"
+          tty: True
           environment:
             container: docker
 

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -656,6 +656,10 @@ platforms_docker_schema = {
                     'type': 'string',
                     'nullable': True,
                 },
+                'tty': {
+                    'type': 'boolean',
+                    'nullable': True,
+                },
                 'pid_mode': {
                     'type': 'string',
                 },

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -90,6 +90,7 @@
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"
+        tty: "{{ item.tty | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -52,6 +52,8 @@ def _model_platforms_docker_section_data():
             False,
             'command':
             'sleep infinity',
+            'tty':
+            True,
             'pid_mode':
             'host',
             'privileged':
@@ -164,6 +166,7 @@ def _model_platforms_docker_errors_section_data():
             },
             'override_command': int(),
             'command': int(),
+            'tty': str(),
             'pid_mode': int(),
             'privileged': str(),
             'security_opts': [
@@ -232,6 +235,7 @@ def test_platforms_docker_has_errors(_config):
                 'privileged': ['must be of boolean type'],
                 'override_command': ['must be of boolean type'],
                 'command': ['must be of string type'],
+                'tty': ['must be of boolean type'],
                 'registry': [{
                     'url': ['must be of string type'],
                     'credentials': [{


### PR DESCRIPTION
Fixes #2010. When a systemd enabled container like `centos` is started with `tty: yes`, log messages sent to the console are available using `docker logs` command.

#### PR Type

- Feature Pull Request
