### PR TITLE
Add env support to Dockerfile

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
@@ -8,7 +8,7 @@ FROM {{ item.image }}
 {% endif %}
 
 {% if item.env is defined %}
-{% for var, value in item.env.iteritems() %}
+{% for var, value in item.env.items() %}
 {% if value %}
 ENV {{ var }} {{ value }}
 {% endif %}

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
@@ -7,6 +7,14 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
+{% if item.env is defined %}
+{% for var, value in item.env.iteritems() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \


### PR DESCRIPTION
In cases where Molecule runs behind a http proxy, the
image needs proxies set.  Taken from Renaud Martinet's
blog [post][1].

[1]: https://renaudmarti.net/posts/molecule-proxy-support/

Signed-off-by: John Dewey <john@dewey.ws>

#### PR Type

- Feature Pull Request
