### PR TITLE
[DOC] ssh_connection_options updating documentation

### DIFF
--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -54,7 +54,7 @@ class Azure(base.Base):
         driver:
           name: azure
           ssh_connection_options:
-            -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 

--- a/molecule/driver/digitalocean.py
+++ b/molecule/driver/digitalocean.py
@@ -54,7 +54,7 @@ class DigitalOcean(base.Base):
         driver:
           name: digitalocean
           ssh_connection_options:
-            -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -92,7 +92,7 @@ class EC2(base.Base):
         driver:
           name: ec2
           ssh_connection_options:
-            -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 

--- a/molecule/driver/gce.py
+++ b/molecule/driver/gce.py
@@ -58,7 +58,7 @@ class GCE(base.Base):
         driver:
           name: gce
           ssh_connection_options:
-            -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 

--- a/molecule/driver/hetznercloud.py
+++ b/molecule/driver/hetznercloud.py
@@ -61,7 +61,7 @@ class HetznerCloud(base.Base):
         driver:
           name: hetznercloud
           ssh_connection_options:
-            -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 

--- a/molecule/driver/linode.py
+++ b/molecule/driver/linode.py
@@ -62,7 +62,7 @@ class Linode(base.Base):
         driver:
           name: linode
           ssh_connection_options:
-            -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 

--- a/molecule/driver/openstack.py
+++ b/molecule/driver/openstack.py
@@ -54,7 +54,7 @@ class Openstack(base.Base):
         driver:
           name: openstack
           ssh_connection_options:
-            - -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 

--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -103,7 +103,7 @@ class Vagrant(base.Base):
         driver:
           name: vagrant
           ssh_connection_options:
-            -o ControlPath=~/.ansible/cp/%r@%h-%p
+            - '-o ControlPath=~/.ansible/cp/%r@%h-%p'
 
     .. important::
 


### PR DESCRIPTION
- `driver.ssh_connection_options` is expecting a list

#### PR Type

- Docs Pull Request

Using the configuration provided by the documentation molecule fails with:
```
ERROR: Failed to validate.

{'driver': [{'ssh_connection_options': ['must be of list type']}]}
```