### PR TITLE
Added podman driver for molecule

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -43,6 +43,7 @@ from molecule.driver import linode
 from molecule.driver import lxc
 from molecule.driver import lxd
 from molecule.driver import openstack
+from molecule.driver import podman
 from molecule.driver import vagrant
 from molecule.lint import yamllint
 from molecule.model import schema_v2
@@ -178,6 +179,8 @@ class Config(object):
             driver = lxd.LXD(self)
         elif driver_name == 'openstack':
             driver = openstack.Openstack(self)
+        elif driver_name == 'podman':
+            driver = podman.Podman(self)
         elif driver_name == 'vagrant':
             driver = vagrant.Vagrant(self)
 
@@ -508,6 +511,7 @@ def molecule_drivers():
         lxc.LXC(None).name,
         lxd.LXD(None).name,
         openstack.Openstack(None).name,
+        podman.Podman(None).name,
         vagrant.Vagrant(None).name,
     ]
 

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -43,6 +43,9 @@ platforms:
   - name: instance
     image: Ubuntu-16.04
     flavor: NO-Nano
+{%- elif cookiecutter.driver_name == 'podman' %}
+  - name: instance
+    image: centos:7
 {%- elif cookiecutter.driver_name == 'vagrant' %}
   - name: instance
     box: ubuntu/xenial64

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -1,0 +1,190 @@
+#  Copyright (c) 2015-2018 Cisco Systems, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+from __future__ import absolute_import
+
+import os
+
+from molecule import logger
+from molecule.driver import base
+
+log = logger.get_logger(__name__)
+
+
+class Podman(base.Base):
+    """
+    The class responsible for managing `Podman`_ containers.  `Podman`_ is
+    not default driver used in Molecule.
+
+    Molecule uses Podman ansible connector and podman CLI while mapping
+    variables from ``molecule.yml`` into ``create.yml`` and ``destroy.yml``.
+
+    .. _`podman connection`: https://docs.ansible.com/ansible/latest/plugins/connection/podman.html
+
+    .. code-block:: yaml
+
+        driver:
+          name: podman
+        platforms:
+          - name: instance
+            hostname: instance
+            image: image_name:tag
+            dockerfile: Dockerfile.j2
+            pull: True|False
+            pre_build_image: True|False
+            registry:
+              url: registry.example.com
+              credentials:
+                username: $USERNAME
+                password: $PASSWORD
+            override_command: True|False
+            command: sleep infinity
+            tty: True|False
+            pid_mode: host
+            privileged: True|False
+            security_opts:
+              - seccomp=unconfined
+            volumes:
+              - /sys/fs/cgroup:/sys/fs/cgroup:ro
+            tmpfs:
+              - /tmp
+              - /run
+            capabilities:
+              - SYS_ADMIN
+            exposed_ports:
+              - 53/udp
+              - 53/tcp
+            published_ports:
+              - 0.0.0.0:8053:53/udp
+              - 0.0.0.0:8053:53/tcp
+            ulimits:
+              - nofile=1024:1028
+            dns_servers:
+              - 8.8.8.8
+            network: host
+            etc_hosts: {'host1.example.com': '10.3.1.5'}
+            cert_path: /foo/bar/cert.pem
+            tls_verify: true
+            env:
+              FOO: bar
+            restart_policy: on-failure
+            restart_retries: 1
+            buildargs:
+              http_proxy: http://proxy.example.com:8080/
+
+    If specifying the `CMD`_ directive in your ``Dockerfile.j2`` or consuming a
+    built image which declares a ``CMD`` directive, then you must set
+    ``override_command: False``. Otherwise, Molecule takes care to honour the
+    value of the ``command`` key or uses the default of ``bash -c "while true;
+    do sleep 10000; done"`` to run the container until it is provisioned.
+
+    When attempting to utilize a container image with `systemd`_ as your init
+    system inside the container to simulate a real machine, make sure to set
+    the ``privileged``, ``volume_mounts``, ``command``, and ``environment``
+    values. An example using the ``centos:7`` image is below:
+
+    .. note:: Do note that running containers in privileged mode is considerably
+              less secure.
+
+    .. code-block:: yaml
+
+        platforms:
+        - name: instance
+          image: centos:7
+          privileged: true
+          volumes:
+            - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+          command: "/usr/sbin/init"
+          tty: True
+
+    .. code-block:: bash
+
+        $ pip install molecule[podman]
+
+    When pulling from a private registry, it is the user's discretion to decide
+    whether to use hard-code strings or environment variables for passing
+    credentials to molecule.
+
+    .. important::
+
+        Hard-coded credentials in ``molecule.yml`` should be avoided, instead use
+        `variable substitution`_.
+
+    Provide a list of files Molecule will preserve, relative to the scenario
+    ephemeral directory, after any ``destroy`` subcommand execution.
+
+    .. code-block:: yaml
+
+        driver:
+          name: podman
+          safe_files:
+            - foo
+
+    .. _`Podman`: https://podman.io/
+    .. _`systemd`: https://www.freedesktop.org/wiki/Software/systemd/
+    .. _`CMD`: https://docs.docker.com/engine/reference/builder/#cmd
+    """  # noqa
+
+    def __init__(self, config):
+        super(Podman, self).__init__(config)
+        self._name = 'podman'
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def login_cmd_template(self):
+        return ('podman exec '
+                '-e COLUMNS={columns} '
+                '-e LINES={lines} '
+                '-e TERM=bash '
+                '-e TERM=xterm '
+                '-ti {instance} bash')
+
+    @property
+    def default_safe_files(self):
+        return [
+            os.path.join(self._config.scenario.ephemeral_directory,
+                         'Dockerfile')
+        ]
+
+    @property
+    def default_ssh_connection_options(self):
+        return []
+
+    def login_options(self, instance_name):
+        return {'instance': instance_name}
+
+    def ansible_connection_options(self, instance_name):
+        return {'ansible_connection': 'podman'}
+
+    def sanity_checks(self):
+        """Implement Podman driver sanity checks."""
+
+        if self._config.state.sanity_checked:
+            return
+
+        log.info("Sanity checks: '{}'".format(self._name))
+        self._config.state.change_state('sanity_checked', True)

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -70,6 +70,7 @@ def pre_validate_base_schema(env, keep_string):
                         'lxc',
                         'lxd',
                         'openstack',
