### PR TITLE
ec2: per-platform ansible_connection overrides and win password lookup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Unreleased
   ``foo: ${UNDEFINED_VAR:-$DEFAULT}`` and ``foo: ${UNDEFINED_VAR-$DEFAULT}``
   are now supported.
 * Use pluggy to load plugins
+* Windows & Linux EC2 instances can be tested simultaneously
+* Windows EC2 instances can be provisioned using the automatically-generated password
 
 2.20
 ====

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -113,6 +113,8 @@ class EC2(base.Base):
               sudo: False
               ansible_user: Administrator
               # Specify a password to override the automatic lookup
+              # or omit to retrieve automatically
+              # (requires boto3 & cryptography packages)
               # ansible_password: hunter2
               ansible_port: 5986
               ansible_connection: winrm

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -106,7 +106,7 @@ class EC2(base.Base):
           name: ec2
         platforms:
           - name: instance
-            image: ami-06a0d33fc8d328de0)
+            image: ami-06a0d33fc8d328de0
             instance_type: t3a.medium
             vpc_subnet_id: subnet-1cb17175
             connection_options:
@@ -190,6 +190,11 @@ class EC2(base.Base):
     def ansible_connection_options(self, instance_name):
         try:
             d = self._get_instance_config(instance_name)
+            plat_conn_opts = next(
+                (item for item in self._config.config.get('platforms', [])
+                 if item['name'] == instance_name),
+                {}
+            ).get('connection_options', {})
             conn_opts = util.merge_dicts(
                 {
                     'ansible_user': d['user'],
@@ -199,9 +204,7 @@ class EC2(base.Base):
                     'connection': 'ssh',
                     'ansible_ssh_common_args': ' '.join(self.ssh_connection_options),
                 },
-                # Merge in override 'connection_options' on platform config
-                next((item for item in self._config.config.get('platforms', [])
-                      if item['name'] == instance_name), {}).get('connection_options', {})
+                plat_conn_opts
             )
             if conn_opts.get('ansible_connection') == 'winrm' and (
                     not conn_opts.get('ansible_password')):

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -18,6 +18,23 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+from base64 import b64decode
+import sys
+
+try:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+    HAS_CRYPTOGRAPHY = True
+except ImportError:
+    HAS_CRYPTOGRAPHY = False
+
+try:
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
 from molecule import logger
 from molecule.driver import base
 
@@ -80,6 +97,27 @@ class EC2(base.Base):
             image_name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*
             instance_type: t2.micro
             vpc_subnet_id: subnet-1cb17175
+
+    Windows EC2 instances can be used as well:
+
+    .. code-block:: yaml
+
+        driver:
+          name: ec2
+        platforms:
+          - name: instance
+            image: ami-06a0d33fc8d328de0)
+            instance_type: t3a.medium
+            vpc_subnet_id: subnet-1cb17175
+            connection_options:
+              sudo: False
+              ansible_user: Administrator
+              # Specify a password to override the automatic lookup
+              # ansible_password: hunter2
+              ansible_port: 5986
+              ansible_connection: winrm
+              ansible_winrm_scheme: https
+              ansible_winrm_server_cert_validation: ignore
 
     .. code-block:: bash
 
@@ -152,15 +190,26 @@ class EC2(base.Base):
     def ansible_connection_options(self, instance_name):
         try:
             d = self._get_instance_config(instance_name)
-
-            return {
-                'ansible_user': d['user'],
-                'ansible_host': d['address'],
-                'ansible_port': d['port'],
-                'ansible_private_key_file': d['identity_file'],
-                'connection': 'ssh',
-                'ansible_ssh_common_args': ' '.join(self.ssh_connection_options),
-            }
+            conn_opts = util.merge_dicts(
+                {
+                    'ansible_user': d['user'],
+                    'ansible_host': d['address'],
+                    'ansible_port': d['port'],
+                    'ansible_private_key_file': d['identity_file'],
+                    'connection': 'ssh',
+                    'ansible_ssh_common_args': ' '.join(self.ssh_connection_options),
+                },
+                # Merge in override 'connection_options' on platform config
+                next((item for item in self._config.config.get('platforms', [])
+                      if item['name'] == instance_name), {}).get('connection_options', {})
+            )
+            if conn_opts.get('ansible_connection') == 'winrm' and (
+                    not conn_opts.get('ansible_password')):
+                conn_opts['ansible_password'] = self._get_windows_instance_pass(
+                    d['instance_ids'][0],
+                    d['identity_file']
+                )
+            return conn_opts
         except StopIteration:
             return {}
         except IOError:
@@ -174,6 +223,20 @@ class EC2(base.Base):
         return next(
             item for item in instance_config_dict if item['instance'] == instance_name
         )
+
+    def _get_windows_instance_pass(self, instance_id, key_file):
+        if not HAS_BOTO3:
+            LOG.error('boto3 required when using Windows instances')
+            sys.exit(1)
+        if not HAS_CRYPTOGRAPHY:
+            LOG.error('cryptography package required when using Windows instances')
+            sys.exit(1)
+        ec2_client = boto3.client('ec2')
+        data_response = ec2_client.get_password_data(InstanceId=instance_id)
+        decoded = b64decode(data_response['PasswordData'])
+        with open(key_file, 'rb') as f:
+            key = load_pem_private_key(f.read(), None, default_backend())
+        return key.decrypt(decoded, PKCS1v15())
 
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks


### PR DESCRIPTION
#### PR Type

- Feature Pull Request

#### Overview

To provision Linux & Windows hosts simultaneously, the same connection_options can't be shared on the provisioner. This PR allows provisioner connection_options to be customized per-platform.

Additionally, if the winrm connection is used on an EC2 instance and a password isn't supplied. the password will be retrieved automatically via boto3 (decryption logic copied from ec2_win_password module)


