### PR TITLE
Allows identifying the EC2 instances through the AWS console

### DIFF
--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -77,13 +77,14 @@
         instance_type: "{{ item.instance_type }}"
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
         group: "{{ security_group_name }}"
-        instance_tags:
-          Name: "{{ item.name }}"
+        instance_tags: "{{ item.instance_tags | combine({'instance': item.name})
+          if item.instance_tags is defined
+          else {'instance': item.name} }}"
         wait: true
         assign_public_ip: true
         exact_count: 1
         count_tag:
-          Name: "{{ item.name }}"
+          instance: "{{ item.name }}"
       register: server
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
@@ -104,7 +105,7 @@
     - name: Populate instance config dict
       set_fact:
         instance_conf_dict: {
-          'instance': "{{ item.instances[0].tags.Name }}",
+          'instance': "{{ item.instances[0].tags.instance }}",
           'address': "{{ item.instances[0].public_ip }}",
           'user': "{{ ssh_user }}",
           'port': "{{ ssh_port }}",

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -78,12 +78,12 @@
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
         group: "{{ security_group_name }}"
         instance_tags:
-          instance: "{{ item.name }}"
+          Name: "{{ item.name }}"
         wait: true
         assign_public_ip: true
         exact_count: 1
         count_tag:
-          instance: "{{ item.name }}"
+          Name: "{{ item.name }}"
       register: server
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
@@ -104,7 +104,7 @@
     - name: Populate instance config dict
       set_fact:
         instance_conf_dict: {
-          'instance': "{{ item.instances[0].tags.instance }}",
+          'instance': "{{ item.instances[0].tags.Name }}",
           'address': "{{ item.instances[0].public_ip }}",
           'user': "{{ ssh_user }}",
           'port': "{{ ssh_port }}",


### PR DESCRIPTION
Just replaced the tag **instance** with **Name** for creating the EC2 instances. It allows identifying the EC2 instances through the AWS console.

#### PR Type
- Feature Pull Request
