### PR TITLE
Fix bug when molecule crash if env value is not a string

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -492,6 +492,8 @@ class Ansible(base.Base):
     def env(self):
         default_env = self.default_env
         env = self._config.config['provisioner']['env'].copy()
+        # ensure that all keys and values are strings
+        env = {str(k): str(v) for k, v in env.items()}
 
         roles_path = default_env['ANSIBLE_ROLES_PATH']
         library_path = default_env['ANSIBLE_LIBRARY']

--- a/test/scenarios/driver/docker/molecule/default/molecule.yml
+++ b/test/scenarios/driver/docker/molecule/default/molecule.yml
@@ -25,6 +25,8 @@ provisioner:
     destroy: ../../../../../resources/playbooks/docker/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+    # keep this here to test that we convert integers to strings:
+    SOME_VALUE_AS_INFO: 1
   lint:
     name: ansible-lint
 scenario:


### PR DESCRIPTION
When configuring values in environment that are not strings,
ensure to convert them to string.

Fixes: #2131
Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

