### PR TITLE
Bumps pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
-  - repo: https://github.com/python/black
+  - repo: https://github.com/python/black.git
     rev: 19.3b0
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v2.2.3
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -15,14 +15,14 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: debug-statements
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+  - repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.7.8
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-black
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$


### PR DESCRIPTION
Avoids bug where pre-commit could fail to clone when local git is
quite old by assuring that urls end with .git

Bumps linters to their current versions.