### PR TITLE
Add `--parallel` to functional test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,19 @@ language: python
   - &env-functional-shard_1
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_1_of_3'
+      '-m shard_1_of_4 -m "not parallelizable"'
   - &env-functional-shard_2
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_2_of_3'
+      '-m shard_2_of_4 -m "not parallelizable"'
   - &env-functional-shard_3
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_3_of_3'
+      '-m shard_3_of_4 -m "not parallelizable"'
+  - &env-functional-shard_4
+    <<: *env-functional
+    PYTEST_ADDOPTS: >-
+      '-n auto -m shard_4_of_4 -m parallelizable'
 
 jobs:
   fast_finish: true
@@ -72,6 +76,10 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
     - <<: *py-36
       env:
         ANSIBLE_VERSION: devel
@@ -88,6 +96,10 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-36
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
     - <<: *py-27
       env:
         ANSIBLE_VERSION: devel
@@ -103,6 +115,10 @@ jobs:
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
         ANSIBLE_VERSION: devel
 
   include:
@@ -183,172 +199,229 @@ jobs:
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 1/4, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 2/4, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 3/4, Ansible 2.8, Python 3.7
+
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 4/4, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.7
+      name: functional tests shard 1/4, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.7
+      name: functional tests shard 2/4, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.7
+      name: functional tests shard 3/4, Ansible 2.7, Python 3.7
+
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 4/4, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.7
+      name: functional tests shard 1/4, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.7
+      name: functional tests shard 2/4, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.7
+      name: functional tests shard 3/4, Ansible 2.6, Python 3.7
+
+    - <<: *py-37
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 4/4, Ansible 2.6, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 1/4, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 2/4, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 3/4, Ansible 2.8, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 4/4, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.6
+      name: functional tests shard 1/4, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.6
+      name: functional tests shard 2/4, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.6
+      name: functional tests shard 3/4, Ansible 2.7, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 4/4, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.6
+      name: functional tests shard 1/4, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.6
+      name: functional tests shard 2/4, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.6
+      name: functional tests shard 3/4, Ansible 2.6, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 4/4, Ansible 2.6, Python 3.6
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/3, Ansible 2.8, Python 2.7
+      name: functional tests shard 1/4, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/3, Ansible 2.8, Python 2.7
+      name: functional tests shard 2/4, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/3, Ansible 2.8, Python 2.7
+      name: functional tests shard 3/4, Ansible 2.8, Python 2.7
+
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "28"
+      name: functional tests shard 4/4, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 1/4, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 2/4, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 3/4, Ansible 2.7, Python 2.7
+
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "27"
+      name: functional tests shard 4/4, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 1/4, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 2/4, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 3/4, Ansible 2.6, Python 2.7
+
+    - <<: *py-27
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: "26"
+      name: functional tests shard 4/4, Ansible 2.6, Python 2.7
 
     # The following set of jobs is running tests against devel branch
     # of ansible/ansible:
@@ -373,6 +446,11 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-37
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
@@ -394,6 +472,11 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
+        ANSIBLE_VERSION: devel
 
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
@@ -414,6 +497,11 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
+        ANSIBLE_VERSION: devel
+    - <<: *py-27
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        <<: *env-functional-shard_4
         ANSIBLE_VERSION: devel
 
     - &deploy-job

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -106,7 +106,7 @@ class Scenario(object):
         :return: None
         """
         LOG.info('Removing scenario state directory from cache')
-        shutil.rmtree(Path(self.ephemeral_directory).parent)
+        shutil.rmtree(str(Path(self.ephemeral_directory).parent))
 
     def prune(self):
         """

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 junit_suite_name = molecule_test_suite
 norecursedirs = dist doc build .tox .eggs
 testpaths = test/
+markers =
+  parallelizable: test can be run in parallel execution mode

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -214,8 +214,12 @@ def login(login_args, scenario_name='default'):
 
 
 @pytest.helpers.register
-def test(driver_name, scenario_name='default'):
-    options = {'scenario_name': scenario_name, 'all': scenario_name is None}
+def test(driver_name, scenario_name='default', parallel=False):
+    options = {
+        'scenario_name': scenario_name,
+        'all': scenario_name is None,
+        'parallel': parallel,
+    }
 
     if driver_name == 'delegated':
         options = {'scenario_name': scenario_name}

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -59,13 +59,14 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
+@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [('cleanup', 'docker', 'default')],
     indirect=['scenario_to_test', 'driver_name', 'scenario_name'],
 )
 def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
-    options = {'driver_name': 'docker', 'all': True}
+    options = {'driver_name': 'docker', 'all': True, 'parallel': True}
     cmd = sh.molecule.bake('test', **options)
     pytest.helpers.run_command(cmd)
 

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -43,6 +43,7 @@ def driver_name(request):
     return request.param
 
 
+@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [
@@ -61,7 +62,7 @@ def driver_name(request):
     indirect=['scenario_to_test', 'driver_name', 'scenario_name'],
 )
 def test_command_check(scenario_to_test, with_scenario, scenario_name):
-    options = {'scenario_name': scenario_name}
+    options = {'scenario_name': scenario_name, 'parallel': True}
     cmd = sh.molecule.bake('check', **options)
     pytest.helpers.run_command(cmd)
 
@@ -740,6 +741,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
+@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [
@@ -759,8 +761,9 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     ],
     indirect=['scenario_to_test', 'driver_name', 'scenario_name'],
 )
