### PR TITLE
Removed obsolete metadata-validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -402,7 +402,7 @@ jobs:
       name: Publishing current Git tagged version of dist to PyPI
       if: repo == "ansible/molecule" AND tag IS present
       env:
-        - TOXENV=metadata-validation,build-dists
+        - TOXENV=build-dists
       before_deploy:
         - echo > setup.py
       deploy: &deploy-step

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -126,19 +126,6 @@ Generate the documentation, using `sphinx`_.
 
 .. _`sphinx`: http://www.sphinx-doc.org
 
-Metadata validation
--------------------
-
-Check if the long description of the generated package will render properly in
-Python eggs and PyPI, using `checkdocs`_ and `twine`_.
-
-.. code-block:: bash
-
-    $ tox -e metadata-validation
-
-.. _`checkdocs`: https://github.com/collective/collective.checkdocs
-
-.. _`twine`: https://twine.readthedocs.io/
 
 Build docker
 ------------


### PR DESCRIPTION
Remove tox environment which no longer exists but was still references
in documentation and travis configuration.

The same validation is now included in previous build steps.

This prevented release of 2.22rc5
