### PR TITLE
Fix bug when molecule crash if env value is not a string

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -480,6 +480,8 @@ class Ansible(base.Base):
     def env(self):
         default_env = self.default_env
         env = self._config.config['provisioner']['env'].copy()
+        # ensure that all keys and values are strings
+        env = {str(k): str(v) for k, v in env.items()}
 
         roles_path = default_env['ANSIBLE_ROLES_PATH']
         library_path = default_env['ANSIBLE_LIBRARY']


### PR DESCRIPTION
Fixes #2131
When configuring values in environment that are not strings,
ensure to convert them to string.



#### PR Type

- Bugfix Pull Request
