### PR TITLE
Handle new _digital_ocean module in ansible 2.8

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -355,7 +355,16 @@ def supports_azure():
 
 @pytest.helpers.register
 def supports_digitalocean():
-    from ansible.modules.cloud.digital_ocean.digital_ocean import HAS_DOPY
+    try:
+        # ansible >=2.8
+        # The _digital_ocean module is deprecated, and will be removed in
+        # ansible 2.12. This is a temporary fix, and should be addressed
+        # based on decisions made in the related github issue:
+        # https://github.com/ansible/molecule/issues/2054
+        from ansible.modules.cloud.digital_ocean._digital_ocean import HAS_DOPY
+    except ImportError:
+        # ansible <2.8
+        from ansible.modules.cloud.digital_ocean.digital_ocean import HAS_DOPY
 
     env_vars = ('DO_API_KEY', )
 


### PR DESCRIPTION
re #2054, fixes a broken import related to the deprecation of the digital_ocean ansible module that was breaking functional testing in ansible 2.8. As mentioned in the comments, this is a temporary fix, be it temporary for a few days, or temporary until the general availability of ansible 2.10.

The py37-ansible28-functional env was breaking; running this in tox with default requirements should skip everything and not error, which it now does again after applying the fix:
```
$ tox -q -e py37-ansible28-functional -e py37-ansible27-functional -- -k digitalocean
  py37-ansible28-functional: commands succeeded
  py37-ansible27-functional: commands succeeded
  congratulations :)
```

#### PR Type

- Bugfix Pull Request

