### PR TITLE
Cache loaded drivers and adopt lru_cache

### DIFF
--- a/molecule/api.py
+++ b/molecule/api.py
@@ -1,6 +1,12 @@
 import pkg_resources
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
+
+@lru_cache()
 def molecule_drivers(as_dict=False):
 
     plugins = {

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -43,6 +43,12 @@ from molecule.verifier import goss
 from molecule.verifier import inspec
 from molecule.verifier import testinfra
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
+
 LOG = logger.get_logger(__name__)
 MOLECULE_DEBUG = boolean(os.environ.get('MOLECULE_DEBUG', 'False'))
 MOLECULE_DIRECTORY = 'molecule'
@@ -139,7 +145,7 @@ class Config(object):
         return molecule_directory(self.project_directory)
 
     @property
-    @util.memoize
+    @lru_cache()
     def dependency(self):
         dependency_name = self.config['dependency']['name']
         if dependency_name == 'galaxy':
@@ -150,7 +156,7 @@ class Config(object):
             return shell.Shell(self)
 
     @property
-    @util.memoize
+    @lru_cache()
     def driver(self):
         driver_name = self._get_driver_name()
         driver = None
@@ -188,36 +194,36 @@ class Config(object):
         }
 
     @property
-    @util.memoize
+    @lru_cache()
     def lint(self):
         lint_name = self.config['lint']['name']
         if lint_name == 'yamllint':
             return yamllint.Yamllint(self)
 
     @property
-    @util.memoize
+    @lru_cache()
     def platforms(self):
         return platforms.Platforms(self, parallelize_platforms=self.is_parallel)
 
     @property
-    @util.memoize
+    @lru_cache()
     def provisioner(self):
         provisioner_name = self.config['provisioner']['name']
         if provisioner_name == 'ansible':
             return ansible.Ansible(self)
 
     @property
-    @util.memoize
+    @lru_cache()
     def scenario(self):
         return scenario.Scenario(self)
 
     @property
-    @util.memoize
+    @lru_cache()
     def state(self):
         return state.State(self)
 
     @property
-    @util.memoize
+    @lru_cache()
     def verifier(self):
         verifier_name = self.config['verifier']['name']
         if verifier_name == 'testinfra':
@@ -230,7 +236,7 @@ class Config(object):
             return ansible_verifier.Ansible(self)
 
     @property
-    @util.memoize
+    @lru_cache()
     def verifiers(self):
         return molecule_verifiers()
 

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -23,6 +23,11 @@ import collections
 import os
 import shutil
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
 from molecule import logger
 from molecule import util
 from molecule.provisioner import base
@@ -609,7 +614,7 @@ class Ansible(base.Base):
         return os.path.join(self._config.scenario.ephemeral_directory, 'ansible.cfg')
 
     @property
-    @util.memoize
+    @lru_cache()
     def playbooks(self):
         return ansible_playbooks.AnsiblePlaybooks(self._config)
 

--- a/molecule/provisioner/base.py
+++ b/molecule/provisioner/base.py
@@ -20,7 +20,11 @@
 
 import abc
 
-from molecule import util
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
 from molecule.provisioner.lint import ansible_lint
 
 
@@ -65,7 +69,7 @@ class Base(object):
         pass
 
     @property
-    @util.memoize
+    @lru_cache()
     def lint(self):
         lint_name = self._config.config['provisioner']['lint']['name']
         if lint_name == 'ansible-lint':

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -309,20 +309,6 @@ def merge_dicts(a, b):
     return a
 
 
-def memoize(function):
-    memo = {}
-
-    def wrapper(*args, **kwargs):
-        if args not in memo:
-            rv = function(*args, **kwargs)
-            memo[args] = rv
-
-            return rv
-        return memo[args]
-
-    return wrapper
-
-
 def validate_parallel_cmd_args(cmd_args):
     if cmd_args.get('parallel') and cmd_args.get('destroy') == 'never':
         msg = 'Combining "--parallel" and "--destroy=never" is not supported'

--- a/molecule/verifier/base.py
+++ b/molecule/verifier/base.py
@@ -22,6 +22,11 @@ import os
 
 import abc
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
 from molecule import util
 from molecule.verifier.lint import flake8
 from molecule.verifier.lint import precommit
@@ -102,7 +107,7 @@ class Base(object):
         )
 
     @property
-    @util.memoize
+    @lru_cache()
     def lint(self):
         lint_name = self._config.config['verifier']['lint']['name']
         if lint_name == 'flake8':

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ install_requires =
     # https://github.com/ssato/python-anyconfig/issues/110
     # 0.9.8, 0.9.9 are known to be broken
     anyconfig == 0.9.7
+    backports.functools_lru_cache; python_version<"3.3"
     flake8 >=3.6.0
     cerberus >= 1.3.1
     click >= 6.7


### PR DESCRIPTION
Caching loaded drivers has serious performance benefits, to have an idea
running unit tests went from ~4min to 1.5mins.

This change also replaces internal caching with stdlib lru_cache
implementation.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
