### PR TITLE
Use selinux shim library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,11 @@ digitalocean =
     dopy; python_version<"3.0"
 docker =
     docker>=2.0.0
+    # selinux python module is needed by ansible-docker modules and allows use
+    # of isolated (default) virtualenvs. It does not avoid need to install the
+    # system selinux libraries but it will provide a clear message when user
+    # has to do that.
+    selinux; sys_platform=="linux2"
 ec2 =
     boto
     boto3

--- a/tox.ini
+++ b/tox.ini
@@ -57,11 +57,6 @@ commands =
     python -m pytest {posargs}
 whitelist_externals =
     find
-# Enabling sitepackages is needed in order to avoid encountering exceptions
-# caused by missing selinux python bindinds in ansible modules like template.
-# Selinux python bindings are binary and they cannot be installed using pip
-# in virtualenvs. Details: https://github.com/ansible/molecule/issues/1724
-sitepackages = true
 
 [testenv:lint-base]
 extras =


### PR DESCRIPTION
Revert the use of site-packages when testing with tox as this proved
to cause other issues and conflicts and use selinux shim module in order
to allow ansible to work correctly from inside the virtualenv.

It should be noted that this is more of a indirect and weak-runtime
dependency due to use of ansible templating with docker.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

#### PR Type

- Bugfix Pull Request
