### PR TITLE
Adds retries to image building tasks

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -73,6 +73,10 @@
       loop_control:
         label: "molecule_local/{{ item.item.image }}"
       no_log: false
+      register: result
+      until: result is not failed
+      retries: 3
+      delay: 30
 
     - name: Build an Ansible compatible image (old)
       when:

--- a/molecule/provisioner/ansible/playbooks/podman/create.yml
+++ b/molecule/provisioner/ansible/playbooks/podman/create.yml
@@ -47,6 +47,10 @@
       when:
         - platforms.changed or podman_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
         - not item.item.pre_build_image | default(false)
+      register: result
+      until: result is not failed
+      retries: 3
+      delay: 30
 
     - name: Determine the CMD directives
       set_fact:

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -66,6 +66,10 @@
       loop_control:
         label: "molecule_local/{{ item.item.image }}"
       no_log: false
+      register: result
+      until: result is not failed
+      retries: 3
+      delay: 30
 
     - name: Build an Ansible compatible image (old)
       when:
@@ -88,6 +92,10 @@
       loop_control:
         label: "molecule_local/{{ item.item.image }}"
       no_log: false
+      register: result
+      until: result is not failed
+      retries: 3
+      delay: 30
 
     - name: Create docker network(s)
       docker_network:


### PR DESCRIPTION
As it was observed in CI, docker_image build can fail due to temporary
network flakiness.

We add 3 retries with 30 delay between them, so we can avoid most
random failures.

Example: https://travis-ci.com/ansible/molecule/jobs/222705245#L582

Error building molecule_local/centos - code: None,
message: Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
