### PR TITLE
Do not prune when --destroy=never

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -140,9 +140,10 @@ def execute_scenario(scenario):
     for action in scenario.sequence:
         execute_subcommand(scenario.config, action)
 
-    # pruning only if a 'destroy' step was in the sequence allows for normal
-    # debugging by manually stepping through a scenario sequence
-    if 'destroy' in scenario.sequence:
+    if (
+        'destroy' in scenario.sequence
+        and scenario.config.command_args.get('destroy') != 'never'
+    ):
         scenario.prune()
 
         if scenario.config.is_parallel:

--- a/molecule/test/unit/command/test_base.py
+++ b/molecule/test/unit/command/test_base.py
@@ -135,7 +135,37 @@ def test_execute_cmdline_scenarios(
     assert _patched_execute_scenario.call_count == 1
 
 
-def test_execute_cmdline_scenarios_destroy(
+def test_execute_cmdline_scenarios_prune(
+    config_instance, _patched_prune, _patched_execute_subcommand
+):
+    # Subcommands should be executed and prune *should* run when
+    # destroy is 'always'
+    scenario_name = 'default'
+    args = {}
+    command_args = {'destroy': 'always', 'subcommand': 'test'}
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+
+    assert _patched_execute_subcommand.called
+    assert _patched_prune.called
+
+
+def test_execute_cmdline_scenarios_no_prune(
+    config_instance, _patched_prune, _patched_execute_subcommand
+):
+    # Subcommands should be executed but prune *should not* run when
+    # destroy is 'never'
+    scenario_name = 'default'
+    args = {}
+    command_args = {'destroy': 'never', 'subcommand': 'test'}
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+
+    assert _patched_execute_subcommand.called
+    assert not _patched_prune.called
+
+
+def test_execute_cmdline_scenarios_exit_destroy(
     config_instance,
     _patched_execute_scenario,
     _patched_prune,
@@ -163,7 +193,7 @@ def test_execute_cmdline_scenarios_destroy(
     assert _patched_sysexit.called
 
 
-def test_execute_cmdline_scenarios_nodestroy(
+def test_execute_cmdline_scenarios_exit_nodestroy(
     config_instance, _patched_execute_scenario, _patched_prune, _patched_sysexit
 ):
     # Ensure execute_cmdline_scenarios handles errors correctly when 'destroy'


### PR DESCRIPTION
Scenarios were incorrectly being pruned due to 'destroy' being in a
scenario sequence, as the prune logic did not take into account whether
'--destroy=never' was specified in the command-line arguments.

Tests have also been added to cover this case. The existing tests
related to the prune logic only covered the case where a sequence step
exited abnormally.

Fixes #2260 