### PR TITLE
Fix docker module deprecations

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -50,26 +50,51 @@
         - not item.pre_build_image | default(false)
       register: docker_images
 
-    - name: Build an Ansible compatible image
+    - name: Build an Ansible compatible image (new)
+      when:
+        - ansible_version.full is version_compare('2.8', '>=')
+        - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+        - not item.item.pre_build_image | default(false)
       docker_image:
-        path: "{{ molecule_ephemeral_directory }}"
+        build:
+          path: "{{ molecule_ephemeral_directory }}"
+          dockerfile: "{{ item.invocation.module_args.dest }}"
+          pull: "{{ item.item.pull | default(true) }}"
         name: "molecule_local/{{ item.item.image }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
-        dockerfile: "{{ item.invocation.module_args.dest }}"
-        force: "{{ item.item.force | default(true) }}"
-        pull: "{{ item.item.pull | default(omit) }}"
+        force_source: "{{ item.item.force | default(true) }}"
+        source: build
         buildargs: "{{ item.item.buildargs | default(omit) }}"
       with_items: "{{ platforms.results }}"
       loop_control:
         label: "molecule_local/{{ item.item.image }}"
       no_log: false
+
+    - name: Build an Ansible compatible image (old)
       when:
+        - ansible_version.full is not version_compare('2.8', '>=')
         - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
         - not item.item.pre_build_image | default(false)
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        dockerfile: "{{ item.invocation.module_args.dest }}"
+        pull: "{{ item.item.pull | default(true) }}"
+        name: "molecule_local/{{ item.item.image }}"
+        docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+        cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
+        cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
+        key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
+        tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
+        force: "{{ item.item.force | default(true) }}"
+        buildargs: "{{ item.item.buildargs | default(omit) }}"
+      with_items: "{{ platforms.results }}"
+      loop_control:
+        label: "molecule_local/{{ item.item.image }}"
+      no_log: false
 
     - name: Create docker network(s)
       docker_network:

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -43,23 +43,51 @@
       when: not item.pre_build_image | default(false)
       register: docker_images
 
-    - name: Build an Ansible compatible image
+    - name: Build an Ansible compatible image (new)
+      when:
+        - ansible_version.full is version_compare('2.8', '>=')
+        - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+        - not item.item.pre_build_image | default(false)
       docker_image:
-        path: "{{ molecule_ephemeral_directory }}"
+        build:
+          path: "{{ molecule_ephemeral_directory }}"
+          dockerfile: "{{ item.invocation.module_args.dest }}"
+          pull: "{{ item.item.pull | default(true) }}"
         name: "molecule_local/{{ item.item.image }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
-        dockerfile: "{{ item.invocation.module_args.dest }}"
-        force: "{{ item.item.force | default(true) }}"
-        pull: "{{ item.item.pull | default(omit) }}"
+        force_source: "{{ item.item.force | default(true) }}"
+        source: build
         buildargs: "{{ item.item.buildargs | default(omit) }}"
       with_items: "{{ platforms.results }}"
+      loop_control:
+        label: "molecule_local/{{ item.item.image }}"
+      no_log: false
+
+    - name: Build an Ansible compatible image (old)
       when:
+        - ansible_version.full is not version_compare('2.8', '>=')
         - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
         - not item.item.pre_build_image | default(false)
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        dockerfile: "{{ item.invocation.module_args.dest }}"
+        pull: "{{ item.item.pull | default(true) }}"
+        name: "molecule_local/{{ item.item.image }}"
+        docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+        cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
+        cert_path: "{{ item.cert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem')  if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
+        key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
+        tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
+        force: "{{ item.item.force | default(true) }}"
+        buildargs: "{{ item.item.buildargs | default(omit) }}"
+      with_items: "{{ platforms.results }}"
+      loop_control:
+        label: "molecule_local/{{ item.item.image }}"
+      no_log: false
 
     - name: Create docker network(s)
       docker_network:


### PR DESCRIPTION
Ansible 2.8 introduces lots of deprecations around docker modules and
sadly there is no backwards compatible way to address them.

Thus we run them with different parameters on 2.8+ than with older versions.