### PR TITLE
Add retry and back-off for dependency download

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Unreleased
 ==========
 
+* ``molecule dependency`` now has a retry and timed back-off by default for flaky network connections.
 * Add the `--parallel` flag to experimentally allow molecule to be run in parallel.
 * `dependency` step is now run by default before any playbook sequence step, including
   `create` and `destroy`. This allows the use of roles in all sequence step playbooks.

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -146,12 +146,7 @@ class AnsibleGalaxy(base.Base):
             self.bake()
 
         self._setup()
-        try:
-            util.run_command(self._sh_command, debug=self._config.debug)
-            msg = 'Dependency completed successfully.'
-            LOG.success(msg)
-        except sh.ErrorReturnCode as e:
-            util.sysexit(e.exit_code)
+        self.execute_with_retries()
 
     def _setup(self):
         """

--- a/molecule/dependency/gilt.py
+++ b/molecule/dependency/gilt.py
@@ -108,12 +108,7 @@ class Gilt(base.Base):
         if self._sh_command is None:
             self.bake()
 
-        try:
-            util.run_command(self._sh_command, debug=self._config.debug)
-            msg = 'Dependency completed successfully.'
-            LOG.success(msg)
-        except sh.ErrorReturnCode as e:
-            util.sysexit(e.exit_code)
+        self.execute_with_retries()
 
     def _config_file(self):
         return self.options.get('config')

--- a/molecule/dependency/shell.py
+++ b/molecule/dependency/shell.py
@@ -111,12 +111,7 @@ class Shell(base.Base):
         if self._sh_command is None:
             self.bake()
 
-        try:
-            util.run_command(self._sh_command, debug=self._config.debug)
-            msg = 'Dependency completed successfully.'
-            LOG.success(msg)
-        except sh.ErrorReturnCode as e:
-            util.sysexit(e.exit_code)
+        self.execute_with_retries()
 
     def _has_command_configured(self):
         return 'command' in self._config.config['dependency']

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -152,10 +152,6 @@ def test_command_create(scenario_to_test, with_scenario, scenario_name):
 def test_command_dependency_ansible_galaxy(
     request, scenario_to_test, with_scenario, scenario_name
 ):
-    # FIXME(decentral1se): skipped due to failures on network access
-    if request.getfixturevalue('driver_name') != 'docker':
-        pytest.skip('Skipped to avoid network access failures')
-
     options = {'scenario_name': scenario_name}
     cmd = sh.molecule.bake('dependency', **options)
     pytest.helpers.run_command(cmd)
@@ -189,10 +185,6 @@ def test_command_dependency_ansible_galaxy(
 def test_command_dependency_gilt(
     request, scenario_to_test, with_scenario, scenario_name
 ):
-    # FIXME(decentral1se): skipped due to failures on network access
-    if request.getfixturevalue('driver_name') != 'docker':
-        pytest.skip('Skipped to avoid network access failures')
-
     options = {'scenario_name': scenario_name}
     cmd = sh.molecule.bake('dependency', **options)
     pytest.helpers.run_command(cmd)
@@ -222,10 +214,6 @@ def test_command_dependency_gilt(
 def test_command_dependency_shell(
     request, scenario_to_test, with_scenario, scenario_name
 ):
-    # FIXME(decentral1se): skipped due to failures on network access
-    if request.getfixturevalue('driver_name') != 'docker':
-        pytest.skip('Skipped to avoid network access failures')
-
     options = {'scenario_name': scenario_name}
     cmd = sh.molecule.bake('dependency', **options)
     pytest.helpers.run_command(cmd)

--- a/test/scenarios/dependency/molecule/ansible-galaxy/requirements.yml
+++ b/test/scenarios/dependency/molecule/ansible-galaxy/requirements.yml
@@ -1,5 +1,4 @@
 ---
-# Note(decentral1se): avoid network access when local path install supported
 - name: timezone
   src: yatesr.timezone
   version: 1.1.0

--- a/test/scenarios/dependency/molecule/gilt/gilt.yml
+++ b/test/scenarios/dependency/molecule/gilt/gilt.yml
@@ -1,5 +1,4 @@
 ---
-# Note(decentral1se): avoid network access when local path install supported
 - git: https://github.com/yatesr/ansible-timezone.git
   version: master
   dst: $MOLECULE_EPHEMERAL_DIRECTORY/roles/timezone/

--- a/test/scenarios/dependency/molecule/shell/requirements.yml
+++ b/test/scenarios/dependency/molecule/shell/requirements.yml
@@ -1,5 +1,4 @@
 ---
-# Note(decentral1se): avoid network access when local path install supported
 - name: timezone
   src: yatesr.timezone
   version: 1.1.0

--- a/test/scenarios/dependency/molecule/shell/run.bash
+++ b/test/scenarios/dependency/molecule/shell/run.bash
@@ -2,7 +2,6 @@
 
 set -e
 
-# Note(decentral1se): avoid network access when local path install supported
 ansible-galaxy install \
 	-vvv \
 	--force \


### PR DESCRIPTION
* Closes https://github.com/ansible/molecule/issues/2114.
* If someone wants it to be configurable, then I'll add it. Not now.
* I've tested this manually. The existing test suite should cover it.

Here's the log:

```
(.venv) ➜  molecule (feature/dependency-retries) ✔ molecule init role -r testdepretry                                               
--> Initializing new role testdepretry...                   
Initialized role in /.../molecule/testdepretry successfully.
(.venv) ➜  molecule (feature/dependency-retries) ✗ cd testdepretry                                                                  
(.venv) ➜  testdepretry (feature/dependency-retries) ✗ cp ../test/scenarios/dependency/molecule/ansible-galaxy/requirements.yml molecule/default 
(.venv) ➜  testdepretry (feature/dependency-retries) ✗                                                                                          
(.venv) ➜  testdepretry (feature/dependency-retries) ✗ nmcli radio wifi off                                                                     
(.venv) ➜  testdepretry (feature/dependency-retries) ✗ molecule dependency              
--> Validating schema /.../molecule/testdepretry/molecule/default/molecule.yml.
Validation completed successfully.
--> Test matrix
    
└── default
    └── dependency
    
--> Scenario: 'default'
--> Action: 'dependency'
 [WARNING]: - timezone was NOT installed successfully: Failed to get data from
the API server (https://galaxy.ansible.com/api/): Failed to connect to
galaxy.ansible.com at port 443: [Errno -2] Name or service not known

ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
Retrying dependency ... 1/3 time(s)
Sleeping 3 seconds before retrying ...
 [WARNING]: - timezone was NOT installed successfully: Failed to get data from
the API server (https://galaxy.ansible.com/api/): Failed to connect to
galaxy.ansible.com at port 443: [Errno -2] Name or service not known

ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
Retrying dependency ... 2/3 time(s)
Sleeping 6 seconds before retrying ...
 [WARNING]: - timezone was NOT installed successfully: Failed to get data from
the API server (https://galaxy.ansible.com/api/): Failed to connect to
galaxy.ansible.com at port 443: [Errno -2] Name or service not known

ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
Retrying dependency ... 3/3 time(s)
Sleeping 9 seconds before retrying ...
 [WARNING]: - timezone was NOT installed successfully: Failed to get data from
the API server (https://galaxy.ansible.com/api/): Failed to connect to
galaxy.ansible.com at port 443: [Errno -2] Name or service not known

ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
[1]    17219 exit 1     molecule dependency
```