### PR TITLE
Revert anyconfig version to last known good

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,8 @@ install_requires =
 
     # TODO(ssbarnea): consider anyconfig removal due to maintenance risks
     # https://github.com/ssato/python-anyconfig/issues/110
-    anyconfig == 0.9.7, !=0.9.8, !=0.9.9
+    # 0.9.8, 0.9.9 are known to be broken
+    anyconfig == 0.9.7
     flake8 >=3.6.0
     cerberus >= 1.3.1
     click >= 6.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,9 @@ install_requires =
     ansible >= 2.5
     ansible-lint >= 4.0.2, < 5
 
-    anyconfig >= 0.9.7
+    # TODO(ssbarnea): consider anyconfig removal due to maintenance risks
+    # https://github.com/ssato/python-anyconfig/issues/110
+    anyconfig == 0.9.7, !=0.9.8, !=0.9.9
     flake8 >=3.6.0
     cerberus >= 1.3.1
     click >= 6.7


### PR DESCRIPTION
Also adds note that we should attempt to remove it from our dependencies
due to risks involving its maintenance (or lack of it).

Fixes: #2207

Related to https://github.com/ssato/python-anyconfig/issues/110