### PR TITLE
WIP: Use markers to run some functional tests with `--parallel`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,19 @@ language: python
   - &env-functional-shard_1
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_1_of_3'
+      '-m shard_1_of_4 -m "not parallelizable"'
   - &env-functional-shard_2
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_2_of_3'
+      '-m shard_2_of_4 -m "not parallelizable"'
   - &env-functional-shard_3
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_3_of_3'
+      '-m shard_3_of_4 -m "not parallelizable"'
+  - &env-functional-shard_4
+    <<: *env-functional
+    PYTEST_ADDOPTS: >-
+      '-m shard_3_of_4 -m parallelizable'
 
 jobs:
   fast_finish: true
@@ -72,6 +76,10 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
     - <<: *py-36
       env:
         ANSIBLE_VERSION: devel
@@ -88,6 +96,10 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
     - <<: *py-27
       env:
         ANSIBLE_VERSION: devel
@@ -103,6 +115,10 @@ jobs:
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
         ANSIBLE_VERSION: devel
 
   include:
@@ -188,172 +204,229 @@ jobs:
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 1/4, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 2/4, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 3/4, Ansible 2.8, Python 3.7
+
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 4/4, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.7
+      name: functional tests shard 1/4, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.7
+      name: functional tests shard 2/4, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.7
+      name: functional tests shard 3/4, Ansible 2.7, Python 3.7
+
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 4/4, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.7
+      name: functional tests shard 1/4, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.7
+      name: functional tests shard 2/4, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.7
+      name: functional tests shard 3/4, Ansible 2.6, Python 3.7
+
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 4/4, Ansible 2.6, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 1/4, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 2/4, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 3/4, Ansible 2.8, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 4/4, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.6
+      name: functional tests shard 1/4, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.6
+      name: functional tests shard 2/4, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.6
+      name: functional tests shard 3/4, Ansible 2.7, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 4/4, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.6
+      name: functional tests shard 1/4, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.6
+      name: functional tests shard 2/4, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.6
+      name: functional tests shard 3/4, Ansible 2.6, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 4/4, Ansible 2.6, Python 3.6
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 2.7
+      name: functional tests shard 1/4, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 2.7
+      name: functional tests shard 2/4, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 2.7
+      name: functional tests shard 3/4, Ansible 2.8, Python 2.7
+
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 4/4, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 1/4, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 2/4, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 3/4, Ansible 2.7, Python 2.7
+
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 4/4, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 1/4, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 2/4, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 3/4, Ansible 2.6, Python 2.7
+
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 4/4, Ansible 2.6, Python 2.7
 
     # The following set of jobs is running tests against devel branch
     # of ansible/ansible:
@@ -378,6 +451,11 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
@@ -399,6 +477,11 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
 
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
@@ -419,6 +502,11 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
         ANSIBLE_VERSION: devel
 
     - &deploy-job

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Unreleased
 ==========
 
+* Add the `--parallel` flag to experimentally allow molecule to be run in parallel.
 * `dependency` step is now run by default before any playbook sequence step, including
   `create` and `destroy`. This allows the use of roles in all sequence step playbooks.
 * Removed validation regex for docker registry passwords, all ``string`` values are now valid.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -279,3 +279,41 @@ lives in a shared location and ``molecule.yml`` is points to the shared tests.
     directory: ../resources/tests/
     lint:
       name: flake8
+
+.. _parallel-usage-example:
+
+Running Molecule processes in parallel mode
+===========================================
+
+.. important::
+
+    This functionality should be considered experimental. It is part of ongoing
+    work towards enabling parallelizable functionality across all moving parts
+    in the execution of the Molecule feature set.
+
+.. note::
+
+    Only the following sequences support parallelizable functionality:
+
+      * ``check_sequence``: ``molecule check --parallel``
+      * ``destroy_sequence``: ``molecule destroy --parallel``
+      * ``test_sequence``: ``molecule test --parallel``
+
+    It is currently only available for use with the Docker driver.
+
+It is possible to run Molecule processes in parallel using another tool to
+orchestrate the parallelization (such as `GNU Parallel`_ or `Pytest`_).
+
+When Molecule receives the ``--parallel`` flag it will generate a `UUID`_ for
+the duration of the testing sequence and will use that unique identifier to
+cache the run-time state for that process. The parallel Molecule processes
+cached state and created instances will therefore not interfere with each
+other.
+
+Molecule uses a new and separate caching folder for this in the
+``$HOME/.cache/molecule_parallel`` location. Molecule exposes a new environment
+variable ``MOLECULE_PARALLEL`` which can enable this functionality.
+
+.. _GNU Parallel: https://www.gnu.org/software/parallel/
+.. _Pytest: https://docs.pytest.org/en/latest/
+.. _UUID: https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -78,3 +78,9 @@ Are there similar tools to Molecule?
 .. _`ansible-test`: https://github.com/nylas/ansible-test
 .. _`abandoned`: https://github.com/nylas/ansible-test/issues/14
 .. _`RoleSpec`: https://github.com/nickjj/rolespec
