### PR TITLE
Refactor "role:" block in cookiecutter template

### DIFF
--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/digitalocean/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/digitalocean/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/hetznercloud/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/hetznercloud/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/linode/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  roles:
-    - role: {{ cookiecutter.role_name }}
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"


### PR DESCRIPTION
Signed-off-by: Michael Shen <mishen@med.umich.edu>

#### PR Type

- Bugfix Pull Request

#### Overview

Fixes #2279 
Uses include_role task instead of role block in cookiecutter playbooks