### PR TITLE
Makes molecule drivers plugins

### DIFF
--- a/molecule/api.py
+++ b/molecule/api.py
@@ -1,0 +1,13 @@
+import pkg_resources
+
+
+def molecule_drivers(as_dict=False):
+
+    plugins = {
+        entry_point.name: entry_point.load()
+        for entry_point in pkg_resources.iter_entry_points('molecule_driver')
+    }
+    if as_dict:
+        return plugins
+    else:
+        return list(plugins.keys())

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -20,8 +20,8 @@
 
 import click
 
-from molecule import config
 from molecule import logger
+from molecule.api import molecule_drivers
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -105,7 +105,7 @@ class Create(base.Base):
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(config.molecule_drivers()),
+    type=click.Choice(molecule_drivers()),
     help='Name of driver to use. (docker)',
 )
 def create(ctx, scenario_name, driver_name):  # pragma: no cover

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -21,8 +21,8 @@
 import os
 import click
 
-from molecule import config
 from molecule import logger
+from molecule.api import molecule_drivers
 from molecule.command import base
 from molecule import util
 
@@ -118,7 +118,7 @@ class Destroy(base.Base):
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(config.molecule_drivers()),
+    type=click.Choice(molecule_drivers()),
     help='Name of driver to use. (docker)',
 )
 @click.option(

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -25,6 +25,7 @@ import click
 from molecule import config
 from molecule import logger
 from molecule import util
+from molecule.api import molecule_drivers
 from molecule.command import base as command_base
 from molecule.command.init import base
 
@@ -105,7 +106,7 @@ class Role(base.Base):
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(config.molecule_drivers()),
+    type=click.Choice(molecule_drivers()),
     default='docker',
     help='Name of driver to initialize. (docker)',
 )

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -25,6 +25,7 @@ import click
 from molecule import config
 from molecule import logger
 from molecule import util
+from molecule.api import molecule_drivers
 from molecule.command import base as command_base
 from molecule.command.init import base
 
@@ -152,7 +153,7 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(config.molecule_drivers()),
+    type=click.Choice(molecule_drivers()),
     default='docker',
     help='Name of driver to initialize. (docker)',
 )

--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -20,8 +20,8 @@
 
 import click
 
-from molecule import config
 from molecule import logger
+from molecule.api import molecule_drivers
 from molecule.command import base
 
 LOG = logger.get_logger(__name__)
