### PR TITLE
Add ansible_args support back to converge command

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -72,7 +72,10 @@ class Base(object):
         self._config.provisioner.manage_inventory()
 
 
-def execute_cmdline_scenarios(scenario_name, args, command_args):
+def execute_cmdline_scenarios(scenario_name,
+                              args,
+                              command_args,
+                              ansible_args=()):
     """
     Execute scenario sequences based on parsed command-line arguments.
 
@@ -90,7 +93,7 @@ def execute_cmdline_scenarios(scenario_name, args, command_args):
 
     """
     scenarios = molecule.scenarios.Scenarios(
-        get_configs(args, command_args), scenario_name)
+        get_configs(args, command_args, ansible_args), scenario_name)
     scenarios.print_matrix()
     for scenario in scenarios:
         try:

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -102,4 +102,5 @@ def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
         'subcommand': subcommand,
     }
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args,
+                                   ansible_args)


### PR DESCRIPTION
During a recent command-calling refactor, I missed the handling of the `ansible_args` extra arguments in the calling of the converge command. This restores that functionality to the converge command, which as far as I can tell was the only command affected.

It also adds a test to cover the expected behavior to hopefully ensure it doesn't get missed again.

fixes #2061 

#### PR Type

- Bugfix Pull Request

Unit tested on py{27,37}, ansible{26,28}, functional testing with `-k 'docker and converge'`