### PR TITLE
update pyyaml to >=5.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ install_requires =
     Jinja2 >= 2.10.1
     pexpect >= 4.6.0, < 5
     psutil == 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
-    PyYAML == 3.13
+    PyYAML >= 5.1
     sh == 1.12.14
     six == 1.11.0
     tabulate == 0.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ install_requires =
     Jinja2 >= 2.10.1
     pexpect >= 4.6.0, < 5
     psutil == 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
-    PyYAML >= 5.1
+    PyYAML >= 5.1, < 6
     sh == 1.12.14
     six == 1.11.0
     tabulate == 0.8.2


### PR DESCRIPTION
Closes #1806

CVE-2017-18342 flags the previously unsafe default yaml load function in pyyaml. Since version 1.0.6 of this project, it looks like the safe loader (`yaml.safe_load`) was already used everywhere. This PR just updates to a version of pyyaml that does not have the CVE associated with it.