### PR TITLE
Support pruning of docker volumes in 'destroy' phase

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 * Add ``tty`` option to the Docker driver.
 * Specify new lower bound of 3.0.2 for ``testinfra`` which uses the new Ansible test runner.
 * Place upper bounds on inspec and rubocop for CI testing.
+* Support pruning of docker volumes in 'destroy' phase for docker driver
 
 2.20
 ====

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -66,6 +66,7 @@ class Docker(base.Base):
               - seccomp=unconfined
             volumes:
               - /sys/fs/cgroup:/sys/fs/cgroup:ro
+            keep_volumes: True|False
             tmpfs:
               - /tmp
               - /run

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -678,6 +678,9 @@ platforms_docker_schema = {
                         'type': 'string',
                     }
                 },
+                'keep_volumes': {
+                    'type': 'boolean',
+                },
                 'tmpfs': {
                     'type': 'list',
                     'schema': {

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -11,6 +11,7 @@
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         state: absent
         force_kill: "{{ item.force_kill | default(true) }}"
+        keep_volumes: "{{ item.keep_volumes | default(true) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/resources/playbooks/docker/destroy.yml
+++ b/test/resources/playbooks/docker/destroy.yml
@@ -11,6 +11,7 @@
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         state: absent
         force_kill: "{{ item.force_kill | default(true) }}"
+        keep_volumes: "{{ item.keep_volumes | default(true) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -64,6 +64,8 @@ def _model_platforms_docker_section_data():
             'volumes': [
                 '/sys/fs/cgroup:/sys/fs/cgroup:ro',
             ],
+            'keep_volumes':
+            True,
             'tmpfs': [
                 '/tmp',
                 '/run ',
@@ -175,6 +177,9 @@ def _model_platforms_docker_errors_section_data():
             'volumes': [
                 int(),
             ],
+            'keep_volumes': [
+                int(),
+            ],
             'tmpfs': [
                 int(),
             ],
@@ -247,6 +252,7 @@ def test_platforms_docker_has_errors(_config):
                 'volumes': [{
                     0: ['must be of string type']
                 }],
+                'keep_volumes': ['must be of boolean type'],
                 'published_ports': [{
                     0: ['must be of string type']
                 }],


### PR DESCRIPTION
By default all docker volumes created by the docker
driver are retained after Molecule destroys instances.
In certain scenarios this could lead to disc space
issues after several test invocations.

This patch adds an option for docker driver to allow
pruning of volumes associated with a removed container.

Signed-off-by: Bartek Grzybowski <bartekgb@users.noreply.github.com>


Please include details of what it is, how to use it, how it's been tested

#### PR Type

- Feature Pull Request
