### PR TITLE
Avoid sanity checks for AnsiblePlaybook unit tests

### DIFF
--- a/test/unit/provisioner/test_ansible_playbook.py
+++ b/test/unit/provisioner/test_ansible_playbook.py
@@ -27,7 +27,14 @@ from molecule.provisioner import ansible_playbook
 
 @pytest.fixture
 def _instance(config_instance):
-    return ansible_playbook.AnsiblePlaybook('playbook', config_instance)
+    _instance = ansible_playbook.AnsiblePlaybook('playbook', config_instance)
+
+    # FIXME(decentral1se): temporarily force the sanity checks to not run while
+    # putting the AnsiblePlaybook under test. TBD: reconsider whether invoking
+    # sanity checks within the `execute()` function makes sense.
+    _instance._config.state.change_state('sanity_checked', True)
+
+    return _instance
 
 
 @pytest.fixture


### PR DESCRIPTION
This avoids the need to have the Docker daemon running when running unit tests which should not be necessary and introduces another way for the unit tests to fail.

I've tested this manually like so:

```
$ sudo systemctl stop docker
$  tox -e py37-ansible28-unit -- -n auto -p no:warning 
```

This is necessary for these tests because they call `_instance.execute` directly which is a wrapper function which includes the call to the sanity checks before calling the mocked runner command.