### PR TITLE
Bash style variable expension in env var supports defaults using variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Unreleased
 * Update testinfra to 3.0.6 so we can use ansible verbosity
 * Add ``sysctls`` option to the Docker driver.
 * dependency now runs before lint on default test and lint sequences
+* Bash style variable expension for environment variable defaults added.
+  ``foo: ${UNDEFINED_VAR:-$DEFAULT}`` and ``foo: ${UNDEFINED_VAR-$DEFAULT}``
+  are now supported.
 
 2.20
 ====

--- a/molecule/interpolation.py
+++ b/molecule/interpolation.py
@@ -45,7 +45,10 @@ class Interpolator(object):
 
     Both ``$VARIABLE`` and ``${VARIABLE}`` syntax are supported. Extended
     shell-style features, such as ``${VARIABLE-default}`` and
-    ``${VARIABLE:-default}`` are also supported.
+    ``${VARIABLE:-default}`` are also supported. Even the default as another
+    environment variable is supported like ``${VARIABLE-$DEFAULT}`` or
+    ``${VARIABLE:-$DEFAULT}``. An empty string is returned when
+    both variables are undefined.
 
     If a literal dollar sign is needed in a configuration, use a double dollar
     sign (`$$`).
@@ -88,9 +91,15 @@ class TemplateWithDefaults(string.Template):
                     return '$%s' % named
                 if ':-' in named:
                     var, _, default = named.partition(':-')
+                    # If default is also a variable
+                    if default.startswith('$'):
+                        default = mapping.get(default[1:], '')
                     return mapping.get(var) or default
                 if '-' in named:
                     var, _, default = named.partition('-')
+                    # If default is also a variable
+                    if default.startswith('$'):
+                        default = mapping.get(default[1:], '')
                     return mapping.get(var, default)
                 val = mapping.get(named, '')
                 return '%s' % (val,)

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -335,6 +335,41 @@ def test_interpolate(patched_logger_critical, config_instance):
     assert x == config_instance._interpolate(string, os.environ, None)
 
 
+def test_interpolate_curly(patched_logger_critical, config_instance):
+    string = 'foo: ${HOME}'
+    x = 'foo: {}'.format(os.environ['HOME'])
+
+    assert x == config_instance._interpolate(string, os.environ, None)
+
+
+def test_interpolate_default(patched_logger_critical, config_instance):
+    string = 'foo: ${NONE-default}'
+    x = 'foo: default'
+
+    assert x == config_instance._interpolate(string, os.environ, None)
+
+
+def test_interpolate_default_colon(patched_logger_critical, config_instance):
+    string = 'foo: ${NONE:-default}'
+    x = 'foo: default'
+
+    assert x == config_instance._interpolate(string, os.environ, None)
+
+
+def test_interpolate_default_variable(patched_logger_critical, config_instance):
+    string = 'foo: ${NONE:-$HOME}'
+    x = 'foo: {}'.format(os.environ['HOME'])
+
+    assert x == config_instance._interpolate(string, os.environ, None)
+
+
+def test_interpolate_curly_default_variable(patched_logger_critical, config_instance):
+    string = 'foo: ${NONE-$HOME}'
+    x = 'foo: {}'.format(os.environ['HOME'])
+
+    assert x == config_instance._interpolate(string, os.environ, None)
+
+
 def test_interpolate_raises_on_failed_interpolation(
     patched_logger_critical, config_instance
 ):


### PR DESCRIPTION
Closes: #2250

#### PR Type

- Feature Pull Request

Expand the interpolation so expands default defined variables. Based on the implementation in bash:

```shell
# export TEST=test
# echo ${NONE:-$TEST}
test
# echo ${NONE:-$NONE}


```

When the default variable is not found it returns an empty string.

I use this to postfix the platform names so no conflicts happen, in the CI it uses a predefined Gitlab variable, for local testing it takes the user running molecule.

```yaml
platforms:
  - name: Docker-CE-${CI_COMMIT_REF_SLUG:-$VMWARE_USER}
```

#### Changes:
* Expanded the existing test so it tests both the curly and non curly braced syntax
* Added a testcase for the existing default string interpolation
* Implemented default variable interpolation and added a testcase