### PR TITLE
refactoring: transformed verifiers into plugins

### DIFF
--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -22,10 +22,10 @@ import os
 
 import click
 
-from molecule import config
 from molecule import logger
 from molecule import util
 from molecule.api import drivers
+from molecule.api import verifiers
 from molecule.command import base as command_base
 from molecule.command.init import base
 
@@ -125,7 +125,7 @@ class Role(base.Base):
 @click.option('--role-name', '-r', required=True, help='Name of the role to create.')
 @click.option(
     '--verifier-name',
-    type=click.Choice(config.molecule_verifiers()),
+    type=click.Choice(verifiers()),
     default='testinfra',
     help='Name of verifier to initialize. (testinfra)',
 )

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -26,6 +26,7 @@ from molecule import config
 from molecule import logger
 from molecule import util
 from molecule.api import drivers
+from molecule.api import verifiers
 from molecule.command import base as command_base
 from molecule.command.init import base
 
@@ -188,7 +189,7 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
 )
 @click.option(
     '--verifier-name',
-    type=click.Choice(config.molecule_verifiers()),
+    type=click.Choice(verifiers()),
     default='testinfra',
     help='Name of verifier to initialize. (testinfra)',
 )

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -230,11 +230,6 @@ class Config(object):
         elif verifier_name == 'ansible':
             return ansible_verifier.Ansible(self)
 
-    @property
-    @util.lru_cache()
-    def verifiers(self):
-        return molecule_verifiers()
-
     def _get_driver_name(self):
         driver_from_state_file = self.state.driver
         driver_from_cli = self.command_args.get('driver_name')
@@ -453,15 +448,6 @@ def molecule_directory(path):
 
 def molecule_file(path):
     return os.path.join(path, MOLECULE_FILE)
-
-
-def molecule_verifiers():
-    return [
-        goss.Goss(None).name,
-        inspec.Inspec(None).name,
-        testinfra.Testinfra(None).name,
-        ansible_verifier.Ansible(None).name,
-    ]
 
 
 def set_env_from_file(env, env_file):

--- a/molecule/test/unit/test_api.py
+++ b/molecule/test/unit/test_api.py
@@ -19,12 +19,11 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-from molecule.api import Driver
-from molecule.api import drivers
+from molecule import api
 
 
 def test_api_drivers():
-    results = drivers()
+    results = api.drivers()
 
     assert isinstance(results, list)
 
@@ -35,7 +34,7 @@ def test_api_drivers():
 
 
 def test_api_drivers_as_dict():
-    results = drivers(as_dict=True)
+    results = api.drivers(as_dict=True)
 
     assert isinstance(results, dict)
 
@@ -45,4 +44,10 @@ def test_api_drivers_as_dict():
     assert 'delegated' in results
 
     for driver in results.values():
-        assert isinstance(driver, Driver)
+        assert isinstance(driver, api.Driver)
+
+
+def test_api_verifiers():
+    x = sorted(['goss', 'inspec', 'testinfra', 'ansible'])
+
+    assert x == api.verifiers()

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -265,12 +265,6 @@ def test_verifier_property_is_ansible(config_instance):
     assert isinstance(config_instance.verifier, ansible_verifier.Ansible)
 
 
-def test_verifiers_property(config_instance):
-    x = ['goss', 'inspec', 'testinfra', 'ansible']
-
-    assert x == config_instance.verifiers
-
-
 def test_get_driver_name_from_state_file(config_instance):
     config_instance.state.change_state('driver', 'state-driver')
 
@@ -470,12 +464,6 @@ def test_molecule_drivers(caplog):
 
     assert x == sorted(drivers())
     assert not caplog.records
-
-
-def test_molecule_verifiers():
-    x = ['goss', 'inspec', 'testinfra', 'ansible']
-
-    assert x == config.molecule_verifiers()
 
 
 def test_set_env_from_file(config_instance):

--- a/molecule/verifier/ansible.py
+++ b/molecule/verifier/ansible.py
@@ -22,12 +22,13 @@ import os
 
 from molecule import logger
 from molecule import util
-from molecule.verifier import base
+from molecule.api import Verifier
+
 
 log = logger.get_logger(__name__)
 
 
-class Ansible(base.Base):
+class Ansible(Verifier):
     """
     `Ansible`_ is not the default test runner.
 

--- a/molecule/verifier/base.py
+++ b/molecule/verifier/base.py
@@ -30,10 +30,10 @@ from molecule.verifier.lint import yamllint
 from molecule.verifier.lint import ansible_lint
 
 
-class Base(object):
+class Verifier(object):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         """
         Base initializer for all :ref:`Verifier` classes.
 

--- a/molecule/verifier/goss.py
+++ b/molecule/verifier/goss.py
@@ -22,12 +22,12 @@ import os
 
 from molecule import logger
 from molecule import util
-from molecule.verifier import base
+from molecule.api import Verifier
 
 LOG = logger.get_logger(__name__)
 
 
-class Goss(base.Base):
+class Goss(Verifier):
     """
     `Goss`_ is not the default test runner.
 
@@ -93,7 +93,7 @@ class Goss(base.Base):
     .. _`Goss`: https://github.com/aelsabbahy/goss
     """
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         """
         Sets up the requirements to execute ``goss`` and returns None.
 

--- a/molecule/verifier/inspec.py
+++ b/molecule/verifier/inspec.py
@@ -22,12 +22,12 @@ import os
 
 from molecule import logger
 from molecule import util
-from molecule.verifier import base
+from molecule.api import Verifier
 
 LOG = logger.get_logger(__name__)
 
 
-class Inspec(base.Base):
+class Inspec(Verifier):
     """
     `Inspec`_ is not the default test runner.
 
@@ -79,7 +79,7 @@ class Inspec(base.Base):
     .. _`Inspec`: https://www.chef.io/inspec/
     """
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         """
         Sets up the requirements to execute ``inspec`` and returns None.
 

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -25,12 +25,12 @@ import sh
 
 from molecule import logger
 from molecule import util
-from molecule.verifier import base
+from molecule.api import Verifier
 
 LOG = logger.get_logger(__name__)
 
 
-class Testinfra(base.Base):
+class Testinfra(Verifier):
     """
     `Testinfra`_ is the default test runner.
 
@@ -90,7 +90,7 @@ class Testinfra(base.Base):
     .. _`Testinfra`: https://testinfra.readthedocs.io
     """
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         """
         Sets up the requirements to execute ``testinfra`` and returns None.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -157,6 +157,11 @@ molecule_driver =
     openstack = molecule.driver.openstack
     podman = molecule.driver.podman
     vagrant = molecule.driver.vagrant
+molecule.verifier =
+    goss = molecule.verifier.goss:Goss
+    inspec = molecule.verifier.inspec:Inspec
+    testinfra = molecule.verifier.testinfra:Testinfra
+    ansible = molecule.verifier.ansible:Ansible
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
This will allow us to add verifiers from outside molecule and to move some of the internal plugins to be external plugins.
