### PR TITLE
Add paramiko dependency (made optional in Ansible 2.8+)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ install_requires =
     cookiecutter == 1.6.0
     python-gilt >= 1.2.1, < 2
     Jinja2 >= 2.10.1
+    paramiko >= 2.4.2, < 3
     pexpect >= 4.6.0, < 5
     psutil == 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
     PyYAML == 3.13


### PR DESCRIPTION
Closes https://github.com/ansible/molecule/issues/2070.

See https://github.com/ansible/ansible/blob/stable-2.8/changelogs/CHANGELOG-v2.8.rst.
See https://www.paramiko.org/installing.html.

As far as I can tell, in the traceback of #2070, it's because we choose to use the Testinfra paramiko back-end. Maybe we can investigate that choice later on. Testinfra doesn't manage these connection back-ends for us and Ansible use to give us this dependency on previous versions transitively.

Questions:
  * Will this conflict with Ansible < 2.8 dependencies?