### PR TITLE
Allow configurable Azure Region

### DIFF
--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -7,7 +7,7 @@
   no_log: "{{ molecule_no_log }}"
   vars:
     resource_group_name: molecule
-    location: westus
+    location: "{{ lookup('env', 'AZURE_REGION') or 'westus' }}"
     ssh_user: molecule
     ssh_port: 22
     virtual_network_name: molecule_vnet


### PR DESCRIPTION
Signed-off-by: Bogdan Gavril <bogavril@microsoft.com>

Azure Region used to hardcoded to West US. While this is a good default, it should be configurable to any of the 50+ Azure Regions 
https://azure.microsoft.com/en-us/global-infrastructure/regions/ 

#### PR Type

- Bugfix Pull Request

