### PR TITLE
 fixes #2150: Vagrant driver regression

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -138,7 +138,7 @@ class Config(object):
 
     @property
     def project_directory(self):
-        return os.getcwd()
+        return os.getenv('MOLECULE_PROJECT_DIRECTORY', os.getcwd())
 
     @property
     def cache_directory(self):

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -145,6 +145,10 @@ class Scenario(object):
 
     @property
     def ephemeral_directory(self):
+        _ephemeral_directory = os.getenv('MOLECULE_EPHEMERAL_DIRECTORY')
+        if _ephemeral_directory:
+            return _ephemeral_directory
+
         project_directory = os.path.basename(self.config.project_directory)
 
         if self.config.is_parallel:


### PR DESCRIPTION
#### PR Type:
Bugfix Pull Request

Fixes #2150 


**Changes:**
Return environment variables if they are already set. This prevents the Ansible-Module `molecule-vagrant` from mistakenly appending another sub-path to the ephemeral directory in it's context.

**Results when retrieving `config.ephemeral_directory` in `molecule-vagrant` Ansible-Module:**
Before (wrong):
`$MOLECULE_EPHEMERAL_DIRECTORY/<CWD>/<SCENARIO_NAME>/`
After (expected):
`$MOLECULE_EPHEMERAL_DIRECTORY`