### PR TITLE
Place upper bounds on inspec/rubcop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -608,6 +608,7 @@ install:
   - >
     ! grep 'ERROR: ' ~/.tox-venv-install.log .tox/*/log/*.log
 before_script:
-  - gem install inspec rubocop
+  - gem install inspec -v '~> 3'
+  - gem install rubocop -v '~> 0.69.0'
 script:
   - tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
   `create` and `destroy`. This allows the use of roles in all sequence step playbooks.
 * Removed validation regex for docker registry passwords, all ``string`` values are now valid.
 * Add ``tty`` option to the Docker driver.
+* Place upper bounds on inspec and rubocop for CI testing.
 
 2.20
 ====


### PR DESCRIPTION
Refs:
  * https://github.com/ansible/molecule/pull/2045
  * https://github.com/ansible/molecule/issues/2042
  * https://github.com/inspec/inspec/blob/master/CHANGELOG.md
  * https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md

I'm OK with having inspec/rubocop users having to come and ask for new major version tool support for the immediate short term. We can bake in a forward looking major version build into the CI more mid-term.