+                        'podman',
                         'vagrant',
                     ],
                     # NOTE(retr0h): Some users use an environment variable to
@@ -774,6 +775,149 @@ platforms_docker_schema = {
     },
 }
 
+platforms_podman_schema = {
+    'platforms': {
+        'type': 'list',
+        'schema': {
+            'type': 'dict',
+            'schema': {
+                'name': {
+                    'type': 'string',
+                },
+                'hostname': {
+                    'type': 'string',
+                },
+                'image': {
+                    'type': 'string',
+                },
+                'dockerfile': {
+                    'type': 'string',
+                },
+                'pull': {
+                    'type': 'boolean',
+                },
+                'pre_build_image': {
+                    'type': 'boolean',
+                },
+                'registry': {
+                    'type': 'dict',
+                    'schema': {
+                        'url': {
+                            'type': 'string',
+                        },
+                        'credentials': {
+                            'type': 'dict',
+                            'schema': {
+                                'username': {
+                                    'type': 'string',
+                                },
+                                'password': {
+                                    'type': 'string',
+                                },
+                            }
+                        },
+                    }
+                },
+                'override_command': {
+                    'type': 'boolean',
+                    'nullable': True,
+                },
+                'command': {
+                    'type': 'string',
+                    'nullable': True,
+                },
+                'tty': {
+                    'type': 'boolean',
+                    'nullable': True,
+                },
+                'pid_mode': {
+                    'type': 'string',
+                },
+                'privileged': {
+                    'type': 'boolean',
+                },
+                'security_opts': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'volumes': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'tmpfs': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'capabilities': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'exposed_ports': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                        'coerce': 'exposed_ports'
+                    }
+                },
+                'published_ports': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'ulimits': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'dns_servers': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'etc_hosts': {
+                    'type': ['string', 'dict'],
+                    'keyschema': {
+                        'type': 'string',
+                    }
+                },
+                'env': {
+                    'type': 'dict',
+                    'keysrules': {
+                        'type': 'string',
+                        'regex': '^[a-zA-Z0-9_-]+$',
+                    }
+                },
+                'restart_policy': {
+                    'type': 'string',
+                },
+                'restart_retries': {
+                    'type': 'integer',
+                },
+                'network': {
+                    'type': 'string',
+                },
+                'cert_path': {
+                    'type': 'string',
+                },
+                'tls_verify': {
+                    'type': 'boolean',
+                }
+            }
+        }
+    },
+}
+
 platforms_lxd_schema = {
     'platforms': {
         'type': 'list',
@@ -1079,6 +1223,8 @@ def validate(c):
     # Driver
     if c['driver']['name'] == 'docker':
         util.merge_dicts(schema, platforms_docker_schema)
+    elif c['driver']['name'] == 'podman':
+        util.merge_dicts(schema, platforms_podman_schema)
     elif c['driver']['name'] == 'vagrant':
         util.merge_dicts(schema, driver_vagrant_provider_section_schema)
         util.merge_dicts(schema, platforms_vagrant_schema)

--- a/molecule/provisioner/ansible/playbooks/podman/create.yml
+++ b/molecule/provisioner/ansible/playbooks/podman/create.yml
@@ -1,0 +1,96 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+
+    - name: Log into a container registry
+      command: >
+        podman login
+        --username {{ item.registry.credentials.username }}
+        --password {{ item.registry.credentials.password }}
+        --tls-verify={{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}
+        {% if lookup('env', 'DOCKER_CERT_PATH') %}--cert-dir {{ item.cert_path | default(lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem') }}{% endif %}
+        {{ item.registry.url }}
+      with_items: "{{ molecule_yml.platforms }}"
+      when:
+        - item.registry is defined
+        - item.registry.credentials is defined
+        - item.registry.credentials.username is defined
+
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}"
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      when: not item.pre_build_image | default(false)
+      register: platforms
+
+    - name: Discover local Docker images
+      shell: >
+        podman image exists molecule_local/{{ item.item.name }} &&
+        podman image inspect molecule_local/{{ item.item.name }}||
+        true
+      with_items: "{{ platforms.results }}"
+      when: not item.pre_build_image | default(false)
+      register: podman_images
+
+    - name: Build an Ansible compatible image
+      command: >
+        podman build
+        -f {{ item.dest }}
+        -t molecule_local/{{ item.item.image }}
+        {% if item.item.buildargs is defined %}{% for i,k in item.item.buildargs.items() %}--build-arg={{ i }}={{ k }} {% endfor %}{% endif %}
+        {% if item.item.pull is defined %}--pull={{ item.item.pull }}{% endif %}
+      with_items: "{{ platforms.results }}"
+      when:
+        - platforms.changed or podman_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+        - not item.item.pre_build_image | default(false)
+
+    - name: Determine the CMD directives
+      set_fact:
+        command_directives_dict: >-
+          {{ command_directives_dict | default({}) |
+             combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
+          }}
+      with_items: "{{ molecule_yml.platforms }}"
+      when: item.override_command | default(true)
+
+    - name: Create molecule instance(s)
+      command: >
+        podman run
+        -d
+        --name "{{ item.name }}"
+        --log-driver=json-file
+        {% if item.pid_mode is defined %}--pid={{ item.pid_mode }}{% endif %}
+        {% if item.privileged is defined %}--privileged={{ item.privileged }}{% endif %}
+        {% if item.security_opts is defined %}{% for i in item.security_opts %}--security-opt {{ i }} {% endfor %}{% endif %}
+        {% if item.volumes is defined %}{% for i in item.volumes %}--volume {{ i }} {% endfor %}{% endif %}
+        {% if item.tmpfs is defined %}{% for i in item.tmpfs %}--tmpfs={{ i }} {% endfor %}{% endif %}
+        {% if item.capabilities is defined %}{% for i in item.capabilities %}--cap-add={{ i }} {% endfor %}{% endif %}
+        {% if item.exposed_ports is defined %}--expose="{{ item.exposed_ports|join(',') }}"{% endif %}
+        {% if item.published_ports is defined %}--publish="{{ item.published_ports|join(',') }}"{% endif %}
+        {% if item.ulimits is defined %}{% for i in item.ulimits %}--ulimit={{ i }} {% endfor %}{% endif %}
+        {% if item.dns_servers is defined %}--dns="{{ item.dns_servers|join(',') }}"{% endif %}
+        {% if item.env is defined %}{% for i,k in item.env.items() %}--env={{ i }}={{ k }} {% endfor %}{% endif %}
+        {% if item.restart_policy is defined %}--restart={{ item.restart_policy }}{% if item.restart_retries is defined %}:{{ item.restart_retries }}{% endif %}{% endif %}
+        {% if item.tty is defined %}--tty={{ item.tty }}{% endif %}
+        {% if item.network is defined %}--network={{ item.network }}{% endif %}
+        {% if item.etc_hosts is defined %}{% for i,k in item.etc_hosts.items() %}--add-host {{ i }}:{{ k }} {% endfor %}{% endif %}
+        {% if item.hostname is defined %}--hostname={{ item.hostname }}{% endif %}
+        {{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}
+        {{ (command_directives_dict | default({}))[item.name] | default('') }}
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: podman_jobs
+      until: podman_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"

--- a/molecule/provisioner/ansible/playbooks/podman/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/podman/destroy.yml
@@ -1,0 +1,21 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      shell: podman container exists {{ item.name }} && podman rm -f {{ item.name }} || true
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) deletion to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -297,6 +297,7 @@ def test_drivers_property(config_instance):
         'lxc',
         'lxd',
         'openstack',
+        'podman',
         'vagrant',
     ]
 
@@ -566,6 +567,7 @@ def test_molecule_drivers():
         'lxc',
         'lxd',
         'openstack',
+        'podman',
         'vagrant',
     ]
 


### PR DESCRIPTION
#### PR Type
- Feature Pull Request
Fixes #1572 

POC of running molecule with podman driver. It may require a patch in ansible which fixes mount problem for rootless podman containers: https://github.com/ansible/ansible/pull/57741 (see issue https://github.com/ansible/ansible/issues/57740)

still requires clean up from docker leftovers and schema (which was copied from dockers one)
Using mostly podman CLI as ansible podman modules don't support yet the required functionality