### PR TITLE
Run dependency before lint on test_sequence

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Unreleased
 * Add WinRM connections options to delegated driver instance_dict
 * Update testinfra to 3.0.6 so we can use ansible verbosity
 * Add ``sysctls`` option to the Docker driver.
+* dependency now runs before lint on default test and lint sequences
 
 2.20
 ====

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -93,7 +93,7 @@ class Lint(base.Base):
     ),
 )
 def lint(ctx, scenario_name):  # pragma: no cover
-    """ Lint the role. """
+    """ Lint the role (dependency, lint). """
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {'subcommand': subcommand}

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -126,7 +126,7 @@ class Test(base.Base):
 )
 def test(ctx, scenario_name, driver_name, __all, destroy, parallel):  # pragma: no cover
     """
-    Test (lint, cleanup, destroy, dependency, syntax, create, prepare,
+    Test (dependency, lint, cleanup, destroy, syntax, create, prepare,
           converge, idempotence, side_effect, verify, cleanup, destroy).
     """
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -428,8 +428,9 @@ class Config(object):
                 'create_sequence': ['dependency', 'create', 'prepare'],
                 'destroy_sequence': ['dependency', 'cleanup', 'destroy'],
                 'test_sequence': [
-                    'lint',
+                    # dependency must be kept before lint to avoid errors
                     'dependency',
+                    'lint',
                     'cleanup',
                     'destroy',
                     'syntax',

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -75,8 +75,8 @@ class Scenario(object):
             - cleanup
             - destroy
           test_sequence:
-            - lint
             - dependency
+            - lint
             - cleanup
             - destroy
             - syntax
@@ -197,7 +197,8 @@ class Scenario(object):
 
     @property
     def lint_sequence(self):
-        return ['lint']
+        # see https://github.com/ansible/molecule/issues/2216
+        return ['dependency', 'lint']
 
     @property
     def prepare_sequence(self):

--- a/test/unit/test_scenario.py
+++ b/test/unit/test_scenario.py
@@ -145,7 +145,8 @@ def test_idempotence_sequence_property(_instance):
 
 
 def test_lint_sequence_property(_instance):
-    assert ['lint'] == _instance.lint_sequence
+    assert 'lint' in _instance.lint_sequence
+    assert 'dependency' in _instance.lint_sequence
 
 
 def test_prepare_sequence_property(_instance):
@@ -162,8 +163,8 @@ def test_syntax_sequence_property(_instance):
 
 def test_test_sequence_property(_instance):
     sequence = [
-        'lint',
         'dependency',
+        'lint',
         'cleanup',
         'destroy',
         'syntax',
@@ -185,7 +186,7 @@ def test_verify_sequence_property(_instance):
 
 
 def test_sequence_property(_instance):
-    assert 'lint' == _instance.sequence[0]
+    assert 'lint' in _instance.sequence
 
 
 def test_sequence_property_with_invalid_subcommand(_instance):

--- a/test/unit/test_scenarios.py
+++ b/test/unit/test_scenarios.py
@@ -83,8 +83,8 @@ def test_print_matrix(mocker, patched_logger_info, patched_logger_out, _instance
 
     matrix_out = u"""
 ├── default
-│   ├── lint
 │   ├── dependency
+│   ├── lint
 │   ├── cleanup
 │   ├── destroy
 │   ├── syntax
@@ -97,8 +97,8 @@ def test_print_matrix(mocker, patched_logger_info, patched_logger_out, _instance
 │   ├── cleanup
 │   └── destroy
 └── foo
-    ├── lint
     ├── dependency
+    ├── lint
     ├── cleanup
     ├── destroy
     ├── syntax
@@ -146,7 +146,7 @@ def test_filter_for_scenario(_instance):
 def test_get_matrix(_instance):
     matrix = {
         'default': {
-            'lint': ['lint'],
+            'lint': ['dependency', 'lint'],
             'idempotence': ['idempotence'],
             'syntax': ['syntax'],
             'converge': ['dependency', 'create', 'prepare', 'converge'],
@@ -168,8 +168,8 @@ def test_get_matrix(_instance):
             'side_effect': ['side_effect'],
             'dependency': ['dependency'],
             'test': [
-                'lint',
                 'dependency',
+                'lint',
                 'cleanup',
                 'destroy',
                 'syntax',
@@ -185,7 +185,7 @@ def test_get_matrix(_instance):
             'destroy': ['dependency', 'cleanup', 'destroy'],
         },
         'foo': {
-            'lint': ['lint'],
+            'lint': ['dependency', 'lint'],
             'idempotence': ['idempotence'],
             'syntax': ['syntax'],
             'converge': ['dependency', 'create', 'prepare', 'converge'],
@@ -207,8 +207,8 @@ def test_get_matrix(_instance):
             'side_effect': ['side_effect'],
             'dependency': ['dependency'],
             'test': [
-                'lint',
                 'dependency',
+                'lint',
                 'cleanup',
                 'destroy',
                 'syntax',


### PR DESCRIPTION
Avoids failure to run linting due to missing dependencies, like ansible modules or roles.

Fixes: #1908
