### PR TITLE
Fix floating IP deletion in openstack driver

### DIFF
--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -84,7 +84,6 @@
         key_name: "{{ keypair_name }}"
         nics:
           - net-id: "{{ openstack_networks[0]['id'] }}"
-        delete_fip: true
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -10,6 +10,7 @@
       os_server:
         name: "{{ item.name }}"
         state: absent
+        delete_fip: true
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/resources/playbooks/delegated/create/openstack.yml
+++ b/test/resources/playbooks/delegated/create/openstack.yml
@@ -36,7 +36,6 @@
     key_name: "{{ openstack.key_name }}"
     nics:
       - net-id: "{{ openstack_networks[0]['id'] }}"
-    delete_fip: true
   register: server
 
 - name: Persist ssh config

--- a/test/resources/playbooks/delegated/destroy/openstack.yml
+++ b/test/resources/playbooks/delegated/destroy/openstack.yml
@@ -3,6 +3,7 @@
   os_server:
     name: delegated-instance-openstack
     state: absent
+    delete_fip: true
 
 - name: Cleanup temporary files file
   file:

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -83,7 +83,6 @@
         key_name: "{{ keypair_name }}"
         nics:
           - net-id: "{{ openstack_networks[0]['id'] }}"
-        delete_fip: true
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/resources/playbooks/openstack/destroy.yml
+++ b/test/resources/playbooks/openstack/destroy.yml
@@ -9,6 +9,7 @@
       os_server:
         name: "{{ item.name }}"
         state: absent
+        delete_fip: true
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200


### PR DESCRIPTION
`delete_fip: true` needs to be set in the _destroy_ playbooks rather than in the _create_ ones.

Currently the allocated floating IPs won't be released after instance deletion. Under $circumstances this could lead to quota, resource or billing issues inside an OpenStack project.

#### PR Type

- Bugfix Pull Request
