### PR TITLE
Remove shard 4 and parallel CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,19 +42,15 @@ language: python
   - &env-functional-shard_1
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_1_of_4 -m "not parallelizable"'
+      '-m shard_1_of_3'
   - &env-functional-shard_2
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_2_of_4 -m "not parallelizable"'
+      '-m shard_2_of_3'
   - &env-functional-shard_3
     <<: *env-functional
     PYTEST_ADDOPTS: >-
-      '-m shard_3_of_4 -m "not parallelizable"'
-  - &env-functional-shard_4
-    <<: *env-functional
-    PYTEST_ADDOPTS: >-
-      '-n auto -m shard_4_of_4 -m parallelizable'
+      '-m shard_3_of_3'
 
 jobs:
   fast_finish: true
@@ -76,10 +72,6 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: devel
     - <<: *py-36
       env:
         ANSIBLE_VERSION: devel
@@ -96,10 +88,6 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
-    - <<: *py-36
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: devel
     - <<: *py-27
       env:
         ANSIBLE_VERSION: devel
@@ -115,10 +103,6 @@ jobs:
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_4
         ANSIBLE_VERSION: devel
 
   include:
@@ -198,229 +182,172 @@ jobs:
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/4, Ansible 2.8, Python 3.7
+      name: functional tests shard 1/3, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/4, Ansible 2.8, Python 3.7
+      name: functional tests shard 2/3, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/4, Ansible 2.8, Python 3.7
-
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 4/4, Ansible 2.8, Python 3.7
+      name: functional tests shard 3/3, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/4, Ansible 2.7, Python 3.7
+      name: functional tests shard 1/3, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/4, Ansible 2.7, Python 3.7
+      name: functional tests shard 2/3, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/4, Ansible 2.7, Python 3.7
-
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 4/4, Ansible 2.7, Python 3.7
+      name: functional tests shard 3/3, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/4, Ansible 2.6, Python 3.7
+      name: functional tests shard 1/3, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/4, Ansible 2.6, Python 3.7
+      name: functional tests shard 2/3, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/4, Ansible 2.6, Python 3.7
-
-    - <<: *py-37
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 4/4, Ansible 2.6, Python 3.7
+      name: functional tests shard 3/3, Ansible 2.6, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/4, Ansible 2.8, Python 3.6
+      name: functional tests shard 1/3, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/4, Ansible 2.8, Python 3.6
+      name: functional tests shard 2/3, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/4, Ansible 2.8, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 4/4, Ansible 2.8, Python 3.6
+      name: functional tests shard 3/3, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/4, Ansible 2.7, Python 3.6
+      name: functional tests shard 1/3, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/4, Ansible 2.7, Python 3.6
+      name: functional tests shard 2/3, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/4, Ansible 2.7, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 4/4, Ansible 2.7, Python 3.6
+      name: functional tests shard 3/3, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/4, Ansible 2.6, Python 3.6
+      name: functional tests shard 1/3, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/4, Ansible 2.6, Python 3.6
+      name: functional tests shard 2/3, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/4, Ansible 2.6, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 4/4, Ansible 2.6, Python 3.6
+      name: functional tests shard 3/3, Ansible 2.6, Python 3.6
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 1/4, Ansible 2.8, Python 2.7
+      name: functional tests shard 1/3, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 2/4, Ansible 2.8, Python 2.7
+      name: functional tests shard 2/3, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "28"
-      name: functional tests shard 3/4, Ansible 2.8, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "28"
-      name: functional tests shard 4/4, Ansible 2.8, Python 2.7
+      name: functional tests shard 3/3, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 1/4, Ansible 2.7, Python 2.7
+      name: functional tests shard 1/3, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 2/4, Ansible 2.7, Python 2.7
+      name: functional tests shard 2/3, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "27"
-      name: functional tests shard 3/4, Ansible 2.7, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "27"
-      name: functional tests shard 4/4, Ansible 2.7, Python 2.7
+      name: functional tests shard 3/3, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_1
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 1/4, Ansible 2.6, Python 2.7
+      name: functional tests shard 1/3, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_2
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 2/4, Ansible 2.6, Python 2.7
+      name: functional tests shard 2/3, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: "26"
-      name: functional tests shard 3/4, Ansible 2.6, Python 2.7
-
-    - <<: *py-27
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: "26"
-      name: functional tests shard 4/4, Ansible 2.6, Python 2.7
+      name: functional tests shard 3/3, Ansible 2.6, Python 2.7
 
     # The following set of jobs is running tests against devel branch
     # of ansible/ansible:
@@ -445,11 +372,6 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
-    - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: devel
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
@@ -471,11 +393,6 @@ jobs:
       env:
         <<: *env-functional-shard_3
         ANSIBLE_VERSION: devel
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_4
-        ANSIBLE_VERSION: devel
 
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
@@ -496,11 +413,6 @@ jobs:
       <<: *if-cron-or-manual-run-or-tagged
       env:
         <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
-    - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        <<: *env-functional-shard_4
         ANSIBLE_VERSION: devel
 
     - &deploy-job

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,3 @@ doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 junit_suite_name = molecule_test_suite
 norecursedirs = dist doc build .tox .eggs test/scenarios test/resources
 testpaths = test/
-markers =
-  parallelizable: test can be run in parallel execution mode

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -59,14 +59,13 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
-@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [('cleanup', 'docker', 'default')],
     indirect=['scenario_to_test', 'driver_name', 'scenario_name'],
 )
 def test_command_cleanup(scenario_to_test, with_scenario, scenario_name):
-    options = {'driver_name': 'docker', 'all': True, 'parallel': True}
+    options = {'driver_name': 'docker', 'all': True}
     cmd = sh.molecule.bake('test', **options)
     pytest.helpers.run_command(cmd)
 

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -43,7 +43,6 @@ def driver_name(request):
     return request.param
 
 
-@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [
@@ -62,7 +61,7 @@ def driver_name(request):
     indirect=['scenario_to_test', 'driver_name', 'scenario_name'],
 )
 def test_command_check(scenario_to_test, with_scenario, scenario_name):
-    options = {'scenario_name': scenario_name, 'parallel': True}
+    options = {'scenario_name': scenario_name}
     cmd = sh.molecule.bake('check', **options)
     pytest.helpers.run_command(cmd)
 
@@ -729,7 +728,6 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
-@pytest.mark.parallelizable
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [
@@ -750,7 +748,7 @@ def test_command_syntax(scenario_to_test, with_scenario, scenario_name):
     indirect=['scenario_to_test', 'driver_name', 'scenario_name'],
 )
 def test_command_test(scenario_to_test, with_scenario, scenario_name, driver_name):
-    pytest.helpers.test(driver_name, scenario_name, parallel=True)
+    pytest.helpers.test(driver_name, scenario_name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This has proven to be quite unstable on the CI resources that we have right now. Other things can be prioritised rather than this. Let's keep the CI stable. Closes https://github.com/ansible/molecule/issues/2177. 