### PR TITLE
Pass merged configuration to provisioner playbooks

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -68,6 +68,7 @@ class Base(object):
 
         :return: None
         """
+        self._config.write()
         self._config.provisioner.write_config()
         self._config.provisioner.manage_inventory()
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -103,6 +103,13 @@ class Config(object):
         if self.molecule_file:
             self._validate()
 
+    def write(self):
+        util.write_file(self.config_file, util.safe_dump(self.config))
+
+    @property
+    def config_file(self):
+        return os.path.join(self.scenario.ephemeral_directory, MOLECULE_FILE)
+
     @property
     def is_parallel(self):
         return self.command_args.get('parallel', False)
@@ -169,7 +176,7 @@ class Config(object):
     def env(self):
         return {
             'MOLECULE_DEBUG': str(self.debug),
-            'MOLECULE_FILE': self.molecule_file,
+            'MOLECULE_FILE': self.config_file,
             'MOLECULE_ENV_FILE': self.env_file,
             'MOLECULE_STATE_FILE': self.state.state_file,
             'MOLECULE_INVENTORY_FILE': self.provisioner.inventory_file,

--- a/molecule/test/unit/command/test_base.py
+++ b/molecule/test/unit/command/test_base.py
@@ -111,8 +111,8 @@ def test_setup(
     _patched_manage_inventory,
     _instance,
 ):
-
     assert os.path.isdir(os.path.dirname(_instance._config.provisioner.inventory_file))
+    assert os.path.isfile(_instance._config.config_file)
 
     _patched_manage_inventory.assert_called_once_with()
     _patched_write_config.assert_called_once_with()

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -183,7 +183,7 @@ def test_env(config_instance):
     config_instance.args = {'env_file': '.env'}
     x = {
         'MOLECULE_DEBUG': 'False',
-        'MOLECULE_FILE': config_instance.molecule_file,
+        'MOLECULE_FILE': config_instance.config_file,
         'MOLECULE_ENV_FILE': util.abs_path(config_instance.args.get('env_file')),
         'MOLECULE_INVENTORY_FILE': config_instance.provisioner.inventory_file,
         'MOLECULE_EPHEMERAL_DIRECTORY': config_instance.scenario.ephemeral_directory,
@@ -494,3 +494,9 @@ def test_set_env_from_file_returns_original_env_when_env_file_not_found(
     env = config.set_env_from_file({}, 'file-not-found')
 
     assert {} == env
+
+
+def test_write_config(config_instance):
+    config_instance.write()
+
+    assert os.path.isfile(config_instance.config_file)


### PR DESCRIPTION
Up until now, molecule_yml variable in create/destroy playbooks contained only values from the scenario molecule YAML file. This made it a bit awkward to share common platforms definitions in different scenarios.

Changes in this commit replace the direct access to the scenario molecule configuration with the merged one. When the inventory and Ansible configuration files are written to the disk, merged
configuration is also stored in the ephemeral directory of the scenario currently being acted upon.


Note: This is a simpler implementation of #2193 and should fix #1423 

#### PR Type

- Feature Pull Request