+
+
+Can I run Molecule processes in parallel?
+=========================================
+
+Please see :ref:`parallel-usage-example` for usage.

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -110,6 +110,8 @@ def execute_cmdline_scenarios(scenario_name,
                 execute_subcommand(scenario.config, 'destroy')
                 # always prune ephemeral dir if destroying on failure
                 scenario.prune()
+                if scenario.config.is_parallel:
+                    scenario._remove_scenario_state_directory()
                 util.sysexit()
             else:
                 raise
@@ -143,6 +145,9 @@ def execute_scenario(scenario):
     # debugging by manually stepping through a scenario sequence
     if 'destroy' in scenario.sequence:
         scenario.prune()
+
+        if scenario.config.is_parallel:
+            scenario._remove_scenario_state_directory()
 
 
 def get_configs(args, command_args, ansible_args=()):

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -18,12 +18,15 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import os
 import click
 
 from molecule import logger
 from molecule.command import base
+from molecule import util
 
 LOG = logger.get_logger(__name__)
+MOLECULE_PARALLEL = os.environ.get('MOLECULE_PARALLEL', False)
 
 
 class Check(base.Base):
@@ -58,6 +61,12 @@ class Check(base.Base):
 
         Load an env file to read variables from when rendering
         molecule.yml.
+
+    .. program:: molecule --parallel check
+
+    .. option:: molecule --parallel check
+
+       Run in parallelizable mode.
     """
 
     def execute(self):
@@ -79,7 +88,11 @@ class Check(base.Base):
     default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
     help='Name of the scenario to target. ({})'.format(
         base.MOLECULE_DEFAULT_SCENARIO_NAME))
-def check(ctx, scenario_name):  # pragma: no cover
+@click.option(
+    '--parallel/--no-parallel',
+    default=MOLECULE_PARALLEL,
+    help='Enable or disable parallel mode. Default is disabled.')
+def check(ctx, scenario_name, parallel):  # pragma: no cover
     """
     Use the provisioner to perform a Dry-Run (destroy, dependency, create,
     prepare, converge).
@@ -87,7 +100,11 @@ def check(ctx, scenario_name):  # pragma: no cover
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {
+        'parallel': parallel,
         'subcommand': subcommand,
     }
+
+    if parallel:
+        util.validate_parallel_cmd_args(command_args)
 
     base.execute_cmdline_scenarios(scenario_name, args, command_args)

--- a/molecule/platforms.py
+++ b/molecule/platforms.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from molecule import logger
+from molecule import util
 
 LOG = logger.get_logger(__name__)
 
@@ -65,13 +66,16 @@ class Platforms(object):
               - child_group1
     """
 
-    def __init__(self, config):
+    def __init__(self, config, parallelize_platforms=False):
         """
         Initialize a new platform class and returns None.
 
         :param config: An instance of a Molecule config.
         :return: None
         """
+        if parallelize_platforms:
+            config.config['platforms'] = util._parallelize_platforms(
+                config.config, config._run_uuid)
         self._config = config
 
     @property

--- a/molecule/provisioner/ansible/plugins/filters/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filters/molecule_core.py
@@ -43,7 +43,9 @@ def from_yaml(data):
     i = interpolation.Interpolator(interpolation.TemplateWithDefaults, env)
     interpolated_data = i.interpolate(data)
 
-    return util.safe_load(interpolated_data)
+    loaded_data = util.safe_load(interpolated_data)
+    loaded_data = _parallelize_config(loaded_data)
+    return loaded_data
 
 
 def to_yaml(data):
@@ -63,6 +65,14 @@ def get_docker_networks(data):
                     name = network['name']
                     network_list.append(name)
     return network_list
+
+
+def _parallelize_config(data):
+    state = util.safe_load_file(os.environ['MOLECULE_STATE_FILE'])
+    if state['is_parallel']:
+        data['platforms'] = util._parallelize_platforms(
+            data, state['run_uuid'])
+    return data
 
 
 class FilterModule(object):

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -18,6 +18,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import shutil
 import os
 import fnmatch
 try:
@@ -98,6 +99,14 @@ class Scenario(object):
         self.config = config
         self._setup()
 
+    def _remove_scenario_state_directory(self):
+        """Remove scenario cached disk stored state.
+
+        :return: None
+        """
+        LOG.info('Removing scenario state directory from cache')
+        shutil.rmtree(Path(self.ephemeral_directory).parent)
+
     def prune(self):
         """
         Prune the scenario ephemeral directory files and returns None.
@@ -137,9 +146,14 @@ class Scenario(object):
     @property
     def ephemeral_directory(self):
         project_directory = os.path.basename(self.config.project_directory)
-        scenario_name = self.name
-        project_scenario_directory = os.path.join(
-            'molecule', project_directory, scenario_name)
+
+        if self.config.is_parallel:
+            project_directory = '{}-{}'.format(project_directory,
+                                               self.config._run_uuid)
+
+        project_scenario_directory = os.path.join(self.config.cache_directory,
+                                                  project_directory, self.name)
+
         path = ephemeral_directory(project_scenario_directory)
 
         return ephemeral_directory(path)

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -30,6 +30,8 @@ VALID_KEYS = [
     'driver',
     'prepared',
     'sanity_checked',
+    'run_uuid',
+    'is_parallel',
 ]
 
 
@@ -101,6 +103,14 @@ class State(object):
     def sanity_checked(self):
         return self._data.get('sanity_checked')
 
+    @property
+    def run_uuid(self):
+        return self._data.get('run_uuid')
+
+    @property
+    def is_parallel(self):
+        return self._data.get('is_parallel')
+
     @marshal
     def reset(self):
         self._data = self._default_data()
@@ -133,6 +143,8 @@ class State(object):
             'driver': None,
             'prepared': None,
             'sanity_checked': False,
+            'run_uuid': self._config._run_uuid,
+            'is_parallel': self._config.is_parallel,
         }
 
     def _load_file(self):

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -311,3 +311,17 @@ def memoize(function):
         return memo[args]
 
     return wrapper
