### PR TITLE
Makes driver loading more resilient

### DIFF
--- a/molecule/api.py
+++ b/molecule/api.py
@@ -1,4 +1,8 @@
 import pkg_resources
+from molecule import logger
+
+
+LOG = logger.get_logger(__name__)
 
 try:
     from functools import lru_cache
@@ -9,10 +13,13 @@ except ImportError:
 @lru_cache()
 def molecule_drivers(as_dict=False):
 
-    plugins = {
-        entry_point.name: entry_point.load()
-        for entry_point in pkg_resources.iter_entry_points('molecule_driver')
-    }
+    plugins = {}
+    for entry_point in pkg_resources.iter_entry_points('molecule_driver'):
+        try:
+            plugins[entry_point.name] = entry_point.load()
+        except Exception as e:
+            LOG.error("Failed to load %s driver: %s", entry_point.name, str(e))
+
     if as_dict:
         return plugins
     else:

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -458,7 +458,7 @@ def test_molecule_file():
     assert '/foo/bar/molecule.yml' == config.molecule_file('/foo/bar')
 
 
-def test_molecule_drivers():
+def test_molecule_drivers(caplog):
     x = [
         'azure',
         'delegated',
@@ -476,6 +476,7 @@ def test_molecule_drivers():
     ]
 
     assert x == sorted(molecule_drivers())
+    assert not caplog.records
 
 
 def test_molecule_verifiers():


### PR DESCRIPTION
Prevents molecule execution failure when a driver fails to load. New code will display the loading failure but continue to load the other drivers.