### PR TITLE
Makes ansible default verifier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,13 @@
 History
 *******
 
-Unreleased
-==========
+3.0 (Unreleased)
+================
+
+* Default verifier is now Ansible, testinfra is now optional and installable as an extra
+
+2.23
+====
 
 * ``molecule dependency`` now has a retry and timed back-off by default for flaky network connections.
 * Add the `--parallel` flag to experimentally allow molecule to be run in parallel.

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV PACKAGES="\
     "
 RUN apk add --update --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ ${PACKAGES}
 
-ENV MOLECULE_EXTRAS="azure,docker,docs,ec2,gce,hetznercloud,linode,lxc,openstack,vagrant,windows"
+ENV MOLECULE_EXTRAS="azure,docker,docs,ec2,gce,hetznercloud,linode,lxc,openstack,vagrant,windows,testinfra"
 
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=917006
 RUN pip3 install -U wheel

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -126,8 +126,8 @@ class Role(base.Base):
 @click.option(
     '--verifier-name',
     type=click.Choice(config.molecule_verifiers()),
-    default='testinfra',
-    help='Name of verifier to initialize. (testinfra)',
+    default='ansible',
+    help='Name of verifier to initialize. (ansible)',
 )
 @click.option(
     '--template',

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -189,8 +189,8 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
 @click.option(
     '--verifier-name',
     type=click.Choice(config.molecule_verifiers()),
-    default='testinfra',
-    help='Name of verifier to initialize. (testinfra)',
+    default='ansible',
+    help='Name of verifier to initialize. (ansible)',
 )
 @click.option(
     '--driver-template',

--- a/molecule/migrate.py
+++ b/molecule/migrate.py
@@ -154,7 +154,7 @@ class Migrate(object):
     def _set_verifier(self):
         verifier = self._v1['verifier']
 
-        self._v2['verifier']['name'] = 'testinfra'
+        self._v2['verifier']['name'] = 'ansible'
         self._v2['verifier']['options'] = collections.OrderedDict({})
         self._v2['verifier']['lint'] = collections.OrderedDict({})
         self._v2['verifier']['lint']['name'] = 'flake8'

--- a/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
@@ -26,6 +26,6 @@ provisioner:
 scenario:
   name: default
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
@@ -30,6 +30,6 @@ provisioner:
 scenario:
   name: ansible-galaxy
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -31,6 +31,6 @@ provisioner:
 scenario:
   name: shell
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/scenarios/driver/delegated/molecule/docker/molecule.yml
+++ b/molecule/test/scenarios/driver/delegated/molecule/docker/molecule.yml
@@ -23,6 +23,6 @@ provisioner:
 scenario:
   name: docker
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/scenarios/idempotence/molecule/raises/molecule.yml
+++ b/molecule/test/scenarios/idempotence/molecule/raises/molecule.yml
@@ -24,6 +24,6 @@ provisioner:
 # scenario:
 #   name: raises
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
@@ -23,6 +23,6 @@ provisioner:
 scenario:
   name: default
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
@@ -26,6 +26,6 @@ provisioner:
 scenario:
   name: default
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
@@ -23,6 +23,6 @@ provisioner:
 scenario:
   name: default
 verifier:
-  name: testinfra
+  name: ansible
   lint:
     name: flake8

--- a/molecule/test/unit/command/init/test_role.py
+++ b/molecule/test/unit/command/init/test_role.py
@@ -35,7 +35,7 @@ def _command_args():
         'role_name': 'test-role',
         'scenario_name': 'default',
         'subcommand': __name__,
-        'verifier_name': 'testinfra',
+        'verifier_name': 'ansible',
     }
 
 

--- a/molecule/test/unit/command/init/test_scenario.py
+++ b/molecule/test/unit/command/init/test_scenario.py
@@ -32,7 +32,7 @@ def _command_args():
         'role_name': 'test-role',
         'scenario_name': 'test-scenario',
         'subcommand': __name__,
-        'verifier_name': 'testinfra',
+        'verifier_name': 'ansible',
     }
 
 

--- a/molecule/test/unit/cookiecutter/test_molecule.py
+++ b/molecule/test/unit/cookiecutter/test_molecule.py
@@ -51,7 +51,7 @@ def _command_args():
         "provisioner_name": "ansible",
         "scenario_name": "default",
         "role_name": "test-role",
-        "verifier_name": "testinfra",
+        "verifier_name": "ansible",
     }
 
 

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -203,7 +203,7 @@ def test_env(config_instance):
         'MOLECULE_PROVISIONER_LINT_NAME': 'ansible-lint',
         'MOLECULE_SCENARIO_NAME': 'default',
         'MOLECULE_STATE_FILE': config_instance.state.state_file,
-        'MOLECULE_VERIFIER_NAME': 'testinfra',
+        'MOLECULE_VERIFIER_NAME': 'ansible',
         'MOLECULE_VERIFIER_LINT_NAME': 'flake8',
         'MOLECULE_VERIFIER_TEST_DIRECTORY': config_instance.verifier.directory,
     }

--- a/molecule/test/unit/test_interpolation.py
+++ b/molecule/test/unit/test_interpolation.py
@@ -23,7 +23,7 @@ def _mock_env():
         'FOO': 'foo',
         'BAR': '',
         'DEPENDENCY_NAME': 'galaxy',
-        'VERIFIER_NAME': 'testinfra',
+        'VERIFIER_NAME': 'ansible',
         'MOLECULE_SCENARIO_NAME': 'default',
     }
 

--- a/molecule/verifier/ansible.py
+++ b/molecule/verifier/ansible.py
@@ -29,7 +29,7 @@ log = logger.get_logger(__name__)
 
 class Ansible(base.Base):
     """
-    `Ansible`_ is not the default test runner.
+    `Ansible`_ is the default test verifier.
 
     Molecule executes a playbook (`verify.yml`) located in the role's
     `scenario.directory`.

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -32,7 +32,7 @@ LOG = logger.get_logger(__name__)
 
 class Testinfra(base.Base):
     """
-    `Testinfra`_ is the default test runner.
+    `Testinfra`_ is no longer the default test verifier since version 2.23.
 
     Additional options can be passed to ``testinfra`` through the options
     dict.  Any option set in this section will override the defaults.

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,6 @@ install_requires =
     sh >= 1.12.14
     six >= 1.11.0
     tabulate >= 0.8.3
-    testinfra >= 3.0.6, < 4
     tree-format >= 0.1.2
     yamllint >= 1.15.0, < 2
 
@@ -138,6 +137,8 @@ test =
     pytest-verbose-parametrize>=1.7.0, < 2
     pytest-xdist>=1.29.0, < 2
     shade>=1.31.0, < 2
+testinfra =
+    testinfra >= 3.0.6, < 4
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Replace testinfra with ansible as the default verifier. This should
only have an impact for people creating new roles and scenarios.

This does not mean we deprecate testinfra but this change is needed
in order to migrate to a plugin architecture.

Fixes: #2013
Relates: #2228

#### PR Type

- Feature Pull Request
