### PR TITLE
Add missing flake8 dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ install_requires =
     ansible-lint >= 4.0.2, < 5
 
     anyconfig >= 0.9.7
+    flake8 >=3.6.0
     cerberus <= 1.3
     click >= 6.7
     click-completion >= 0.3.1


### PR DESCRIPTION
Avoids issue where flake8 may be missing in published molecule image.

Fixes: #2094
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
