### PR TITLE
Inspec diagnosis

### DIFF
--- a/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.rb
+++ b/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Molecule managed
 
 describe file('/etc/hosts') do

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,6 +40,9 @@ def run_command(cmd, env=os.environ, log=True):
     if log:
         cmd = _rebake_command(cmd, env)
 
+    # Never let sh truncate exceptions in testing
+    cmd = cmd.bake(_truncate_exc=False)
+
     return util.run_command(cmd)
 
 

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -101,7 +101,8 @@ def test_command_init_role_inspec(temp_dir):
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
-        sh.molecule('test')
+        cmd = sh.molecule.bake('test')
+        pytest.helpers.run_command(cmd)
 
 
 def test_command_init_scenario_inspec(temp_dir):
@@ -138,7 +139,8 @@ def test_command_init_role_goss(temp_dir):
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
-        sh.molecule('test')
+        cmd = sh.molecule.bake('test')
+        pytest.helpers.run_command(cmd)
 
 
 def test_command_init_scenario_goss(temp_dir):
@@ -254,7 +256,8 @@ def test_command_init_role_with_template(temp_dir):
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
-        sh.molecule('test')
+        cmd = sh.molecule.bake('test')
+        pytest.helpers.run_command(cmd)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### PR Type

- Bugfix Pull Request

Two related commits:

## Never truncate exceptions raised by sh in testing
    
    The sh module, by default, truncates the output in string
    representations of exceptions. This change tells sh to stop truncating
    those strings in testing, and also fixes a few instances of direct calls
    to the 'sh' module that were not using the pytest.helpers.run_command
    wrapper.

## Comply with rubocop FrozenStringLiteralComment cop
    
    This was fixed with `rubocop --auto-correct`, similar to running `yapf
    --in-place`. I have insufficient ruby experience (and no interest) to
    agree or disagree with rubocop's opinion.

I did targeted testing on the failing inspec test, but I'm going to let travis do the legwork on making sure my `run_command` changes don't otherwise break functional tests.

closes #2042