### PR TITLE
Force flake to use py3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-black
+        language_version: python3
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.16.0
     hooks:


### PR DESCRIPTION
`tox -e lint` uses flake8 which defaults to python2, causing an error as the undelying tool (black) is not compatible with py2

#### PR Type

- Bugfix Pull Request