+
+
+def validate_parallel_cmd_args(cmd_args):
+    if cmd_args.get('parallel') and cmd_args.get('destroy') == 'never':
+        msg = 'Combining "--parallel" and "--destroy=never" is not supported'
+        sysexit_with_message(msg)
+
+
+def _parallelize_platforms(config, run_uuid):
+    def parallelize(platform):
+        platform['name'] = '{}-{}'.format(platform['name'], run_uuid)
+        return platform
+
+    return [parallelize(platform) for platform in config['platforms']]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 junit_suite_name = molecule_test_suite
 norecursedirs = dist doc build .tox .eggs
 testpaths = test/
+markers =
+  parallelizable: test can be run in parallel execution mode

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -231,10 +231,11 @@ def login(login_args, scenario_name='default'):
 
 
 @pytest.helpers.register
-def test(driver_name, scenario_name='default'):
+def test(driver_name, scenario_name='default', parallel=False):
     options = {
         'scenario_name': scenario_name,
         'all': scenario_name is None,
+        'parallel': parallel,
     }
 
     if driver_name == 'delegated':

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -70,6 +70,7 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
+@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
         ('cleanup', 'docker', 'default'),
@@ -83,6 +84,7 @@ def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
     options = {
         'driver_name': 'docker',
         'all': True,
+        'parallel': True,
     }
     cmd = sh.molecule.bake('test', **options)
     pytest.helpers.run_command(cmd)

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -43,6 +43,7 @@ def driver_name(request):
     return request.param
 
 
+@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [
@@ -64,7 +65,7 @@ def driver_name(request):
         'scenario_name',
     ])
 def test_command_check(scenario_to_test, with_scenario, scenario_name):
-    options = {'scenario_name': scenario_name}
+    options = {'scenario_name': scenario_name, 'parallel': True}
     cmd = sh.molecule.bake('check', **options)
     pytest.helpers.run_command(cmd)
 
@@ -704,6 +705,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
+@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [
@@ -728,7 +730,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     ])
 def test_command_test(scenario_to_test, with_scenario, scenario_name,
                       driver_name):
