### PR TITLE
Unpin install requirements to avoid conflicts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,23 +70,23 @@ install_requires =
     ansible >= 2.5
     ansible-lint >= 4.0.2, < 5
 
-    anyconfig == 0.9.7
+    anyconfig >= 0.9.7
     cerberus <= 1.3
-    click == 6.7
-    click-completion == 0.3.1
-    colorama == 0.3.9
-    cookiecutter == 1.6.0
+    click >= 6.7
+    click-completion >= 0.3.1
+    colorama >= 0.3.9
+    cookiecutter >= 1.6.0
     python-gilt >= 1.2.1, < 2
     Jinja2 >= 2.10.1
     paramiko >= 2.4.2, < 3
     pexpect >= 4.6.0, < 5
     psutil == 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
     PyYAML >= 5.1, < 6
-    sh == 1.12.14
-    six == 1.11.0
-    tabulate == 0.8.2
+    sh >= 1.12.14
+    six >= 1.11.0
+    tabulate >= 0.8.2
     testinfra >= 3.0.5, < 4
-    tree-format == 0.1.2
+    tree-format >= 0.1.2
     yamllint >= 1.15.0, < 2
 
 [options.extras_require]


### PR DESCRIPTION
Converts requirement pins to ranges in order to avoid conflicts. If
needed we will be adding capping to packages that are not compatible.

This fixed errors that we seen on Travis related to conflicts.