### PR TITLE
Update docker driver test for ansible 2.8

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -196,16 +196,12 @@ class Docker(base.Base):
 
         log.info("Sanity checks: '{}'".format(self._name))
 
-        HAS_DOCKER_PY = None
         try:
-            from ansible.module_utils.docker_common import HAS_DOCKER_PY
+            # ansible >= 2.8
+            from ansible.module_utils.docker.common import HAS_DOCKER_PY
         except ImportError:
-
-            # ansible 2.8+
-            try:
-                from ansible.module_utils.docker.common import HAS_DOCKER_PY
-            except ImportError:
-                pass
+            # ansible < 2.8
+            from ansible.module_utils.docker_common import HAS_DOCKER_PY
 
         if not HAS_DOCKER_PY:
             msg = ('Missing Docker driver dependency. Please '

--- a/test/unit/driver/test_docker.py
+++ b/test/unit/driver/test_docker.py
@@ -143,8 +143,14 @@ def test_converged(_instance):
 
 
 def test_sanity_checks_missing_docker_dependency(mocker, _instance):
-    target = 'ansible.module_utils.docker_common.HAS_DOCKER_PY'
-    mocker.patch(target, False)
+    try:
+        # ansible >= 2.8
+        target = 'ansible.module_utils.docker.common.HAS_DOCKER_PY'
+        mocker.patch(target, False)
+    except ImportError:
+        # ansible < 2.8
+        target = 'ansible.module_utils.docker_common.HAS_DOCKER_PY'
+        mocker.patch(target, False)
 
     with pytest.raises(SystemExit):
         _instance.sanity_checks()


### PR DESCRIPTION
In addition to the docker driver test, I also slightly modified the docker driver itself, both changes were
made with the following rationale:

Ansible 2.8 should be the default. The older versions of ansible
should be considered exceptional cases to future-proof the import,
since the new location of the HAS_DOCKER_PY constant will presumably
persist for the forseeable future.

I also removed handling for the case where HAS_DOCKER_PY cannot be
imported, under the assumption that being unable to import this constant
from either its 2.8 or pre-2.8 location is insane for all supported
versions of ansible. My apologies if this assumption is in error.


Please include details of what it is, how to use it, how it's been tested:

Tested with tox envs: lint, format-check, unit, functional (-k docker). ~~Tests were failing with testinfra 1.19, so this needs #2034 to be merged before tests will pass.~~ <-Merged

#### PR Type

- Bugfix Pull Request: Updates docker driver tests for ansible 2.8 compatibility
