### PR TITLE
use password specified in instance config to add host variables in generated inventory files

### DIFF
--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -175,8 +175,6 @@ class Delegated(base.Base):
                 d = self._get_instance_config(instance_name)
                 conn_dict = {}
                 conn_dict['ansible_user'] = d.get('user')
-                if d.get('password'):
-                    conn_dict['ansible_password'] = d.get('password')
                 conn_dict['ansible_host'] = d.get('address')
                 conn_dict['ansible_port'] = d.get('port')
                 conn_dict['ansible_connection'] = d.get('connection', 'smart')
@@ -189,6 +187,8 @@ class Delegated(base.Base):
                         'identity_file')
                     conn_dict['ansible_ssh_common_args'] = ' '.join(
                         self.ssh_connection_options)
+                if d.get('password'):
+                    conn_dict['ansible_password'] = d.get('password')
 
                 return conn_dict
 

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -175,6 +175,8 @@ class Delegated(base.Base):
                 d = self._get_instance_config(instance_name)
                 conn_dict = {}
                 conn_dict['ansible_user'] = d.get('user')
+                if d.get('password'):
+                    conn_dict['ansible_password'] = d.get('password')
                 conn_dict['ansible_host'] = d.get('address')
                 conn_dict['ansible_port'] = d.get('port')
                 conn_dict['ansible_connection'] = d.get('connection', 'smart')


### PR DESCRIPTION
When using Molecule with AWS Windows instances, connecting over WinRM requires the initial AWS generated password to be available. 

Below are relevant sections for a working test case

molecule.yml

Make sure to change the YOURSUBNETID below

```
---
dependency:
  name: galaxy
driver:
  name: delegated
lint:
  name: yamllint
platforms:
  - name: instance
    image: ami-0781cf90f9cef3437
    instance_type: t2.micro
    vpc_subnet_id: YOURSUBNETID
    groups:
      - windows
provisioner:
  name: ansible
  log: True
  connection_options:
    ansible_connection: winrm
  inventory:
    group_vars:
      windows:
        ansible_winrm_transport: credssp
        ansible_winrm_server_cert_validation: ignore
  lint:
    name: ansible-lint
verifier:
  name: testinfra
  lint:
    name: flake8
  options:
    v: 4
```


create.yml

```
---
- name: Create
  hosts: localhost
  connection: local
  gather_facts: false
  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
  vars:
    ssh_user: ec2-user
    winrm_user: Administrator
    ssh_port: 22
    winrm_http_port: 5985
    winrm_https_port: 5986
    winrm_init_userdata_script: init_windows.txt
    security_group_name: ansible-molecule-dev-com
    security_group_description: Security group for testing Molecule
    security_group_rules:
      - proto: tcp
        from_port: "{{ ssh_port }}"
        to_port: "{{ ssh_port }}"
        cidr_ip: '0.0.0.0/0'
      - proto: icmp
        from_port: 8
        to_port: -1
        cidr_ip: '0.0.0.0/0'
      - proto: tcp
        from_port: "{{ winrm_http_port }}"
        to_port: "{{ winrm_http_port }}"
        cidr_ip: '0.0.0.0/0'
      - proto: tcp
        from_port: "{{ winrm_https_port }}"
        to_port: "{{ winrm_https_port }}"
        cidr_ip: '0.0.0.0/0'
    security_group_rules_egress:
      - proto: -1
        from_port: 0
        to_port: 0
        cidr_ip: '0.0.0.0/0'

    keypair_name: molecule-key
    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
    instance_name: pc-molecule-1
    owner: 'xyz'
  tasks:
    - name: Create security group
      ec2_group:
        name: "{{ security_group_name }}"
        description: "{{ security_group_name }}"
        rules: "{{ security_group_rules }}"
        rules_egress: "{{ security_group_rules_egress }}"
        tags: { "Owner": "{{ owner }}" }

    - name: Test for presence of local keypair
      stat:
        path: "{{ keypair_path }}"
      register: keypair_local

    - name: Delete remote keypair
      ec2_key:
        name: "{{ keypair_name }}"
        state: absent
      when: not keypair_local.stat.exists

    - name: Create keypair
      ec2_key:
        name: "{{ keypair_name }}"
      register: keypair

    - name: Persist the keypair
      copy:
        dest: "{{ keypair_path }}"
        content: "{{ keypair.key.private_key }}"
        mode: 0600
      when: keypair.changed

    - name: Create molecule instance(s)
      ec2:
        key_name: "{{ keypair_name }}"
        image: "{{ item.image }}"
        instance_type: "{{ item.instance_type }}"
        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
        instance_tags: { "instance": "{{ item.name }}", "Name": "{{ instance_name }}", "Owner": "{{ owner }}", "Patch Group": "SSMLINUXDEV", "Function": "DEV VM", "Env": "DEV", "Business Service": "IT Development", "Application": "Ansible-Molecule-DEV" }
        wait: yes
        user_data: "{{ lookup('file', '{{ winrm_init_userdata_script }}') }}"
      register: server
      with_items: "{{ molecule_yml.platforms }}"
      async: 7200
      poll: 0

    - name: Wait for instance(s) creation to complete
      async_status:
        jid: "{{ item.ansible_job_id }}"
      register: ec2_jobs
      until: ec2_jobs.finished
      retries: 300
      with_items: "{{ server.results }}"

    # Mandatory configuration for Molecule to function.
    - name: get windows password
      ec2_win_password:
        instance_id: "{{ item.instance_ids[0] }}"
        key_file: "{{ keypair_path }}"
        wait: yes
        wait_timeout: 600
      with_items: "{{ ec2_jobs.results }}"
      register: win_ec2_passwords

    - name: Populate instance config dict
      set_fact:
        instance_conf_dict: {
          'instance': "{{ item.0.instances[0].tags.instance }}",
          'address': "{{ item.0.instances[0].private_ip }}",
          'user': "{{ winrm_user }}",
          'password': "{{ item.1.win_password }}",
          'port': "{{ winrm_https_port }}",
          'identity_file': "{{ keypair_path }}",
          'instance_ids': "{{ item.0.instance_ids }}", }
      with_together:
        - "{{ ec2_jobs.results }}"
        - "{{ win_ec2_passwords.results }}"
      register: instance_config_dict
      when: server.changed | bool

    - name: Convert instance config dict to a list
      set_fact:
        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
      when: server.changed | bool

    - name: Dump instance config
      copy:
        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
        dest: "{{ molecule_instance_config }}"
      when: server.changed | bool

    - name: Wait for WinRM
      wait_for:
        port: "{{ winrm_https_port }}"
        host: "{{ item.address }}"
        delay: 10
        timeout: 320
      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"

    - name: Wait for boot process to finish
      pause:
        minutes: 2
```

init_windows.txt
```
Based on the ConfigureRemotingForAnsible.ps1 with one change

Param (
   ...
    [switch]$EnableCredSSP = $true
)

Make sure to include <powershell> begin and </powershell> end block to the init_windows.txt
```

#### PR Type

- Bugfix Pull Request