### PR TITLE
Upgrade testinfra

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ History
 Important Changes
 -----------------
 
+* Upgrade ``testinfra``: fix Ansible 2.8 compatibility
 * Project now maintained by the Ansible Team, see `Move to Red Hat`_ for details
 * Docker Container now hosted on `quay.io`_
 

--- a/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.rb
+++ b/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Molecule managed
 
 describe file('/etc/hosts') do

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ PyYAML==3.13
 sh==1.12.14
 six==1.11.0
 tabulate==0.8.2
-testinfra==1.19.0
+testinfra >= 3.0.5, < 4
 tree-format==0.1.2

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,6 +40,9 @@ def run_command(cmd, env=os.environ, log=True):
     if log:
         cmd = _rebake_command(cmd, env)
 
+    # Never let sh truncate exceptions in testing
+    cmd = cmd.bake(_truncate_exc=False)
+
     return util.run_command(cmd)
 
 

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -101,7 +101,8 @@ def test_command_init_role_inspec(temp_dir):
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
-        sh.molecule('test')
+        cmd = sh.molecule.bake('test')
+        pytest.helpers.run_command(cmd)
 
 
 def test_command_init_scenario_inspec(temp_dir):
@@ -138,7 +139,8 @@ def test_command_init_role_goss(temp_dir):
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
-        sh.molecule('test')
+        cmd = sh.molecule.bake('test')
+        pytest.helpers.run_command(cmd)
 
 
 def test_command_init_scenario_goss(temp_dir):
@@ -254,7 +256,8 @@ def test_command_init_role_with_template(temp_dir):
     pytest.helpers.metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
-        sh.molecule('test')
+        cmd = sh.molecule.bake('test')
+        pytest.helpers.run_command(cmd)
 
 
 @pytest.mark.parametrize(

--- a/test/scenarios/driver/docker/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/docker/molecule/default/tests/test_default.py
@@ -30,4 +30,4 @@ def test_etc_molecule_ansible_hostname_file(host):
 
 def test_buildarg_env_var(host):
     cmd_out = host.run("echo $envarg")
-    assert cmd_out.stdout == 'this_is_a_test'
+    assert cmd_out.stdout.strip() == 'this_is_a_test'

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -311,8 +311,7 @@ def test_execute_bakes(patched_run_command, _patched_testinfra_get_tests,
 
 def test_executes_catches_and_exits_return_code(
         patched_run_command, _patched_testinfra_get_tests, _instance):
-    patched_run_command.side_effect = sh.ErrorReturnCode_1(
-        sh.testinfra, b'', b'')
+    patched_run_command.side_effect = sh.ErrorReturnCode_1(sh.pytest, b'', b'')
     with pytest.raises(SystemExit) as e:
         _instance.execute()
 


### PR DESCRIPTION
backport following commits:
- 981048e65ba35465263c5efd2f37f1500b65bdc4
- 3651120ae5514f5d7f144b5b4eb4bec535debdb5
- 6b525f8b692a94dbaa72424c659c5fd08b41c992
- 145640a3635c302832da4b67cc13a24e84f0b437

Then 2.20.2 should be released :)

#### PR Type

- Bugfix Pull Request
