### PR TITLE
Remove use of tox-venv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
     - $HOME/.cache/pre-commit
     - $HOME/.pre-commit
     - $HOME/.rvm
-    - $HOME/virtualenv/python$(python -c 'import platform; print(platform.python_version())')
     - $HOME/Library/Caches/Homebrew
 
 services:
@@ -470,11 +469,7 @@ addons:
       - lxd-client
 before_install:
   - export TOXENV=$(echo $TOXENV_TMPL | envsubst)
-  - pip install tox-venv tox-tags
-install:
-  - tox --notest | tee ~/.tox-venv-install.log
-  - >
-    ! grep 'ERROR: ' ~/.tox-venv-install.log .tox/*/log/*.log
+  - pip install tox-tags
 before_script:
   - gem install inspec -v '~> 3'
   - gem install rubocop -v '~> 0.69.0'


### PR DESCRIPTION
tox-venv seems to cause some weird issues on Travis and its use only on
CI makes testing diverge from normal usage.

Avoid exception below which happened after tox-venv was installed:
```
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ModuleNotFoundError: No module named 'tox_venv'
```

I faced this issue while doing a pre-release, the tag build failed and prevented the publish of the release files. See https://travis-ci.com/ansible/molecule/jobs/210164970 -- retry did not work.