### PR TITLE
fix dependency gem for rubocop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ ENV PIP_INSTALL_ARGS="\
 
 ENV GEM_PACKAGES="\
     rubocop \
+    json \
+    etc \
     "
 
 ENV MOLECULE_EXTRAS="azure,docker,docs,ec2,gce,linode,lxc,openstack,vagrant,windows"


### PR DESCRIPTION
#### PR Type

- Bugfix Pull Request

I use Rubocop linter for the Inspec verifier.
For my gitlab-ci pipeline I use the image `quay.io/ansible/molecule:latest`

The linter rubocop fails with the following error:
https://gitlab.com/Pinaute/sandbox-ansible-pipeline/-/jobs/224766289

To fix the issue, I needed to add two Gem : json and etc
https://gitlab.com/Pinaute/sandbox-ansible-pipeline/-/jobs/225035679