@@ -115,7 +115,7 @@ class Prepare(base.Base):
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(config.molecule_drivers()),
+    type=click.Choice(molecule_drivers()),
     help='Name of driver to use. (docker)',
 )
 @click.option(

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -21,8 +21,8 @@
 import os
 import click
 
-from molecule import config
 from molecule import logger
+from molecule.api import molecule_drivers
 from molecule.command import base
 from molecule import util
 
@@ -104,7 +104,7 @@ class Test(base.Base):
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(config.molecule_drivers()),
+    type=click.Choice(molecule_drivers()),
     help='Name of driver to use. (docker)',
 )
 @click.option(

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -31,22 +31,10 @@ from molecule import platforms
 from molecule import scenario
 from molecule import state
 from molecule import util
+from molecule.api import molecule_drivers
 from molecule.dependency import ansible_galaxy
 from molecule.dependency import gilt
 from molecule.dependency import shell
-from molecule.driver import azure
-from molecule.driver import delegated
-from molecule.driver import digitalocean
-from molecule.driver import docker
-from molecule.driver import ec2
-from molecule.driver import gce
-from molecule.driver import linode
-from molecule.driver import lxc
-from molecule.driver import lxd
-from molecule.driver import hetznercloud
-from molecule.driver import openstack
-from molecule.driver import podman
-from molecule.driver import vagrant
 from molecule.lint import yamllint
 from molecule.model import schema_v2
 from molecule.provisioner import ansible
@@ -166,33 +154,7 @@ class Config(object):
         driver_name = self._get_driver_name()
         driver = None
 
-        if driver_name == 'azure':
-            driver = azure.Azure(self)
-        elif driver_name == 'delegated':
-            driver = delegated.Delegated(self)
-        elif driver_name == 'digitalocean':
-            driver = digitalocean.DigitalOcean(self)
-        elif driver_name == 'docker':
-            driver = docker.Docker(self)
-        elif driver_name == 'ec2':
-            driver = ec2.EC2(self)
-        elif driver_name == 'gce':
-            driver = gce.GCE(self)
-        elif driver_name == 'hetznercloud':
-            driver = hetznercloud.HetznerCloud(self)
-        elif driver_name == 'linode':
-            driver = linode.Linode(self)
-        elif driver_name == 'lxc':
-            driver = lxc.LXC(self)
-        elif driver_name == 'lxd':
-            driver = lxd.LXD(self)
-        elif driver_name == 'openstack':
-            driver = openstack.Openstack(self)
-        elif driver_name == 'podman':
-            driver = podman.Podman(self)
-        elif driver_name == 'vagrant':
-            driver = vagrant.Vagrant(self)
-
+        driver = molecule_drivers(as_dict=True)[driver_name].load(self)
         driver.name = driver_name
 
         return driver
@@ -482,24 +444,6 @@ def molecule_directory(path):
 
 def molecule_file(path):
     return os.path.join(path, MOLECULE_FILE)
-
-
-def molecule_drivers():
-    return [
-        azure.Azure(None).name,
-        delegated.Delegated(None).name,
-        digitalocean.DigitalOcean(None).name,
-        docker.Docker(None).name,
-        ec2.EC2(None).name,
-        gce.GCE(None).name,
-        hetznercloud.HetznerCloud(None).name,
-        linode.Linode(None).name,
-        lxc.LXC(None).name,
-        lxd.LXD(None).name,
-        openstack.Openstack(None).name,
-        podman.Podman(None).name,
-        vagrant.Vagrant(None).name,
-    ]
 
 
 def molecule_verifiers():

--- a/molecule/driver/azure.py
+++ b/molecule/driver/azure.py
@@ -140,3 +140,7 @@ class Azure(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return Azure(self)

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -233,3 +233,7 @@ class Delegated(base.Base):
     def sanity_checks(self):
         # Note(decentral1se): Cannot implement driver specifics are unknown
         pass
+
+
+def load(self):
+    return Delegated(self)

--- a/molecule/driver/digitalocean.py
+++ b/molecule/driver/digitalocean.py
@@ -139,3 +139,7 @@ class DigitalOcean(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return DigitalOcean(self)

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -235,3 +235,7 @@ class Docker(base.Base):
             sysexit_with_message(msg)
 
         self._config.state.change_state('sanity_checked', True)
+
+
+def load(self):
+    return Docker(self)

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -178,3 +178,7 @@ class EC2(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return EC2(self)

--- a/molecule/driver/gce.py
+++ b/molecule/driver/gce.py
@@ -144,3 +144,7 @@ class GCE(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return GCE(self)

--- a/molecule/driver/hetznercloud.py
+++ b/molecule/driver/hetznercloud.py
@@ -175,3 +175,7 @@ class HetznerCloud(base.Base):
             sysexit_with_message(msg)
 
         self._config.state.change_state('sanity_checked', True)
+
+
+def load(self):
+    return HetznerCloud(self)

--- a/molecule/driver/linode.py
+++ b/molecule/driver/linode.py
@@ -160,3 +160,7 @@ class Linode(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return Linode(self)

--- a/molecule/driver/lxc.py
+++ b/molecule/driver/lxc.py
@@ -89,3 +89,7 @@ class LXC(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return LXC(self)

--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -110,3 +110,7 @@ class LXD(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return LXD(self)

--- a/molecule/driver/openstack.py
+++ b/molecule/driver/openstack.py
@@ -140,3 +140,7 @@ class Openstack(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return Openstack(self)

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -187,3 +187,7 @@ class Podman(base.Base):
 
         log.info("Sanity checks: '{}'".format(self._name))
         self._config.state.change_state('sanity_checked', True)
+
+
+def load(self):
+    return Podman(self)

--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -211,3 +211,7 @@ class Vagrant(base.Base):
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks
         pass
+
+
+def load(self):
+    return Vagrant(self)

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -27,6 +27,7 @@ import cerberus
 import cerberus.errors
 
 from molecule import interpolation, util
+from molecule.api import molecule_drivers
 
 
 def coerce_env(env, keep_string, v):
@@ -53,21 +54,7 @@ def pre_validate_base_schema(env, keep_string):
                 'name': {
                     'type': 'string',
                     'molecule_env_var': True,
-                    'allowed': [
-                        'azure',
-                        'delegated',
-                        'digitalocean',
-                        'docker',
-                        'ec2',
-                        'gce',
-                        'hetznercloud',
-                        'linode',
-                        'lxc',
-                        'lxd',
-                        'openstack',
-                        'podman',
-                        'vagrant',
-                    ],
+                    'allowed': molecule_drivers(),
                     # NOTE(retr0h): Some users use an environment variable to
                     # change the driver name.  May add this coercion to rest of
                     # config using allowed validation.

--- a/setup.cfg
+++ b/setup.cfg
@@ -142,6 +142,20 @@ test =
 [options.entry_points]
 console_scripts =
     molecule = molecule.__main__:main
+molecule_driver =
+    azure = molecule.driver.azure
+    docker = molecule.driver.docker
+    delegated = molecule.driver.delegated
+    digitalocean = molecule.driver.digitalocean
+    ec2 = molecule.driver.ec2
+    gce = molecule.driver.gce
+    hetznercloud = molecule.driver.hetznercloud
+    linode = molecule.driver.linode
+    lxc = molecule.driver.lxc
+    lxd = molecule.driver.lxd
+    openstack = molecule.driver.openstack
+    podman = molecule.driver.podman
+    vagrant = molecule.driver.vagrant
 
 [options.packages.find]
 where = .

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -27,19 +27,10 @@ from molecule import platforms
 from molecule import scenario
 from molecule import state
 from molecule import util
+from molecule.api import molecule_drivers
 from molecule.dependency import ansible_galaxy
 from molecule.dependency import gilt
 from molecule.dependency import shell
-from molecule.driver import azure
-from molecule.driver import delegated
-from molecule.driver import digitalocean
-from molecule.driver import docker
-from molecule.driver import ec2
-from molecule.driver import gce
-from molecule.driver import lxc
-from molecule.driver import lxd
-from molecule.driver import openstack
-from molecule.driver import vagrant
 from molecule.lint import yamllint
 from molecule.provisioner import ansible
 from molecule.verifier import goss
@@ -129,20 +120,9 @@ def test_dependency_property_is_shell(config_instance):
     assert isinstance(config_instance.dependency, shell.Shell)
 
 
-def test_driver_property(config_instance):
-    assert isinstance(config_instance.driver, docker.Docker)
-
-
 @pytest.fixture
 def _config_driver_azure_section_data():
     return {'driver': {'name': 'azure'}}
-
-
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_azure_section_data'], indirect=True
-)
-def test_driver_property_is_azure(config_instance):
-    assert isinstance(config_instance.driver, azure.Azure)
 
 
 @pytest.fixture
@@ -150,23 +130,9 @@ def _config_driver_delegated_section_data():
     return {'driver': {'name': 'delegated', 'options': {'managed': False}}}
 
 
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_delegated_section_data'], indirect=True
-)
-def test_driver_property_is_delegated(config_instance):
-    assert isinstance(config_instance.driver, delegated.Delegated)
-
-
 @pytest.fixture
 def _config_driver_digitalocean_section_data():
     return {'driver': {'name': 'digitalocean'}}
-
-
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_digitalocean_section_data'], indirect=True
-)
-def test_driver_property_is_digitalocean(config_instance):
-    assert isinstance(config_instance.driver, digitalocean.DigitalOcean)
 
 
 @pytest.fixture
@@ -174,23 +140,9 @@ def _config_driver_ec2_section_data():
     return {'driver': {'name': 'ec2'}}
 
 
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_ec2_section_data'], indirect=True
-)
-def test_driver_property_is_ec2(config_instance):
-    assert isinstance(config_instance.driver, ec2.EC2)
-
-
 @pytest.fixture
 def _config_driver_gce_section_data():
     return {'driver': {'name': 'gce'}}
-
-
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_gce_section_data'], indirect=True
-)
-def test_driver_property_is_gce(config_instance):
-    assert isinstance(config_instance.driver, gce.GCE)
 
 
 @pytest.fixture
@@ -198,23 +150,9 @@ def _config_driver_lxc_section_data():
     return {'driver': {'name': 'lxc'}}
 
 
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_lxc_section_data'], indirect=True
-)
-def test_driver_property_is_lxc(config_instance):
-    assert isinstance(config_instance.driver, lxc.LXC)
-
-
 @pytest.fixture
 def _config_driver_lxd_section_data():
     return {'driver': {'name': 'lxd'}}
-
-
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_lxd_section_data'], indirect=True
-)
-def test_driver_property_is_lxd(config_instance):
-    assert isinstance(config_instance.driver, lxd.LXD)
 
 
 @pytest.fixture
@@ -222,23 +160,9 @@ def _config_driver_openstack_section_data():
     return {'driver': {'name': 'openstack'}}
 
 
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_openstack_section_data'], indirect=True
-)
-def test_driver_property_is_openstack(config_instance):
-    assert isinstance(config_instance.driver, openstack.Openstack)
-
-
 @pytest.fixture
 def _config_driver_vagrant_section_data():
     return {'driver': {'name': 'vagrant', 'provider': {'name': 'virtualbox'}}}
-
-
-@pytest.mark.parametrize(
-    'config_instance', ['_config_driver_vagrant_section_data'], indirect=True
-)
-def test_driver_property_is_vagrant(config_instance):
-    assert isinstance(config_instance.driver, vagrant.Vagrant)
 
 
 def test_drivers_property(config_instance):
@@ -258,7 +182,7 @@ def test_drivers_property(config_instance):
         'vagrant',
     ]
 
-    assert x == config_instance.drivers
+    assert x == sorted(config_instance.drivers)
 
 
 def test_env(config_instance):
@@ -516,7 +440,7 @@ def test_molecule_drivers():
         'vagrant',
     ]
 
-    assert x == config.molecule_drivers()
+    assert x == sorted(molecule_drivers())
 
 
 def test_molecule_verifiers():


### PR DESCRIPTION
Transforms molecule drivers into plugins, which will allow others
to write their own plugins and publish them separately.

Later we will move some plugins out of the code, into their own
repositories, where they can be tested correctly.

Part of #2228
