### PR TITLE
Add a section about the Podman driver to documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,6 +132,12 @@ Openstack
 .. autoclass:: molecule.driver.openstack.Openstack()
    :undoc-members:
 
+Podman
+^^^^^^
+
+.. autoclass:: molecule.driver.podman.Podman()
+    :undoc-members:
+
 Vagrant
 ^^^^^^^
 


### PR DESCRIPTION
#### PR Type
- Docs Pull Request

#### PR Explanation
The PR #2098 doesn't add a section in the documentation. The current PR address that.