### PR TITLE
Add support for docker IPAM configuration

### DIFF
--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -132,7 +132,7 @@
         exposed_ports: "{{ item.exposed_ports | default(omit) }}"
         published_ports: "{{ item.published_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
-        networks: "{{ item.networks | default(omit) }}"
+        networks: "{{ (item | molecule_get_docker_container_networks) or omit }}"
         network_mode: "{{ item.network_mode | default(omit) }}"
         purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"

--- a/test/resources/playbooks/docker/create_ipam.yml
+++ b/test/resources/playbooks/docker/create_ipam.yml
@@ -24,21 +24,15 @@
 
     - name: Create Dockerfiles from image names
       template:
-        src: "{{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}"
+        src: "{{ item.dockerfile | default('Dockerfile.j2') }}"
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)
       register: platforms
-
-    - name: Determine which docker image info module to use
-      set_fact:
-        _docker_image_info_module: >-
-          {{ ansible_version.full is version_compare('2.8', '>=') |
-            ternary('docker_image_info', 'docker_image_facts') }}
+      no_log: item.failed
 
     - name: Discover local Docker images
-      action: "{{ _docker_image_info_module }}"
-      args:
+      docker_image_facts:
         name: "molecule_local/{{ item.item.name }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
@@ -46,8 +40,7 @@
         key_path: "{{ item.key_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/key.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
       with_items: "{{ platforms.results }}"
-      when:
-        - not item.pre_build_image | default(false)
+      when: not item.pre_build_image | default(false)
       register: docker_images
 
     - name: Build an Ansible compatible image (new)
@@ -108,8 +101,6 @@
         tls_verify: "{{ item.tls_verify | default(lookup('env', 'DOCKER_TLS_VERIFY')) or false }}"
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_network_configs }}"
-      loop_control:
-        label: "{{ item }}"
       no_log: false
 
     - name: Determine the CMD directives
@@ -152,14 +143,11 @@
         env: "{{ item.env | default(omit) }}"
         restart_policy: "{{ item.restart_policy | default(omit) }}"
         restart_retries: "{{ item.restart_retries | default(omit) }}"
-        tty: "{{ item.tty | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
-      loop_control:
-        label: "{{ item.name }}"
-      no_log: false
       async: 7200
       poll: 0
+      no_log: false
 
     - name: Wait for instance(s) creation to complete
       async_status:
@@ -168,3 +156,4 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      no_log: item.failed

--- a/test/scenarios/driver/docker/molecule/ipam/molecule.yml
+++ b/test/scenarios/driver/docker/molecule/ipam/molecule.yml
@@ -1,0 +1,40 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: ../../../resources/.yamllint
+platforms:
+  - name: instance
+    image: centos:latest
+    networks:
+      - name: foo
+        ipam_options:
+          subnet: '10.255.255.0/24'
+      - name: bar
+        ipam_config:
+          subnet: '10.255.254.0/24'
+      - name: noipam
+    buildargs:
+      testarg: this_is_a_test
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_roles,profile_tasks,timer
+  playbooks:
+    create: ../../../../../resources/playbooks/docker/create_ipam.yml
+    destroy: ../../../../../resources/playbooks/docker/destroy.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  lint:
+    name: ansible-lint
+scenario:
+  name: ipam
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/test/scenarios/driver/docker/molecule/ipam/playbook.yml
+++ b/test/scenarios/driver/docker/molecule/ipam/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  roles:
+    - molecule

--- a/test/scenarios/driver/docker/molecule/ipam/requirements.yml
+++ b/test/scenarios/driver/docker/molecule/ipam/requirements.yml
@@ -1,0 +1,4 @@
+---
+- name: timezone
+  src: yatesr.timezone
+  version: 1.1.0

--- a/test/scenarios/driver/docker/molecule/ipam/tests/test_default.py
+++ b/test/scenarios/driver/docker/molecule/ipam/tests/test_default.py
@@ -1,0 +1,48 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hostname(host):
+    assert 'instance' == host.check_output('hostname -s')
+
+
+def test_etc_molecule_directory(host):
+    f = host.file('/etc/molecule')
+
+    assert f.is_directory
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o755
+
+
+def test_etc_molecule_ansible_hostname_file(host):
+    f = host.file('/etc/molecule/instance')
+
+    assert f.is_file
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o644
+
+
+def test_buildarg_env_var(host):
+    cmd_out = host.run("echo $envarg")
+    assert cmd_out.stdout.strip() == 'this_is_a_test'
+
+
+def test_host_docker_network_interfaces(host):
+    interface_count = 4
+    interface_addresses = []
+
+    for i in range(0, interface_count):
+        interface = host.interface('eth{}'.format(i))
+        assert interface.exists
+        interface_addresses += interface.addresses
+
+    assert len(filter(lambda addr: addr.startswith(
+        '10.255.254.'), interface_addresses)) == 1
+    assert len(filter(lambda addr: addr.startswith(
+        '10.255.255.'), interface_addresses)) == 1


### PR DESCRIPTION
Modify docker provisioner's create.yml to allow specification of _ipam_config_ (or _ipam_options_) to adjust IPAM configuration as needed.

This also introduces two new filters so we do not break creation in case _create.yml_ was customized.

_molecule_get_docker_network_configs_ is an extension of _molecule_get_docker_networks_ which includes the IPAM configuration. Depending on the Ansible version this will either set _ipam_config_ (for Ansible >= 2.8) or _ipam_options_ for the _docker_network_ module, no matter how it was specified inside the platform configuration, taking into account that _ipam_options_ was deprecated and will eventually be removed from the module. 

_molecule_get_docker_container_networks_ is very similar to _molecule_get_docker_networks_, but works on a platform item. The purpose of this filter is to remove _ipam_options_ or _ipam_config_, as _docker_container_ does not accept those attributes.

#### PR Type

- Feature Pull Request
