### PR TITLE
Use pluggy to load plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Unreleased
 * Bash style variable expension for environment variable defaults added.
   ``foo: ${UNDEFINED_VAR:-$DEFAULT}`` and ``foo: ${UNDEFINED_VAR-$DEFAULT}``
   are now supported.
+* Use pluggy to load plugins
 
 2.20
 ====

--- a/molecule/api.py
+++ b/molecule/api.py
@@ -1,26 +1,50 @@
-import pkg_resources
+import pluggy
+from importlib import import_module
 from molecule import logger
-
+import traceback
 
 LOG = logger.get_logger(__name__)
-
 try:
     from functools import lru_cache
 except ImportError:
     from backports.functools_lru_cache import lru_cache
 
 
-@lru_cache()
-def molecule_drivers(as_dict=False):
+CORE_DRIVERS = [
+    "delegated",
+    "digitalocean",
+    "docker",
+    "ec2",
+    "gce",
+    "hetznercloud",
+    "linode",
+    "lxc",
+    "lxd",
+    "openstack",
+    "podman",
+    "vagrant",
+]
 
+
+@lru_cache()
+def molecule_drivers(as_dict=False, config=None):
     plugins = {}
-    for entry_point in pkg_resources.iter_entry_points('molecule_driver'):
+    pm = pluggy.PluginManager("molecule_driver")
+    for driver in CORE_DRIVERS:
+        pm.register(import_module("molecule.driver.%s" % driver), name=driver)
+    try:
+        pm.load_setuptools_entrypoints("molecule_driver")
+    except Exception:
+        # These are not fatal because a broken driver should not make the entire
+        # tool unusable.
+        LOG.error("Failed to load driver entry points %s", traceback.format_exc())
+    for p in pm.get_plugins():
         try:
-            plugins[entry_point.name] = entry_point.load()
+            plugins[pm.get_name(p)] = p.load(config)
         except Exception as e:
-            LOG.error("Failed to load %s driver: %s", entry_point.name, str(e))
+            LOG.error("Failed to load %s driver: %s", pm.get_name(p), str(e))
 
     if as_dict:
         return plugins
     else:
-        return list(plugins.keys())
+        return sorted(list(plugins.keys()))

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -161,14 +161,14 @@ class Config(object):
         driver_name = self._get_driver_name()
         driver = None
 
-        driver = molecule_drivers(as_dict=True)[driver_name].load(self)
+        driver = molecule_drivers(as_dict=True, config=self)[driver_name]
         driver.name = driver_name
 
         return driver
 
     @property
     def drivers(self):
-        return molecule_drivers()
+        return molecule_drivers(config=self)
 
     @property
     def env(self):

--- a/molecule/test/unit/test_api.py
+++ b/molecule/test/unit/test_api.py
@@ -1,0 +1,34 @@
+from molecule.driver.base import Base
+from molecule.api import molecule_drivers
+
+
+def looks_iterable(a):
+    try:
+        (x for x in a)
+        return True
+    except TypeError:
+        return False
+
+
+def test_api_molecule_drivers():
+
+    # check if call without parameters returns a list of strings
+    results = molecule_drivers()
+    # print(results)
+    assert looks_iterable(results)
+    # delegated driver is expected to always be present
+    assert 'delegated' in results
+
+
+def test_api_molecule_drivers_as_dict():
+
+    # check that with as_dict it will return a dictionary of driver instances
+    results = molecule_drivers(as_dict=True)
+
+    assert looks_iterable(results)
+
+    # delegated driver is expected to always be present
+    assert 'delegated' in results
+
+    for driver in results.values():
+        assert isinstance(driver, Base)

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ install_requires =
     paramiko >= 2.5.0, < 3
     pathlib2; python_version<"3.2"
     pexpect >= 4.6.0, < 5
+    pluggy >= 0.7.1, < 1.0
     pre-commit >= 1.17.0, < 2
     psutil >= 5.4.6, < 6; sys_platform!="win32" and sys_platform!="cygwin"
     PyYAML >= 5.1, < 6


### PR DESCRIPTION
Adopts use of pluggy for loading plugins in order to make their loading
more reliable to errors. Using pkg_resources proved to be less reliable
as its entry point iterator can break on any import, spotting to return
more entry points.

Apparently using pluggy is a better bet as it is already used by two
major tools with lots of plugins: pytest and tox.