### PR TITLE
Removed emoji from github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: 🐛 Bug report
+name: Bug report
 about: Create a report to help us improve
 labels: bug
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: ✨ Feature request
+name: Feature request
 about: Suggest an idea for the Molecule project
 labels: enhancement
 ---

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,6 +1,6 @@
 ---
-name: 📝 Proposal
-about: Suggest an large change for the Molecule project
+name: Proposal
+about: Suggest a large change for the Molecule project
 labels: proposal
 ---
 

--- a/.github/ISSUE_TEMPLATE/security_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/security_bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: 🔥 Security bug report
+name: Security bug report
 about: How to report security vulnerabilities
 ---
 


### PR DESCRIPTION
Emoji clutters the inteface and are likely to cause rendering issues
on multiple platforms.

It is ok to use them in github comments or chat, but not on code, commit
messages, or issue titles.

Closes-Bug: #1987

#### PR Type

- Bugfix Pull Request
