### PR TITLE
make cookiecutter yamllint match galaxy

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
@@ -3,19 +3,31 @@
 extends: default
 
 rules:
-  braces: {max-spaces-inside: 1, level: error}
-  brackets: {max-spaces-inside: 1, level: error}
-  colons: {max-spaces-after: -1, level: error}
-  commas: {max-spaces-after: -1, level: error}
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
   comments: disable
   comments-indentation: disable
   document-start: disable
-  empty-lines: {max: 3, level: error}
-  hyphens: {level: error}
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
   indentation: disable
   key-duplicates: enable
   line-length: disable
   new-line-at-end-of-file: disable
-  new-lines: {type: unix}
+  new-lines:
+    type: unix
   trailing-spaces: disable
   truthy: disable

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
@@ -1,11 +1,21 @@
+---
+# Based on ansible-lint config
 extends: default
 
 rules:
-  braces:
-    max-spaces-inside: 1
-    level: error
-  brackets:
-    max-spaces-inside: 1
-    level: error
+  braces: {max-spaces-inside: 1, level: error}
+  brackets: {max-spaces-inside: 1, level: error}
+  colons: {max-spaces-after: -1, level: error}
+  commas: {max-spaces-after: -1, level: error}
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines: {max: 3, level: error}
+  hyphens: {level: error}
+  indentation: disable
+  key-duplicates: enable
   line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: {type: unix}
+  trailing-spaces: disable
   truthy: disable


### PR DESCRIPTION
Modified the cookiecutter version of .yamllint to match that of Ansible Galaxy to ensure parity between tests.

#### PR Type

- Feature Pull Request
