### PR TITLE
Unpin test depedencies and migrate them into test extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -125,7 +125,7 @@ test =
     flake8>=3.6.0, < 4
 
     mock>=3.0.5, < 4
-    pytest>=4.6.3, < 6
+    pytest>=4.6.3, < 5
     pytest-cov>=2.7.1, < 3
     pytest-helpers-namespace>=2019.1.8, < 2020
     pytest-mock>=1.10.4, < 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,14 +124,14 @@ windows =
 test =
     flake8>=3.6.0,<4
 
-    mock>=3.0.5
-    pytest>=4.6.3
-    pytest-cov>=2.7.1
-    pytest-helpers-namespace>=2019.1.8
-    pytest-mock>=1.10.4
-    pytest-verbose-parametrize>=1.7.0
-    pytest-xdist>=1.29.0
-    shade>=1.31.0
+    mock>=3.0.5, <4
+    pytest>=4.6.3, <6
+    pytest-cov>=2.7.1, <3
+    pytest-helpers-namespace>=2019.1.8, <2020
+    pytest-mock>=1.10.4, <2
+    pytest-verbose-parametrize>=1.7.0, <2
+    pytest-xdist>=1.29.0, <2
+    shade>=1.31.0, <2
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,16 +122,16 @@ vagrant =
 windows =
     pywinrm
 test =
-    flake8>=3.6.0,<4
+    flake8>=3.6.0, < 4
 
-    mock>=3.0.5, <4
-    pytest>=4.6.3, <6
-    pytest-cov>=2.7.1, <3
-    pytest-helpers-namespace>=2019.1.8, <2020
-    pytest-mock>=1.10.4, <2
-    pytest-verbose-parametrize>=1.7.0, <2
-    pytest-xdist>=1.29.0, <2
-    shade>=1.31.0, <2
+    mock>=3.0.5, < 4
+    pytest>=4.6.3, < 6
+    pytest-cov>=2.7.1, < 3
+    pytest-helpers-namespace>=2019.1.8, < 2020
+    pytest-mock>=1.10.4, < 2
+    pytest-verbose-parametrize>=1.7.0, < 2
+    pytest-xdist>=1.29.0, < 2
+    shade>=1.31.0, < 2
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,6 +121,17 @@ vagrant =
     python-vagrant
 windows =
     pywinrm
+test =
+    flake8>=3.6.0,<4
+
+    mock>=3.0.5
+    pytest>=4.6.3
+    pytest-cov>=2.7.1
+    pytest-helpers-namespace>=2019.1.8
+    pytest-mock>=1.10.4
+    pytest-verbose-parametrize>=1.7.0
+    pytest-xdist>=1.29.0
+    shade>=1.31.0
 
 [options.entry_points]
 console_scripts =

--- a/tox.ini
+++ b/tox.ini
@@ -24,17 +24,6 @@ setenv =
     unit: PYTEST_ADDOPTS=test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {env:PYTEST_ADDOPTS:-n auto}
     functional: PYTEST_ADDOPTS=test/functional/ {env:PYTEST_ADDOPTS:}
 deps =
-    flake8>=3.6.0,<4
-
-    mock==3.0.5
-    pytest==4.6.3
-    pytest-cov==2.7.1
-    pytest-helpers-namespace==2019.1.8
-    pytest-mock==1.10.4
-    pytest-verbose-parametrize==1.7.0
-    pytest-xdist==1.29.0
-    shade==1.31.0
-
     ansible25: ansible>=2.5,<2.6
     ansible26: ansible>=2.6,<2.7
     ansible27: ansible>=2.7,<2.8
@@ -50,6 +39,7 @@ extras =
     openstack
     vagrant
     windows
+    test
 commands_pre =
     find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
     sh -c 'find {homedir}/.cache -type d -path "*/molecule_*" -exec rm -rfv \{\} +;'


### PR DESCRIPTION
This moved test deps into an extra, which will allow us to install
molecule test environment without tox.

By unpining them we will avoid potential version conflicts as the small
risk of detecting breakages. If detected we can easily add capping
until we address the issues.
