### PR TITLE
Fixed invalid use of env params on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,22 +40,6 @@ language: python
   - &hetzner-cloud-cleanup
     after_script:
       - ./contrib/tokenmgmr.py remove --driver hetznercloud
-  - &env-functional
-    TESTS_TYPE: functional
-  - &env-hetzner-cloud
-    HCLOUD_TOKEN: "$(./contrib/tokenmgmr.py get --driver hetznercloud)"
-  - &env-functional-shard_1
-    <<: *env-functional
-    PYTEST_ADDOPTS: >-
-      '-m shard_1_of_3'
-  - &env-functional-shard_2
-    <<: *env-functional
-    PYTEST_ADDOPTS: >-
-      '-m shard_2_of_3'
-  - &env-functional-shard_3
-    <<: *env-functional
-    PYTEST_ADDOPTS: >-
-      '-m shard_3_of_3'
 
 jobs:
   fast_finish: true
@@ -63,124 +47,113 @@ jobs:
   allow_failures:
     - <<: *py-37
       env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        - TOXENV=ansibledevel-unit
+
     - <<: *py-37
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-37
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-37
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-36
       env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        - TOXENV="ansibledevel-unit"
     - <<: *py-36
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-36
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-36
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-27
       env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        - TOXENV=ansibledevel-unit
     - <<: *py-27
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-27
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-27
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansibledevel-functional
 
   include:
     - <<: *lint
       name: linting the code
       env:
-        TOXENV: lint
+        - TOXENV=lint
 
     - <<: *lint
       name: checking the docs build
       env:
-        TOXENV: doc
+        - TOXENV=doc
 
     - <<: *lint
       name: Additional checks
       env:
-        TOXENV: check
+        - TOXENV=check
 
     - <<: *py-37
       env:
-        ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+        - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
-        ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+        - TOXENV=ansible27-unit
       name: unit tests, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
-        ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+        - TOXENV=ansible26-unit
       name: unit tests, Ansible 2.6, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+        - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+        - TOXENV=ansible27-unit
       name: unit tests, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+        - TOXENV=ansible26-unit
       name: unit tests, Ansible 2.6, Python 3.6
 
     - <<: *py-27
       env:
-        ANSIBLE_VERSION: "28"
-        TESTS_TYPE: unit
+        - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
-        ANSIBLE_VERSION: "27"
-        TESTS_TYPE: unit
+        - TOXENV=ansible27-unit
       name: unit tests, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
-        ANSIBLE_VERSION: "26"
-        TESTS_TYPE: unit
+        - TOXENV=ansible26-unit
       name: unit tests, Ansible 2.6, Python 2.7
 
     # Note(decentral1se): we temporarily only run Hetzner Cloud functional
@@ -189,174 +162,174 @@ jobs:
     # solution
     - <<: *py-37
       env:
-        <<: *env-functional-shard_1
-        <<: *env-hetzner-cloud
-        ANSIBLE_VERSION: "28"
+        - HCLOUD_TOKEN="$(./contrib/tokenmgmr.py get --driver hetznercloud)"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 1/3, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 2/3, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 3/3, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 1/3, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 2/3, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 3/3, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 1/3, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 2/3, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 3/3, Ansible 2.6, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 1/3, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 2/3, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 3/3, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 1/3, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 2/3, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 3/3, Ansible 2.7, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 1/3, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 2/3, Ansible 2.6, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 3/3, Ansible 2.6, Python 3.6
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 1/3, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 2/3, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "28"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible28-functional
       name: functional tests shard 3/3, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 1/3, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 2/3, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "27"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible27-functional
       name: functional tests shard 3/3, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 1/3, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 2/3, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: "26"
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansible26-functional
       name: functional tests shard 3/3, Ansible 2.6, Python 2.7
 
     # The following set of jobs is running tests against devel branch
@@ -365,65 +338,62 @@ jobs:
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        - TOXENV=ansibledevel-unit
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansibledevel-functional
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        - TOXENV=ansibledevel-unit
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_2
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansibledevel-functional
 
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        ANSIBLE_VERSION: devel
-        TESTS_TYPE: unit
+        - TOXENV=ansibledevel-unit
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_1
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - TOXENV=ansibledevel-functional
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        <<: *env-functional-shard_3
-        ANSIBLE_VERSION: devel
+        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - TOXENV=ansibledevel-functional
 
     - &deploy-job
       <<: *py-37
@@ -432,7 +402,7 @@ jobs:
       name: Publishing current Git tagged version of dist to PyPI
       if: repo == "ansible/molecule" AND tag IS present
       env:
-        TOXENV: metadata-validation,build-dists
+        - TOXENV=metadata-validation,build-dists
       before_deploy:
         - echo > setup.py
       deploy: &deploy-step
@@ -461,9 +431,6 @@ jobs:
         <<: *deploy-step
         server: https://test.pypi.org/legacy/
 
-env:
-  global:
-    TOXENV_TMPL: "'ansible${ANSIBLE_VERSION}-${TESTS_TYPE}'"
 addons:
   apt:
     packages:
@@ -472,7 +439,6 @@ addons:
       - lxd
       - lxd-client
 before_install:
-  - export TOXENV=$(echo $TOXENV_TMPL | envsubst)
   - pip install tox-tags
 before_script:
   - gem install inspec -v '~> 3'


### PR DESCRIPTION
Replaced dictionaries with lists on travis config as the former are
considered invalid syntax.

While invalid travis does parse them but not without side-effects, like
seeing this on ENV section of the Travis jobs:

One of the secure variables in your .travis.yml has an invalid format.