### PR TITLE
Fix Deprecations

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -102,7 +102,7 @@ def execute_cmdline_scenarios(scenario_name, args, command_args):
                 msg = ('An error occurred during the {} sequence action: '
                        "'{}'. Cleaning up.").format(scenario.config.subcommand,
                                                     scenario.config.action)
-                LOG.warn(msg)
+                LOG.warning(msg)
                 execute_subcommand(scenario.config, 'cleanup')
                 execute_subcommand(scenario.config, 'destroy')
                 # always prune ephemeral dir if destroying on failure

--- a/molecule/model/schema_v1.py
+++ b/molecule/model/schema_v1.py
@@ -33,7 +33,7 @@ base_schema = {
             },
             'raw_env_vars': {
                 'type': 'dict',
-                'keyschema': {
+                'keysrules': {
                     'type': 'string',
                     'regex': '^[A-Z0-9_-]+$',
                 },

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -196,7 +196,7 @@ base_schema = {
             },
             'env': {
                 'type': 'dict',
-                'keyschema': {
+                'keysrules': {
                     'type': 'string',
                     'regex': '^[A-Z0-9_-]+$',
                 },
@@ -258,7 +258,7 @@ base_schema = {
             },
             'env': {
                 'type': 'dict',
-                'keyschema': {
+                'keysrules': {
                     'type': 'string',
                     'regex': '^[A-Z0-9_-]+$',
                 },
@@ -334,11 +334,11 @@ base_schema = {
             },
             'env': {
                 'type': 'dict',
-                'keyschema': {
+                'keysrules': {
                     'type': 'string',
                     'regex': '^[A-Z0-9_-]+$',
                 },
-                'valueschema': {
+                'valuesrules': {
                     'nullable': False,
                 },
                 'schema': {
@@ -416,7 +416,7 @@ base_schema = {
                     },
                     'env': {
                         'type': 'dict',
-                        'keyschema': {
+                        'keysrules': {
                             'type': 'string',
                             'regex': '^[A-Z0-9_-]+$',
                         },
@@ -477,7 +477,7 @@ base_schema = {
             },
             'env': {
                 'type': 'dict',
-                'keyschema': {
+                'keysrules': {
                     'type': 'string',
                     'regex': '^[A-Z0-9_-]+$',
                 },
@@ -505,7 +505,7 @@ base_schema = {
                     },
                     'env': {
                         'type': 'dict',
-                        'keyschema': {
+                        'keysrules': {
                             'type': 'string',
                             'regex': '^[A-Z0-9_-]+$',
                         },
@@ -717,7 +717,7 @@ platforms_docker_schema = {
                 },
                 'env': {
                     'type': 'dict',
-                    'keyschema': {
+                    'keysrules': {
                         'type': 'string',
                         'regex': '^[a-zA-Z0-9_-]+$',
                     }
@@ -871,7 +871,7 @@ verifier_options_readonly_schema = {
         'type': 'dict',
         'schema': {
             'options': {
-                'keyschema': {
+                'keysrules': {
                     'readonly': True,
                 },
             },

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -182,7 +182,7 @@ def molecule_file_fixture(molecule_scenario_directory_fixture,
 def config_instance(molecule_file_fixture, molecule_data, request):
     mdc = copy.deepcopy(molecule_data)
     if hasattr(request, 'param'):
-        util.merge_dicts(mdc, request.getfuncargvalue(request.param))
+        util.merge_dicts(mdc, request.getfixturevalue(request.param))
     pytest.helpers.write_molecule_file(molecule_file_fixture, mdc)
     c = config.Config(molecule_file_fixture)
     c.command_args = {'subcommand': 'test'}

--- a/test/unit/model/v2/conftest.py
+++ b/test/unit/model/v2/conftest.py
@@ -36,6 +36,6 @@ def _molecule_file():
 def _config(_molecule_file, request):
     d = util.safe_load(open(_molecule_file))
     if hasattr(request, 'param'):
-        d = util.merge_dicts(d, request.getfuncargvalue(request.param))
+        d = util.merge_dicts(d, request.getfixturevalue(request.param))
 
     return d

--- a/test/unit/test_logger.py
+++ b/test/unit/test_logger.py
@@ -50,7 +50,7 @@ def test_out(capsys):
 
 def test_warn(capsys):
     log = logger.get_logger(__name__)
-    log.warn('foo')
+    log.warning('foo')
 
     stdout, _ = capsys.readouterr()
 


### PR DESCRIPTION
This attempts to clear up most of the deprecation warnings being thrown as a result of molecule code. I spread it out across multiple commits, so if anything is particularly objectionable to reviewers we can pop that commit off and put it up in a separate PR. Most commits are straightforward, but a couple are not:

- The addition of `filterwarnings` to `pytest.ini` is a bit of a special case due to the impressive number of deprecation warnings being raised by that plugin. The plugin maintainers appear unresponsive, so the real solution may be to either fix the plugin or just vendor it here and maintain it ourselves, but for now I would prefer to just stop the noise and figure out the right solution later.
- The changes to the schema tests are *drastic*. This alone potentially warrants splitting that off into its own PR, and is a juicy bikeshed target. :)

Tests: lint, format-check, unit, and limited functional. Ansible 2.8 unit tests will fail due to the issue addressed by #2050.