### PR TITLE
WIP: Enhance Vagrant driver configuration

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -155,7 +155,7 @@ Vagrant.configure('2') do |config|
   c['options'].delete('synced_folder')
 
   c['options'].each { |key, value|
-    eval("config.#{key} = #{value}")
+    config.send "#{key}=", value
   }
 
   ##
@@ -206,7 +206,7 @@ Vagrant.configure('2') do |config|
       # Custom
       provider['options'].each { |key, value|
         if key != 'linked_clone'
-          eval("virtualbox.#{key} = #{value}")
+          virtualbox.send "#{key}=", value
         end
       }
 
@@ -245,7 +245,7 @@ Vagrant.configure('2') do |config|
 
       # Custom
       provider['options'].each { |key, value|
-        eval("vmware.#{key} = #{value}")
+        vmware.send "#{key}=", value
       }
 
       # Raw Configuration
@@ -274,7 +274,7 @@ Vagrant.configure('2') do |config|
 
       # Custom
       provider['options'].each { |key, value|
-        eval("parallels.#{key} = #{value}")
+        parallels.send "#{key}=", value
       }
 
       # Raw Configuration
@@ -303,7 +303,7 @@ Vagrant.configure('2') do |config|
 
       # Custom
       provider['options'].each { |key, value|
-        eval("libvirt.#{key} = #{value}")
+        libvirt.send "#{key}=", value
       }
 
       # Raw Configuration


### PR DESCRIPTION
For all configuration values of the Vagrant driver that are set inside the Vagrantfile using eval you have to supply them as valid ruby code inside your yaml file. That might not be obvious if you just look at the  the documentation and if the value you are going to set is an int or bool you might not even notice that you have to supply them as ruby literals. You just do the right thing intuitively. It works the way you expect it to work. But when it comes to strings, you have to supply them as valid ruby string literal which results in redundant writing of quotes.

For example the config below doesn't work and throws a ruby syntax error:
```
provider_options:
  uri: qemu:///system
```
instead you have to write something like this:
```
provider_options:
  uri: "'qemu:///system'"
```
What makes it even worse is that the behavior is not consistent. Some config option strings are evaled, some are set using the parsed value from the yaml config in a variable assingment. For those values, supplying a string without all the quotes works fine. So to figure out where to use which syntax you have to look at the implementation details.

In this pull request i replaced eval with send. This way you can omit the added quotes in the yaml string and setting variables inside the yaml works more consistently.