### PR TITLE
Parallelize unit test execution

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -97,11 +97,12 @@ def get_molecule_file(path):
 
 
 @pytest.helpers.register
-def molecule_ephemeral_directory():
-    project_directory = 'test-project'
+def molecule_ephemeral_directory(_fixture_uuid):
+    project_directory = 'test-project-{}'.format(_fixture_uuid)
     scenario_name = 'test-instance'
 
-    return ephemeral_directory(os.path.join(project_directory, scenario_name))
+    return ephemeral_directory(
+        os.path.join('molecule_test', project_directory, scenario_name))
 
 
 def pytest_addoption(parser):

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -18,12 +18,17 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+from uuid import uuid4
 import copy
 import functools
 import glob
 import os
 import re
 import shutil
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 
 import pytest
 
@@ -167,9 +172,11 @@ def molecule_scenario_directory_fixture(molecule_directory_fixture):
 
 @pytest.fixture
 def molecule_ephemeral_directory_fixture(molecule_scenario_directory_fixture):
-    path = pytest.helpers.molecule_ephemeral_directory()
+    path = pytest.helpers.molecule_ephemeral_directory(str(uuid4()))
     if not os.path.isdir(path):
         os.makedirs(path)
+    yield
+    shutil.rmtree(str(Path(path).parent))
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ passenv = *
 setenv =
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     PYTHONDONTWRITEBYTECODE=1
-    unit: PYTEST_ADDOPTS=test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {env:PYTEST_ADDOPTS:}
+    # -n auto used only on unit as is not supported by functional yet
+    unit: PYTEST_ADDOPTS=test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {env:PYTEST_ADDOPTS:-n auto}
     functional: PYTEST_ADDOPTS=test/functional/ {env:PYTEST_ADDOPTS:}
 deps =
     flake8>=3.6.0,<4


### PR DESCRIPTION
Enable parallel mode when calling unittests. User is still able to disable this behavior by defining his own PYTEST_ADDOPTS value.
