### PR TITLE
Assures ansibledevel jobs run all the time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,55 +43,6 @@ language: python
 
 jobs:
   fast_finish: true
-
-  allow_failures:
-    - <<: *py-37
-      env:
-        - TOXENV=ansibledevel-unit
-
-    - <<: *py-37
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-37
-      env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-37
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-36
-      env:
-        - TOXENV="ansibledevel-unit"
-    - <<: *py-36
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-36
-      env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-36
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-27
-      env:
-        - TOXENV=ansibledevel-unit
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansibledevel-functional
-
   include:
     - <<: *lint
       name: linting the code
@@ -336,61 +287,49 @@ jobs:
     # of ansible/ansible:
 
     - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - TOXENV=ansibledevel-unit
     - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_3'
         - TOXENV=ansibledevel-functional
     - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_3'
         - TOXENV=ansibledevel-functional
     - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_3_of_3'
         - TOXENV=ansibledevel-functional
 
     - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - TOXENV=ansibledevel-unit
     - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_3'
         - TOXENV=ansibledevel-functional
     - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_3'
         - TOXENV=ansibledevel-functional
     - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_3_of_3'
         - TOXENV=ansibledevel-functional
 
     - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - TOXENV=ansibledevel-unit
     - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_1_of_3'
         - TOXENV=ansibledevel-functional
     - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_2_of_3'
         - TOXENV=ansibledevel-functional
     - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
       env:
         - PYTEST_ADDOPTS='-m shard_3_of_3'
         - TOXENV=ansibledevel-functional


### PR DESCRIPTION
Decision to skip running ansibledevel bought us some speed boost at
the cost of no longer testing code and introducing costly bugs.

This caused failure to release 2.22rc4 which failed on ansibledevel
jobs, which were not run during normal PRs.

From now on we need to be sure that we test all PRs with the same set of
jobs as we do for releases.