### PR TITLE
Fix removed match filter

### DIFF
--- a/test/scenarios/driver/docker/molecule/ansible-verifier/verify.yml
+++ b/test/scenarios/driver/docker/molecule/ansible-verifier/verify.yml
@@ -4,7 +4,7 @@
   tasks:
   - name: Assert that the hostname is set
     assert:
-      that: ansible_hostname | match('instance.*')
+      that: ansible_hostname is match('instance.*')
 
   - name: Stat /etc/molecule directory
     stat:


### PR DESCRIPTION
Ansibe devel removed jinja2 match filter and this use the
newer syntax for calling it.

Fixes broken test on ansible-devel.
