### PR TITLE
Revert the null value test for Vagrant driver

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ install_requires =
     ansible-lint >= 4.0.2, < 5
 
     anyconfig == 0.9.7
-    cerberus >= 1.2, < 3
+    cerberus <= 1.3
     click == 6.7
     click-completion == 0.3.1
     colorama == 0.3.9

--- a/test/unit/model/v2/test_driver_section.py
+++ b/test/unit/model/v2/test_driver_section.py
@@ -134,13 +134,7 @@ def _model_driver_provider_name_not_nullable_when_vagrant_section_data():
     ['_model_driver_provider_name_not_nullable_when_vagrant_section_data'],
     indirect=True)
 def test_driver_provider_name_not_nullable_when_vagrant_driver(_config):
-    x = {
-        'driver': [{
-            'provider': [{
-                'name': ['unallowed value None', 'null value not allowed']
-            }]
-        }]
-    }
+    x = {'driver': [{'provider': [{'name': ['null value not allowed']}]}]}
 
     assert x == schema_v2.validate(_config)
 


### PR DESCRIPTION
To review with caution. Related to https://github.com/ansible/molecule/issues/2022

#### PR Type

- Bugfix Pull Request

This particular unit test seems broken. I reverted the current behavior for the third time after https://github.com/ansible/molecule/commit/cd2ea98325bd1a418371eb8a24b0e2a1b5952f05#diff-d3601755c38e1ab64638083914501041 and https://github.com/ansible/molecule/commit/bd69c6d9af6bc9683fd3eda74f30d9060de878e7#diff-d3601755c38e1ab64638083914501041

This should be carefully reviewed as it is a personal opinioned patch following https://github.com/ansible/molecule/issues/2022#issuecomment-488613124