-    pytest.helpers.test(driver_name, scenario_name)
+    pytest.helpers.test(driver_name, scenario_name, parallel=True)
 
 
 @pytest.mark.parametrize(

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -55,12 +55,7 @@ def driver_name(request):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -86,12 +81,7 @@ def test_command_check(scenario_to_test, with_scenario, scenario_name):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -115,12 +105,7 @@ def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -146,12 +131,7 @@ def test_command_converge(scenario_to_test, with_scenario, scenario_name):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -279,12 +259,7 @@ def test_command_dependency_shell(request, scenario_to_test, with_scenario,
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -310,12 +285,7 @@ def test_command_destroy(scenario_to_test, with_scenario, scenario_name):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -379,12 +349,7 @@ def test_command_init_scenario(temp_dir, driver_name, skip_test):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -470,10 +435,6 @@ instance-2       openstack      ansible             multi-node       false      
 Instance Name                 Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ----------------------------  -------------  ------------------  ---------------  ---------  -----------
 delegated-instance-docker     delegated      ansible             docker           unknown    true
-delegated-instance-ec2        delegated      ansible             ec2              unknown    true
-delegated-instance-gce        delegated      ansible             gce              unknown    true
-delegated-instance-openstack  delegated      ansible             openstack        unknown    true
-delegated-instance-vagrant    delegated      ansible             vagrant          unknown    false
 """.strip()),  # noqa
         ('driver/vagrant', 'vagrant', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
@@ -541,10 +502,6 @@ instance-2  openstack  ansible  multi-node  false  false
 """.strip()),
         ('driver/delegated', 'delegated', """
 delegated-instance-docker     delegated  ansible  docker     unknown  true
-delegated-instance-ec2        delegated  ansible  ec2        unknown  true
-delegated-instance-gce        delegated  ansible  gce        unknown  true
-delegated-instance-openstack  delegated  ansible  openstack  unknown  true
-delegated-instance-vagrant    delegated  ansible  vagrant    unknown  false
 """.strip()),
         ('driver/vagrant', 'vagrant', """
 instance    vagrant  ansible  default     false  false
@@ -644,29 +601,9 @@ def test_command_list_with_format_plain(scenario_to_test, with_scenario,
             '.*instance-2.*',
         ]], 'multi-node'),
         ('driver/delegated', 'delegated', [[
-            'delegated-instance-azure',
-            '.*delegated-instance-azure.*',
-        ]], 'azure'),
-        ('driver/delegated', 'delegated', [[
             'delegated-instance-docker',
             '.*delegated-instance-docker.*',
         ]], 'docker'),
-        ('driver/delegated', 'delegated', [[
-            'delegated-instance-ec2',
-            '.*ip-.*',
-        ]], 'ec2'),
-        ('driver/delegated', 'delegated', [[
-            'delegated-instance-gce',
-            '.*delegated-instance-gce.*',
-        ]], 'gce'),
-        ('driver/delegated', 'delegated', [[
-            'delegated-instance-openstack',
-            '.*delegated-instance-openstack.*',
-        ]], 'openstack'),
-        #  ('driver/delegated', 'delegated', [[
-        #      'delegated-instance-vagrant',
-        #      '.*delegated-instance-vagrant.*',
-        #  ]], 'vagrant'),
         ('driver/vagrant', 'vagrant', [[
             'instance-1',
             '.*instance-1.*',
@@ -697,12 +634,7 @@ def test_command_login(scenario_to_test, with_scenario, login_args,
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -732,12 +664,7 @@ def test_command_prepare(scenario_to_test, with_scenario, scenario_name):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -763,12 +690,7 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[
@@ -796,12 +718,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
         ('driver/lxc', 'lxc', None),
         ('driver/lxd', 'lxd', None),
         ('driver/openstack', 'openstack', None),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', None),
     ],
     indirect=[
@@ -825,12 +742,7 @@ def test_command_test(scenario_to_test, with_scenario, scenario_name,
         ('driver/lxc', 'lxc', 'default'),
         ('driver/lxd', 'lxd', 'default'),
         ('driver/openstack', 'openstack', 'default'),
-        #  ('driver/delegated', 'delegated', 'azure'),
         ('driver/delegated', 'delegated', 'docker'),
-        ('driver/delegated', 'delegated', 'ec2'),
-        ('driver/delegated', 'delegated', 'gce'),
-        ('driver/delegated', 'delegated', 'openstack'),
-        #  ('driver/delegated', 'delegated', 'vagrant'),
         ('driver/vagrant', 'vagrant', 'default'),
     ],
     indirect=[

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -323,6 +323,7 @@ def test_env(config_instance):
         'MOLECULE_PROVISIONER_NAME': 'ansible',
         'MOLECULE_PROVISIONER_LINT_NAME': 'ansible-lint',
         'MOLECULE_SCENARIO_NAME': 'default',
+        'MOLECULE_STATE_FILE': config_instance.state.state_file,
         'MOLECULE_VERIFIER_NAME': 'testinfra',
         'MOLECULE_VERIFIER_LINT_NAME': 'flake8',
         'MOLECULE_VERIFIER_TEST_DIRECTORY': config_instance.verifier.directory,


### PR DESCRIPTION
Relies on https://github.com/ansible/molecule/pull/2146 and https://github.com/ansible/molecule/pull/2137 to be merged. Adds a new shard which only selects functional tests that can be parallelizable. I've come to realise we cannot removing the sharding since we can only parallelize a small part of the functional tests. This is an experiment to see how this runs on the CI. Up for comments!