### PR TITLE
Remove sharding on functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,416 +20,243 @@ services:
 
 language: python
 
-.mixtures:  # is not used by Travis CI, but helps avoid duplication
-  - &if-cron-or-manual-run-or-tagged
-    if: type IN (cron, api) OR tag IS present
-  - &py-27
-    python: "2.7"
-  - &py-36
-    python: "3.6"
-  - &py-37
-    python: "3.7"
-  - &reset-prerequisites
-    addons: {}
-    before_install:
-      - pip install tox-venv tox-tags
-    before_script: []
-    services: []
-  - &lint
-    <<: *py-37
-    <<: *reset-prerequisites
-  - &env-functional
-    TESTS_TYPE: functional
-  - &env-functional-shard_1
-    <<: *env-functional
-    PYTEST_ADDOPTS: >-
-      '-m shard_1_of_3'
-  - &env-functional-shard_2
-    <<: *env-functional
-    PYTEST_ADDOPTS: >-
-      '-m shard_2_of_3'
-  - &env-functional-shard_3
-    <<: *env-functional
-    PYTEST_ADDOPTS: >-
-      '-m shard_3_of_3'
-
 jobs:
   fast_finish: true
 
   allow_failures:
-    - <<: *py-37
-      env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
-    - <<: *py-36
-      env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
-    - <<: *py-36
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-36
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
-    - <<: *py-36
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
-    - <<: *py-27
-      env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=unit
+      python: "3.7"
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=functional
+      python: "3.7"
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=unit
+      python: "3.6"
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=functional
+      python: "3.6"
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=unit
+      python: "2.7"
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=functional
+      python: "2.7"
 
   include:
-    - <<: *lint
-      name: linting the code
+    - name: linting the code
       env:
-        TOXENV: lint
+        - TOXENV=lint
+      python: "3.7"
+      addons: {}
+      before_install:
+        - pip install tox-venv tox-tags
+      before_script: []
+      services: []
 
-    - <<: *lint
-      name: checking the code style
+    - name: checking the code style
       env:
-        TOXENV: format-check
-
-    - <<: *lint
-      name: checking the docs build
+        - TOXENV=format-check
+      python: "3.7"
+      addons: {}
+      before_install:
+        - pip install tox-venv tox-tags
+      before_script: []
+      services: []
+    
+    - name: checking the docs build
       env:
-        TOXENV: doc
+        - TOXENV=doc
+      python: "3.7"
+      addons: {}
+      before_install:
+        - pip install tox-venv tox-tags
+      before_script: []
+      services: []
 
-    - <<: *lint
-      name: checking the Python distribution package metadata consistency
+    - name: checking the Python distribution package metadata consistency
       if: repo == "ansible/molecule" AND type IN (cron, pull_request)  # Only run if PR or cron
       env:
-        TOXENV: metadata-validation
-
-    - <<: *py-37
-      env:
-        ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+        - TOXENV=metadata-validation
+      python: "3.7"
+      addons: {}
+      before_install:
+        - pip install tox-venv tox-tags
+      before_script: []
+      services: []
+    
+    - env:
+        - ANSIBLE_VERSION="28"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.8, Python 3.7
+      python: "3.7"
 
-    - <<: *py-37
-      env:
-        ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="27"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.7, Python 3.7
+      python: "3.7"
 
-    - <<: *py-37
-      env:
-        ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="26"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.6, Python 3.7
+      python: "3.7"
 
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="28"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.8, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="27"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.7, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="26"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.6, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-27
-      env:
-        ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="28"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.8, Python 2.7
+      python: "2.7"
 
-    - <<: *py-27
-      env:
-        ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="27"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.7, Python 2.7
+      python: "2.7"
 
-    - <<: *py-27
-      env:
-        ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+    - env:
+        - ANSIBLE_VERSION="26"
+        - TESTS_TYPE=unit
       name: unit tests, Ansible 2.6, Python 2.7
