### PR TITLE
Fix Ansible 2.8 deprecation warnings in provisioner playbook

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -30,8 +30,15 @@
       when: not item.pre_build_image | default(false)
       register: platforms
 
+    - name: Determine which docker image info module to use
+      set_fact:
+        _docker_image_info_module: >-
+          {{ ansible_version.full is version_compare('2.8', '>=') |
+            ternary('docker_image_info', 'docker_image_facts') }}
+
     - name: Discover local Docker images
-      docker_image_facts:
+      action: "{{ _docker_image_info_module }}"
+      args:
         name: "molecule_local/{{ item.item.name }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
@@ -39,7 +46,8 @@
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
       with_items: "{{ platforms.results }}"
-      when: not item.pre_build_image | default(false)
+      when:
+        - not item.pre_build_image | default(false)
       register: docker_images
 
     - name: Build an Ansible compatible image


### PR DESCRIPTION
The [`docker_image_facts` Ansible module](https://docs.ansible.com/ansible/latest/modules/docker_image_facts_module.html) causes deprecation warnings in Ansible 2.8 like:
```
[DEPRECATION WARNING]: docker_image_facts is kept for backwards compatibility
but usage is discouraged. The module documentation details page may explain
more about this rationale.. This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

The preferred alternative, [`docker_image_info`](https://docs.ansible.com/ansible/latest/modules/docker_image_info_module.html) has been available since Ansible 2.1.

This fixes the default `create.yml` playbook for the `molecule.provisioner.ansible.Ansible` provisioner to use `docker_image_info` instead.

Signed-off-by: Brian Helba <brian.helba@kitware.com>
