### PR TITLE
Add testinfra lower bound of >= 3.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
   `create` and `destroy`. This allows the use of roles in all sequence step playbooks.
 * Removed validation regex for docker registry passwords, all ``string`` values are now valid.
 * Add ``tty`` option to the Docker driver.
+* Specify new lower bound of 3.0.2 for ``testinfra`` which uses the new Ansible test runner.
 
 2.20
 ====

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ install_requires =
     sh == 1.12.14
     six == 1.11.0
     tabulate == 0.8.2
-    testinfra == 1.19.0
+    testinfra >= 3.0.2, < 4
     tree-format == 0.1.2
 
 [options.extras_require]

--- a/test/scenarios/driver/docker/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/docker/molecule/default/tests/test_default.py
@@ -30,4 +30,4 @@ def test_etc_molecule_ansible_hostname_file(host):
 
 def test_buildarg_env_var(host):
     cmd_out = host.run("echo $envarg")
-    assert cmd_out.stdout == 'this_is_a_test'
+    assert cmd_out.stdout.strip() == 'this_is_a_test'

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -311,8 +311,7 @@ def test_execute_bakes(patched_run_command, _patched_testinfra_get_tests,
 
 def test_executes_catches_and_exits_return_code(
         patched_run_command, _patched_testinfra_get_tests, _instance):
-    patched_run_command.side_effect = sh.ErrorReturnCode_1(
-        sh.testinfra, b'', b'')
+    patched_run_command.side_effect = sh.ErrorReturnCode_1(sh.pytest, b'', b'')
     with pytest.raises(SystemExit) as e:
         _instance.execute()
 


### PR DESCRIPTION
Closes https://github.com/ansible/molecule/issues/1849.
Closes https://github.com/ansible/molecule/issues/1727.

I've manually tested this and seen no breaking issues :+1: 