### PR TITLE
Fix Ansible 2.8 deprecation warnings in provisioner playbook

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -27,7 +27,7 @@
       register: platforms
 
     - name: Discover local Docker images
-      docker_image_facts:
+      docker_image_info:
         name: "molecule_local/{{ item.item.name }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
       with_items: "{{ platforms.results }}"


### PR DESCRIPTION
**PR Type**
* Bugfix Pull Request

The [`docker_image_facts` Ansible module](https://docs.ansible.com/ansible/latest/modules/docker_image_facts_module.html) causes deprecation warnings in Ansible 2.8 like:
```
[DEPRECATION WARNING]: docker_image_facts is kept for backwards compatibility
but usage is discouraged. The module documentation details page may explain
more about this rationale.. This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

The preferred alternative, [`docker_image_info`](https://docs.ansible.com/ansible/latest/modules/docker_image_info_module.html) has been available since Ansible 2.1.

This fixes the default `create.yml` playbook for the `molecule.provisioner.ansible.Ansible` provisioner to use `docker_image_info` instead.