### PR TITLE
WIP: Allow external plugins to have their own templates

### DIFF
--- a/molecule/command/init/base.py
+++ b/molecule/command/init/base.py
@@ -51,6 +51,7 @@ class Base(object):
         :return: None
         """
         template_dir = self._resolve_template_dir(template_dir)
+        template_dir = os.path.abspath(template_dir)
         self._validate_template_dir(template_dir)
 
         try:

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -81,9 +81,12 @@ class Role(base.Base):
         self._process_templates(template_directory, self._command_args, role_directory)
         scenario_base_directory = os.path.join(role_directory, role_name)
         templates = [
-            'scenario/driver/{driver_name}'.format(**self._command_args),
+            molecule_drivers(as_dict=True)[
+                self._command_args['driver_name']
+            ]._get_template_path(),
             'scenario/verifier/{verifier_name}'.format(**self._command_args),
         ]
+
         for template in templates:
             self._process_templates(
                 template, self._command_args, scenario_base_directory

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -82,7 +82,15 @@ class Scenario(base.Base):
             ).format(scenario_name)
             util.sysexit_with_message(msg)
 
-        driver_template = 'scenario/driver/{driver_name}'.format(**self._command_args)
+        drivers = molecule_drivers(as_dict=True)
+        if self._command_args['driver_name'] not in drivers:
+            msg = "Driver %s not found" % self._command_args['driver_name']
+            util.sysexit_with_message(msg)
+
+        driver_template = drivers[
+            self._command_args['driver_name']
+        ]._get_template_path()
+
         if 'driver_template' in self._command_args:
             self._validate_template_dir(self._command_args['driver_template'])
             cli_driver_template = '{driver_template}/{driver_name}'.format(

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -218,3 +218,9 @@ class Base(object):
 
     def _converged(self):
         return str(self._config.state.converged).lower()
+
+    def _get_template_path(self):
+        """ Return path to its own cookiecutterm templates. It is used by init
+        command in order to figure out where to load the templates from.
+        """
+        return 'scenario/driver/' + self.name

--- a/molecule/test/unit/command/init/test_scenario.py
+++ b/molecule/test/unit/command/init/test_scenario.py
@@ -110,9 +110,7 @@ def test_execute_with_invalid_driver(
 
     assert 1 == e.value.code
 
-    msg = (
-        'The specified template directory ({template_dir})' ' does not exist'
-    ).format(template_dir=_instance._resolve_template_dir('scenario/driver/ec3'))
+    msg = 'Driver ec3 not found'
     patched_logger_critical.assert_called_once_with(msg)
 
 

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -176,7 +176,8 @@ def test_drivers_property(config_instance):
         'vagrant',
     ]
 
-    assert x == sorted(config_instance.drivers)
+    # assure all expected drivers are loaded, others are allowed to exist
+    assert not (set(x) - set(config_instance.drivers))
 
 
 def test_env(config_instance):
@@ -467,8 +468,8 @@ def test_molecule_drivers(caplog):
         'podman',
         'vagrant',
     ]
-
-    assert x == sorted(molecule_drivers())
+    # assure all expected drivers are loaded, others are allowed to exist
+    assert not (set(x) - set(molecule_drivers()))
     assert not caplog.records
 
 


### PR DESCRIPTION
This fix bug introduced by the removal of Azure driver, where the
external one was not longer able to be used with `init` command due
to the missing template in molecule itself.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
