### PR TITLE
Cache loaded drivers

### DIFF
--- a/molecule/api.py
+++ b/molecule/api.py
@@ -1,6 +1,8 @@
 import pkg_resources
+from molecule.util import memoize
 
 
+@memoize
 def molecule_drivers(as_dict=False):
 
     plugins = {


### PR DESCRIPTION
Caching loaded drivers has serious performance benefits, to have an idea
running unit tests went from ~4min to 1.5mins.