### PR TITLE
Disable no_log on creation of resources

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -44,6 +44,9 @@
         pull: "{{ item.item.pull | default(omit) }}"
         buildargs: "{{ item.item.buildargs | default(omit) }}"
       with_items: "{{ platforms.results }}"
+      loop_control:
+        label: "molecule_local/{{ item.item.image }}"
+      no_log: false
       when:
         - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
         - not item.item.pre_build_image | default(false)
@@ -54,6 +57,9 @@
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+      loop_control:
+        label: "{{ item }}"
+      no_log: false
 
     - name: Determine the CMD directives
       set_fact:
@@ -93,6 +99,9 @@
         tty: "{{ item.tty | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      no_log: false
       async: 7200
       poll: 0
 

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -13,6 +13,9 @@
         force_kill: "{{ item.force_kill | default(true) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      no_log: false
       async: 7200
       poll: 0
 
@@ -30,3 +33,6 @@
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         state: absent
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+      loop_control:
+        label: "{{ item }}"
+      no_log: false

--- a/molecule/provisioner/ansible/playbooks/lxd/create.yml
+++ b/molecule/provisioner/ansible/playbooks/lxd/create.yml
@@ -28,3 +28,6 @@
         wait_for_ipv4_addresses: true
         timeout: 600
       with_items: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      no_log: false

--- a/molecule/provisioner/ansible/playbooks/lxd/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/lxd/destroy.yml
@@ -15,3 +15,6 @@
         state: absent
         force_stop: "{{ item.force_stop | default(true) }}"
       with_items: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      no_log: false

--- a/molecule/provisioner/ansible/playbooks/vagrant/create.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/create.yml
@@ -29,6 +29,9 @@
         state: up
       register: server
       with_items: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      no_log: false
 
     # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance creation
     # causes issues.

--- a/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
@@ -17,6 +17,9 @@
         state: destroy
       register: server
       with_items: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      no_log: false
 
     # NOTE(retr0h): Vagrant/VBox sucks and parallelizing instance deletion
     # causes issues.


### PR DESCRIPTION
Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Feature Pull Request

So far when creating/destroying resources, the output only looked like this:

```
--> Action: 'destroy'
    
    PLAY [Destroy] *****************************************************************
    
    TASK [Destroy molecule instance(s)] ********************************************
    changed: [localhost] => (item=None)
    changed: [localhost] => (item=None)
    changed: [localhost] => (item=None)
    changed: [localhost]
    
    TASK [Populate instance config] ************************************************
    ok: [localhost]
    
    TASK [Dump instance config] ****************************************************
    changed: [localhost]
    
    PLAY RECAP *********************************************************************
    localhost                  : ok=3    changed=2    unreachable=0    failed=0
```

This PR disables `no_log` on resource creation/destruction and adds a label to the loop instead (so the whole config isn't always dumped to stdout).

As far as I understand it, this might still leak some information compared to the current situation when something fails (probably the whole `item` gets logged then), so I'm not so sure if this PR is really that harmless. OTOH it is really frustrating to see only `(item=None)` there and if it fails you don't even know which container/VM is the culprit and you have to hope it fails on the next run too so you can run molecule in debug mode instead.