### PR TITLE
Enable profiling during test execution

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ install_command =
 usedevelop = True
 passenv = *
 setenv =
+    ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     PYTHONDONTWRITEBYTECODE=1
     unit: PYTEST_ADDOPTS=test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {env:PYTEST_ADDOPTS:}
     functional: PYTEST_ADDOPTS=test/functional/ {env:PYTEST_ADDOPTS:}


### PR DESCRIPTION
Enables task and role profiling during test execution so we can see
how long different operations took.

This would allow us to focus on. optimizing tasks that take most of the
time and lower the total execution time.

Developer can still define his own callbacks which will take precedence
over the default ones.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>
