### PR TITLE
travis: switch to 2 shards instead of 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,45 +51,33 @@ jobs:
 
     - <<: *py-37
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-37
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-37
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-36
       env:
         - TOXENV="ansibledevel-unit"
     - <<: *py-36
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-36
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-36
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-27
       env:
         - TOXENV=ansibledevel-unit
     - <<: *py-27
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-27
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansibledevel-functional
 
   include:
@@ -163,174 +151,117 @@ jobs:
     - <<: *py-37
       env:
         - HCLOUD_TOKEN="$(./contrib/tokenmgmr.py get --driver hetznercloud)"
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansible28-functional
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 1, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansible28-functional
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.7
+      name: functional tests shard 2, Ansible 2.8, Python 3.7
 
     - <<: *py-37
       env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible28-functional
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.7
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - TOXENV=ansible27-functional
+      name: functional tests shard 1, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansible27-functional
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.7
+      name: functional tests shard 2, Ansible 2.7, Python 3.7
 
     - <<: *py-37
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansible27-functional
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.7
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - TOXENV=ansible26-functional
+      name: functional tests shard 1, Ansible 2.6, Python 3.7
 
     - <<: *py-37
       env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible27-functional
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.7
-
-    - <<: *py-37
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansible26-functional
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.7
-
-    - <<: *py-37
-      env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansible26-functional
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.7
-
-    - <<: *py-37
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible26-functional
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.7
+      name: functional tests shard 2, Ansible 2.6, Python 3.7
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansible28-functional
-      name: functional tests shard 1/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 1, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansible28-functional
-      name: functional tests shard 2/3, Ansible 2.8, Python 3.6
+      name: functional tests shard 2, Ansible 2.8, Python 3.6
 
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - TOXENV=ansible27-functional
+      name: functional tests shard 1, Ansible 2.7, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - TOXENV=ansible27-functional
+      name: functional tests shard 2, Ansible 2.7, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
+        - TOXENV=ansible26-functional
+      name: functional tests shard 1, Ansible 2.6, Python 3.6
+
+    - <<: *py-36
+      <<: *if-cron-or-manual-run-or-tagged
+      env:
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
+        - TOXENV=ansible26-functional
+      name: functional tests shard 2, Ansible 2.6, Python 3.6
+
+    - <<: *py-27
+      env:
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansible28-functional
-      name: functional tests shard 3/3, Ansible 2.8, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
-        - TOXENV=ansible27-functional
-      name: functional tests shard 1/3, Ansible 2.7, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansible27-functional
-      name: functional tests shard 2/3, Ansible 2.7, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible27-functional
-      name: functional tests shard 3/3, Ansible 2.7, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
-        - TOXENV=ansible26-functional
-      name: functional tests shard 1/3, Ansible 2.6, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansible26-functional
-      name: functional tests shard 2/3, Ansible 2.6, Python 3.6
-
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible26-functional
-      name: functional tests shard 3/3, Ansible 2.6, Python 3.6
+      name: functional tests shard 1, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansible28-functional
-      name: functional tests shard 1/3, Ansible 2.8, Python 2.7
+      name: functional tests shard 2, Ansible 2.8, Python 2.7
 
     - <<: *py-27
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansible28-functional
-      name: functional tests shard 2/3, Ansible 2.8, Python 2.7
-
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible28-functional
-      name: functional tests shard 3/3, Ansible 2.8, Python 2.7
-
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansible27-functional
-      name: functional tests shard 1/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 1, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansible27-functional
-      name: functional tests shard 2/3, Ansible 2.7, Python 2.7
+      name: functional tests shard 2, Ansible 2.7, Python 2.7
 
     - <<: *py-27
       env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible27-functional
-      name: functional tests shard 3/3, Ansible 2.7, Python 2.7
-
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansible26-functional
-      name: functional tests shard 1/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 1, Ansible 2.6, Python 2.7
 
     - <<: *py-27
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansible26-functional
-      name: functional tests shard 2/3, Ansible 2.6, Python 2.7
-
-    - <<: *py-27
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
-        - TOXENV=ansible26-functional
-      name: functional tests shard 3/3, Ansible 2.6, Python 2.7
+      name: functional tests shard 2, Ansible 2.6, Python 2.7
 
     # The following set of jobs is running tests against devel branch
     # of ansible/ansible:
@@ -342,17 +273,12 @@ jobs:
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-37
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-37
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansibledevel-functional
 
     - <<: *py-36
@@ -362,17 +288,12 @@ jobs:
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-36
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-36
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansibledevel-functional
 
     - <<: *py-27
@@ -382,17 +303,12 @@ jobs:
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_1_of_3'
+        - PYTEST_ADDOPTS='-m shard_1_of_2'
         - TOXENV=ansibledevel-functional
     - <<: *py-27
       <<: *if-cron-or-manual-run-or-tagged
       env:
-        - PYTEST_ADDOPTS='-m shard_2_of_3'
-        - TOXENV=ansibledevel-functional
-    - <<: *py-27
-      <<: *if-cron-or-manual-run-or-tagged
-      env:
-        - PYTEST_ADDOPTS='-m shard_3_of_3'
+        - PYTEST_ADDOPTS='-m shard_2_of_2'
         - TOXENV=ansibledevel-functional
 
     - &deploy-job


### PR DESCRIPTION
Using only 2 shards should be fine and will speedup testing by avoiding the queue waiting for new VMs.
