### PR TITLE
Avoid failure to open symlinked molecule.yml files

### DIFF
--- a/molecule/util.py
+++ b/molecule/util.py
@@ -199,6 +199,10 @@ def open_file(filename, mode='r'):
     :param mode: A string describing the way in which the file will be used.
     :return: file type
     """
+    # Resolve symlinks as on Linux open() could fail to open it and raise
+    # [Errno 2] No such file or directory
+    filename = os.path.realpath(filename)
+
     with open(filename, mode) as stream:
         yield stream
 


### PR DESCRIPTION
Avoid "[Errno 2] No such file or directory" when molecule encounters
a molecule.yml file that is a symlink under Linux.

Apparently the same operations works correctly under MacOS.

By resolving the path before calling open() we avoid its failure.

Encountered this bug while working on pytest-html at https://travis-ci.com/pycontribs/pytest-molecule/jobs/210205752