### PR TITLE
Attempt to parallelize unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ language: python
     <<: *reset-prerequisites
   - &env-functional
     TESTS_TYPE: functional
+  - &env-unit
+    TESTS_TYPE: unit
+    PYTEST_ADDOPTS: >-
+      '-n auto'
   - &env-functional-shard_1
     <<: *env-functional
     PYTEST_ADDOPTS: >-
@@ -59,7 +63,7 @@ jobs:
     - <<: *py-37
       env:
         ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        <<: *env-unit
     - <<: *py-37
       env:
         <<: *env-functional-shard_1
@@ -75,7 +79,7 @@ jobs:
     - <<: *py-36
       env:
         ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        <<: *env-unit
     - <<: *py-36
       env:
         <<: *env-functional-shard_1
@@ -91,7 +95,7 @@ jobs:
     - <<: *py-27
       env:
         ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        <<: *env-unit
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
@@ -130,58 +134,58 @@ jobs:
     - <<: *py-37
       env:
         ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.6, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.6, Python 3.6
 
     - <<: *py-27
       env:
         ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+        <<: *env-unit
       name: unit tests, Ansible 2.6, Python 2.7
 
     - <<: *py-37
@@ -362,7 +366,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        <<: *env-unit
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
@@ -383,7 +387,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        <<: *env-unit
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
@@ -404,7 +408,7 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        <<: *env-unit
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -97,11 +97,12 @@ def get_molecule_file(path):
 
 
 @pytest.helpers.register
-def molecule_ephemeral_directory():
-    project_directory = 'test-project'
+def molecule_ephemeral_directory(_fixture_uuid):
+    project_directory = 'test-project-{}'.format(_fixture_uuid)
     scenario_name = 'test-instance'
 
-    return ephemeral_directory(os.path.join(project_directory, scenario_name))
+    return ephemeral_directory(
+        os.path.join('molecule_test', project_directory, scenario_name))
 
 
 def pytest_addoption(parser):

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -18,12 +18,17 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+from uuid import uuid4
 import copy
 import functools
 import glob
 import os
 import re
 import shutil
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 
 import pytest
 
@@ -167,9 +172,11 @@ def molecule_scenario_directory_fixture(molecule_directory_fixture):
 
 @pytest.fixture
 def molecule_ephemeral_directory_fixture(molecule_scenario_directory_fixture):
-    path = pytest.helpers.molecule_ephemeral_directory()
+    path = pytest.helpers.molecule_ephemeral_directory(str(uuid4()))
     if not os.path.isdir(path):
         os.makedirs(path)
+    yield
+    shutil.rmtree(str(Path(path).parent))
 
 
 @pytest.fixture


### PR DESCRIPTION
After https://github.com/ansible/molecule/pull/2137, I think I understand a little further that the unit tests fixtures just "pretend" to build up the usual config/state folder hierarchy manually. So, we override that to add in a random UUID and push `-n auto` into only the unit test environments from the Travis configuration. This might work ...

Another one for https://github.com/ansible/molecule/issues/1702.