### PR TITLE
Resolve pytest deprecation warnings

### DIFF
--- a/molecule/test/conftest.py
+++ b/molecule/test/conftest.py
@@ -116,8 +116,9 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_collection_modifyitems(items):
-    marker = pytest.config.getoption('-m')
+def pytest_collection_modifyitems(items, config):
+
+    marker = config.getoption('-m')
     is_sharded = False
     shard_id = 0
     shards_num = 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,8 @@ doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 junit_suite_name = molecule_test_suite
 norecursedirs = dist doc build .tox .eggs molecule/test/scenarios molecule/test/resources
 testpaths = molecule/test/
+filterwarnings =
+    # remove once https://github.com/cookiecutter/cookiecutter/pull/1127 is released
+    ignore::DeprecationWarning:cookiecutter
+    # remove once https://github.com/pytest-dev/pytest-cov/issues/327 is released
+    ignore::pytest.PytestWarning:pytest_cov


### PR DESCRIPTION
Adopts newer calling convention in pytest so we no longer get warnings.