### PR TITLE
Add yamllint to install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ install_requires =
     tabulate == 0.8.2
     testinfra == 1.19.0
     tree-format == 0.1.2
+    yamllint >= 1.15.0, < 2
 
 [options.extras_require]
 docs =

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ setenv =
     functional: PYTEST_ADDOPTS=test/functional/ {env:PYTEST_ADDOPTS:}
 deps =
     flake8>=3.6.0,<4
-    yamllint>=1.11.1,<2
 
     mock==3.0.5
     pytest==3.10.1  # pyup: < 4 # blocked by `pytest-verbose-parametrize`


### PR DESCRIPTION
This is required in the run time and is suddenly not present when installing the package as can be seen in the report from https://github.com/ansible/molecule/issues/2012. We now include this in our `install_require` list and manage the bounds directly to ensure we have a working default linter.
