### PR TITLE
Remove references to volume_mounts from docs

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -108,7 +108,7 @@ class Docker(base.Base):
 
     When attempting to utilize a container image with `systemd`_ as your init
     system inside the container to simulate a real machine, make sure to set
-    the ``privileged``, ``volume_mounts``, ``command``, and ``environment``
+    the ``privileged``, ``volumes``, ``command``, and ``environment``
     values. An example using the ``centos:7`` image is below:
 
     .. note:: Do note that running containers in privileged mode is considerably
@@ -121,7 +121,7 @@ class Docker(base.Base):
         - name: instance
           image: centos:7
           privileged: true
-          volume_mounts:
+          volumes:
             - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
           command: "/usr/sbin/init"
           tty: True

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -97,7 +97,7 @@ class Podman(base.Base):
 
     When attempting to utilize a container image with `systemd`_ as your init
     system inside the container to simulate a real machine, make sure to set
-    the ``privileged``, ``volume_mounts``, ``command``, and ``environment``
+    the ``privileged``, ``volumes``, ``command``, and ``environment``
     values. An example using the ``centos:7`` image is below:
 
     .. note:: Do note that running containers in privileged mode is considerably


### PR DESCRIPTION
Corrects docs to avoid references to outdated volume_mounts.

#### PR Type
- Docs Pull Request
