### PR TITLE
WIP: Check performance benefits from avoiding docker rmi

### DIFF
--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -290,11 +290,11 @@ def test_command_test_overrides_driver(scenario_to_test, with_scenario,
     ])
 def test_command_test_builds_local_molecule_image(
         scenario_to_test, with_scenario, scenario_name, driver_name):
-    try:
-        cmd = sh.docker.bake('rmi', 'molecule_local/centos:latest', '--force')
-        pytest.helpers.run_command(cmd)
-    except sh.ErrorReturnCode:
-        pass
+    # try:
+    #     cmd = sh.docker.bake('rmi', 'molecule_local/centos:latest', '--force')
+    #     pytest.helpers.run_command(cmd)
+    # except sh.ErrorReturnCode:
+    #     pass
 
     pytest.helpers.test(driver_name, scenario_name)
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ install_command =
 usedevelop = True
 passenv = *
 setenv =
+    ANSIBLE_CALLABLE_WHITELIST=timer,profile_roles
     PYTHONDONTWRITEBYTECODE=1
     unit: PYTEST_ADDOPTS=test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {env:PYTEST_ADDOPTS:}
     functional: PYTEST_ADDOPTS=test/functional/ {env:PYTEST_ADDOPTS:}


### PR DESCRIPTION
Avoid doing `docker rmi --force` during testing in order to avoid
extra time needed for getting the images multiple times.

Based on local testing duration of test_command_init_role test was
reduced from ~120s to 85s (30%).

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>