### PR TITLE
Added missing assert to some statements in tests.

### DIFF
--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -942,7 +942,7 @@ def test_absolute_path_for(_instance):
         ]
     )
 
-    x == _instance._absolute_path_for(env, 'foo')
+    assert x == _instance._absolute_path_for(env, 'foo')
 
 
 def test_absolute_path_for_raises_with_missing_key(_instance):

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -218,7 +218,7 @@ def test_os_walk(temp_dir):
 def test_render_template():
     template = "{{ foo }} = {{ bar }}"
 
-    "foo = bar" == util.render_template(template, foo='foo', bar='bar')
+    assert "foo = bar" == util.render_template(template, foo='foo', bar='bar')
 
 
 def test_write_file(temp_dir):


### PR DESCRIPTION
Ran an inspect code in PyCharm, and found these two statements listed as "no effect". I'm guessing that an `assert` was forgotten?