### PR TITLE
Move onto latest Tox and remove install hack

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.9.0
+minversion = 3.12.0
 envlist =
     flake8
     yamllint
@@ -11,11 +11,6 @@ skip_missing_interpreters = True
 isolated_build = True
 
 [testenv]
-# Hotfix for https://github.com/pypa/pip/issues/6434
-# Based on https://github.com/jaraco/skeleton/commit/123b0b2
-# Check https://github.com/tox-dev/tox/issues/1276 for the final solution
-install_command =
-    python -c 'import subprocess, sys; pip_inst_cmd = sys.executable, "-m", "pip", "install"; subprocess.check_call(pip_inst_cmd + ("pip<19.1", )); subprocess.check_call(pip_inst_cmd + tuple(sys.argv[1:]))' {opts} {packages}
 usedevelop = True
 passenv = *
 setenv =


### PR DESCRIPTION
We should get rid of this because it obscures dependency installation errors during the development workflow. The solution is available in the current version of Tox.