+      python: "2.7"
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="28"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.8, Python 3.7
+      python: "3.7"
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="27"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.7, Python 3.7
+      python: "3.7"
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="26"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.6, Python 3.7
+      python: "3.7"
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="28"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.8, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="27"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.7, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="26"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.6, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="28"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.8, Python 2.7
+      python: "2.7"
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.7
+    - env:
+        - ANSIBLE_VERSION="27"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.7, Python 2.7
+      python: "2.7"
 
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.7
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.6
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 2.7
+    - env:
+        - ANSIBLE_VERSION="26"
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible 2.6, Python 2.7
+      python: "2.7"
 
     # The following set of jobs is running tests against devel branch
     # of ansible/ansible:
 
-    - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
-    - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
-    - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=unit
+      name: unit tests, Ansible devel, Python 3.7
+      python: "3.7"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible devel, Python 3.7
+      python: "3.7"
+      if: type IN (cron, api) OR tag IS present
 
-    - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
-    - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
-    - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=unit
+      name: functional unit, Ansible devel, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
+
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible devel, Python 3.6
+      python: "3.6"
+      if: type IN (cron, api) OR tag IS present
+
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=unit
+      name: unit tests, Ansible devel, Python 2.7
+      python: "2.7"
+      if: type IN (cron, api) OR tag IS present
+
+    - env:
+        - ANSIBLE_VERSION=devel
+        - TESTS_TYPE=functional
+      name: functional tests, Ansible devel, Python 2.7
+      python: "2.7"
+      if: type IN (cron, api) OR tag IS present
 
     - &deploy-job
-      <<: *py-37
-      <<: *reset-prerequisites
+      python: "3.7"
       stage: Deploy
       name: Publishing current Git tagged version of dist to PyPI
       if: repo == "ansible/molecule" AND tag IS present
       env:
-        TOXENV: metadata-validation,build-dists
+        - TOXENV=metadata-validation,build-dists
       before_deploy:
         - echo > setup.py
       deploy: &deploy-step
@@ -442,7 +269,12 @@ jobs:
         skip-cleanup: true
         "on":
           all_branches: true
-
+      addons: {}
+      before_install:
+        - pip install tox-venv tox-tags
+      before_script: []
+      services: []
+      
     - <<: *deploy-job
       if: >-  # publish only pushes to master and tags; only if upstream
         repo == "ansible/molecule" AND
@@ -460,7 +292,7 @@ jobs:
 
 env:
   global:
-    TOXENV_TMPL: "'ansible${ANSIBLE_VERSION}-${TESTS_TYPE}'"
+    - TOXENV_TMPL="'ansible${ANSIBLE_VERSION}-${TESTS_TYPE}'"
 addons:
   apt:
     packages:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -110,37 +110,6 @@ def pytest_addoption(parser):
         '--delegated', action='store_true', help='Run delegated driver tests.')
 
 
-def pytest_collection_modifyitems(items):
-    marker = pytest.config.getoption('-m')
-    is_sharded = False
-    shard_id = 0
-    shards_num = 0
-    if not marker.startswith('shard_'):
-        return
-    shard_id, _, shards_num = marker[6:].partition('_of_')
-    if shards_num:
-        shard_id = int(shard_id)
-        shards_num = int(shards_num)
-        is_sharded = True
-    else:
-        raise ValueError('shard_{}_of_{} marker is invalid')
-    if not is_sharded:
-        return
-    if not (0 < shard_id <= shards_num):
-        raise ValueError(
-            'shard_id must be greater than 0 and not bigger than shards_num')
-    for test_counter, item in enumerate(items):
-        cur_shard_id = test_counter % shards_num + 1
-        marker = getattr(pytest.mark, 'shard_{}_of_{}'.format(
-            cur_shard_id,
-            shards_num,
-        ))
-        item.add_marker(marker)
-    del marker
-    print('Running sharded test group #{} out of {}'.format(
-        shard_id, shards_num))
-
-
 @pytest.fixture(autouse=True)
 def reset_pytest_vars(monkeypatch):
     """Make PYTEST_* env vars inaccessible to subprocesses."""


### PR DESCRIPTION
Sharding tests was hacky approach for dealing with Travis build time
limitations, one that caused lots of issues.

In order to simplify the testing and ease the migration toward other
CI system, we are better-off dropping the sharding feature (which also
seems to prevent bumping pytest).
