### PR TITLE
Disable deprecation warnings from own dependencies

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,13 @@ junit_suite_name = molecule_test_suite
 norecursedirs = dist doc build .tox .eggs molecule/test/scenarios molecule/test/resources
 testpaths = molecule/test/
 filterwarnings =
+    # remove once https://github.com/boto/boto3/pull/1603 is released
+    ignore::DeprecationWarning:boto3
+    # remove once https://github.com/boto/botocore/issues/1615 is released
+    ignore::DeprecationWarning:botocore
     # remove once https://github.com/cookiecutter/cookiecutter/pull/1127 is released
     ignore::DeprecationWarning:cookiecutter
     # remove once https://github.com/pytest-dev/pytest-cov/issues/327 is released
     ignore::pytest.PytestWarning:pytest_cov
+    # remove once https://bitbucket.org/astanin/python-tabulate/issues/174/invalid-escape-sequence
+    ignore::DeprecationWarning:tabulate


### PR DESCRIPTION
Once we assure we have an upstream bug track we track, we can disable
deprecation warnings from dependencies producing them.

If they do not fix them we should consider finding a way to drop these
dependencies:

* https://github.com/boto/boto3/pull/1603
* https://github.com/boto/botocore/issues/1615
* https://github.com/cookiecutter/cookiecutter/pull/1127 
* https://github.com/pytest-dev/pytest-cov/issues/327
* https://bitbucket.org/astanin/python-tabulate/issues/174/invalid-escape-sequence