-def test_command_test(scenario_to_test, with_scenario, scenario_name, driver_name):
-    pytest.helpers.test(driver_name, scenario_name)
+def test_command_test(scenario_to_test, with_scenario, scenario_name,
+                      driver_name):
+    pytest.helpers.test(driver_name, scenario_name, parallel=True)
 
 
 @pytest.mark.parametrize(

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -761,8 +761,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     ],
     indirect=['scenario_to_test', 'driver_name', 'scenario_name'],
 )
-def test_command_test(scenario_to_test, with_scenario, scenario_name,
-                      driver_name):
+def test_command_test(scenario_to_test, with_scenario, scenario_name, driver_name):
     pytest.helpers.test(driver_name, scenario_name, parallel=True)
 
 

--- a/test/scenarios/driver/azure/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/azure/molecule/multi-node/tests/test_default.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
+    assert re.search(r'instance-[12].*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/delegated/molecule/docker/tests/test_default.py
+++ b/test/scenarios/driver/delegated/molecule/docker/tests/test_default.py
@@ -1,3 +1,4 @@
+import re
 import os
 
 import testinfra.utils.ansible_runner
@@ -8,7 +9,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'delegated-instance-docker' == host.check_output('hostname -s')
+    assert re.search(r'delegated-instance-docker.*',
+                     host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +23,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    f = host.file('/etc/molecule/delegated-instance-docker')
+    f = host.file('/etc/molecule/{}'.format(host.check_output('hostname -s')))
 
     assert f.is_file
     assert f.user == 'root'

--- a/test/scenarios/driver/delegated/molecule/docker/tests/test_default.py
+++ b/test/scenarios/driver/delegated/molecule/docker/tests/test_default.py
@@ -9,8 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'delegated-instance-docker.*',
-                     host.check_output('hostname -s'))
+    assert re.search(r'delegated-instance-docker.*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/digitalocean/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/digitalocean/molecule/multi-node/tests/test_default.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
+    assert re.search(r'instance-[12].*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/docker/molecule/ansible-verifier/verify.yml
+++ b/test/scenarios/driver/docker/molecule/ansible-verifier/verify.yml
@@ -4,7 +4,7 @@
   tasks:
   - name: Assert that the hostname is set
     assert:
-      that: ansible_hostname == 'instance'
+      that: ansible_hostname | match('instance.*')
 
   - name: Stat /etc/molecule directory
     stat:
@@ -21,7 +21,7 @@
 
   - name: Stat created instance file
     stat:
-      path: /etc/molecule/instance
+      path: "/etc/molecule/{{ ansible_host }}"
     register: instance_file
 
   - name: Assert that the file is in the expected state

--- a/test/scenarios/driver/docker/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/docker/molecule/default/tests/test_default.py
@@ -1,3 +1,4 @@
+import re
 import os
 
 import testinfra.utils.ansible_runner
@@ -8,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.check_output('hostname -s')
+    assert re.search(r'instance.*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +22,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    f = host.file('/etc/molecule/instance')
+    f = host.file('/etc/molecule/{}'.format(host.check_output('hostname -s')))
 
     assert f.is_file
     assert f.user == 'root'

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_bar.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_bar.py
@@ -1,3 +1,4 @@
+import re
 import os
 
 import testinfra.utils.ansible_runner
@@ -8,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance-1' == host.check_output('hostname -s')
+    assert re.search(r'instance-1.*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +22,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    f = host.file('/etc/molecule/instance-1')
+    f = host.file('/etc/molecule/{}'.format(host.check_output('hostname -s')))
 
     assert f.is_file
     assert f.user == 'root'

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_baz.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_baz.py
@@ -1,3 +1,4 @@
+import re
 import os
 
 import testinfra.utils.ansible_runner
@@ -8,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance-2' == host.check_output('hostname -s')
+    assert re.search(r'instance-2.*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +22,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    f = host.file('/etc/molecule/instance-2')
+    f = host.file('/etc/molecule/{}'.format(host.check_output('hostname -s')))
 
     assert f.is_file
     assert f.user == 'root'

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_default.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
+    assert re.search(r'instance-[12].*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_foo.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_foo.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
+    assert re.search(r'instance-[12].*', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -21,9 +21,7 @@
 from uuid import uuid4
 import copy
 import functools
-import glob
 import os
-import re
 import shutil
 
 try:
@@ -35,11 +33,6 @@ import pytest
 
 from molecule import util
 from molecule import config
-from molecule.scenario import ephemeral_directory
-
-for d in glob.glob(os.path.join(ephemeral_directory('molecule'), '*')):
-    if re.search('[A-Z]{5}$', d):
-        shutil.rmtree(d)
 
 
 @pytest.helpers.register

--- a/tox.ini
+++ b/tox.ini
@@ -51,10 +51,12 @@ extras =
     windows
 commands_pre =
     find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
+    sh -c 'find {homedir}/.cache -type d -path "*/molecule_*" -exec rm -rfv \{\} +;'
 commands =
     python -m pytest {posargs}
 whitelist_externals =
     find
+    sh
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
We have to add a 4th shard and markers because of the limitations of pytest-xdist. If the tests are passing and there is not so much of a huge difference in time spent on the Travis build, then I think we should move forward with this. We need to have more guarantees that the `--parallel` stuff is working and guarded from regressions.

PS. Let's coordinate merging with #2152.