### PR TITLE
Unpin psutil

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ install_requires =
     paramiko >= 2.5.0, < 3
     pathlib2; python_version<"3.2"
     pexpect >= 4.6.0, < 5
-    psutil == 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
+    psutil >= 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
     PyYAML >= 5.1, < 6
     sh >= 1.12.14
     six >= 1.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ install_requires =
     paramiko >= 2.5.0, < 3
     pathlib2; python_version<"3.2"
     pexpect >= 4.6.0, < 5
-    psutil >= 5.4.6; sys_platform!="win32" and sys_platform!="cygwin"
+    psutil >= 5.4.6, < 6; sys_platform!="win32" and sys_platform!="cygwin"
     PyYAML >= 5.1, < 6
     sh >= 1.12.14
     six >= 1.11.0


### PR DESCRIPTION
Pinning psutil makes installation process more problematic and causing
either conflicts or requiring a development python libraries and the gcc
compiler (psutil being a compiled extension).

As a first step we should unpin it and also aim to have it addressed by
https://github.com/click-contrib/click-completion/issues/25

Related to: https://github.com/ansible/molecule/issues/2168