### PR TITLE
refactoring: verifiers should expose their own linters

### DIFF
--- a/molecule/api.py
+++ b/molecule/api.py
@@ -21,6 +21,9 @@ class UserListMap(UserList):
         else:
             return self.__dict__[i]
 
+    def get(self, key, default):
+        return self.__dict__.get(key, default)
+
     def append(self, element):
         self.__dict__[str(element)] = element
         return super(UserListMap, self).append(element)
@@ -47,7 +50,7 @@ def drivers(config=None):
 
 
 @lru_cache()
-def verifiers():
+def verifiers(config=None):
     # type: (object) -> UserListMap[Verifier]
     plugins = UserListMap()
     pm = pluggy.PluginManager("molecule.verifier")
@@ -59,7 +62,7 @@ def verifiers():
         LOG.error("Failed to load verifier entry point %s", traceback.format_exc())
     for p in pm.get_plugins():
         try:
-            plugins.append(p())
+            plugins.append(p(config))
         except Exception as e:
             LOG.error("Failed to load %s driver: %s", pm.get_name(p), str(e))
     plugins.sort()

--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -22,10 +22,9 @@ import os
 
 import click
 
+from molecule import api
 from molecule import logger
 from molecule import util
-from molecule.api import drivers
-from molecule.api import verifiers
 from molecule.command import base as command_base
 from molecule.command.init import base
 
@@ -106,7 +105,7 @@ class Role(base.Base):
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(drivers()),
+    type=click.Choice(api.drivers()),
     default='docker',
     help='Name of driver to initialize. (docker)',
 )
@@ -125,7 +124,7 @@ class Role(base.Base):
 @click.option('--role-name', '-r', required=True, help='Name of the role to create.')
 @click.option(
     '--verifier-name',
-    type=click.Choice(verifiers()),
+    type=click.Choice(api.verifiers()),
     default='testinfra',
     help='Name of verifier to initialize. (testinfra)',
 )
@@ -158,14 +157,7 @@ def role(
         'verifier_name': verifier_name,
     }
 
-    if verifier_name == 'inspec':
-        command_args['verifier_lint_name'] = 'rubocop'
-
-    if verifier_name == 'goss':
-        command_args['verifier_lint_name'] = 'yamllint'
-
-    if verifier_name == 'ansible':
-        command_args['verifier_lint_name'] = 'ansible-lint'
+    command_args['verifier_lint_name'] = api.verifiers()[verifier_name].default_linter
 
     if template is not None:
         command_args['template'] = template

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -22,11 +22,10 @@ import os
 
 import click
 
+from molecule import api
 from molecule import config
 from molecule import logger
 from molecule import util
-from molecule.api import drivers
-from molecule.api import verifiers
 from molecule.command import base as command_base
 from molecule.command.init import base
 
@@ -154,7 +153,7 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(drivers()),
+    type=click.Choice(api.drivers()),
     default='docker',
     help='Name of driver to initialize. (docker)',
 )
@@ -189,7 +188,7 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
 )
 @click.option(
     '--verifier-name',
-    type=click.Choice(verifiers()),
+    type=click.Choice(api.verifiers()),
     default='testinfra',
     help='Name of verifier to initialize. (testinfra)',
 )
@@ -223,14 +222,7 @@ def scenario(
         'verifier_name': verifier_name,
     }
 
-    if verifier_name == 'inspec':
-        command_args['verifier_lint_name'] = 'rubocop'
-
-    if verifier_name == 'goss':
-        command_args['verifier_lint_name'] = 'yamllint'
-
-    if verifier_name == 'ansible':
-        command_args['verifier_lint_name'] = 'ansible-lint'
+    command_args['verifier_lint_name'] = api.verifiers()[verifier_name].default_linter
 
     driver_template = driver_template or os.environ.get(
         'MOLECULE_SCENARIO_DRIVER_TEMPLATE', None

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -38,10 +38,6 @@ from molecule.dependency import shell
 from molecule.lint import yamllint
 from molecule.model import schema_v2
 from molecule.provisioner import ansible
-from molecule.verifier import ansible as ansible_verifier
-from molecule.verifier import goss
-from molecule.verifier import inspec
-from molecule.verifier import testinfra
 
 
 LOG = logger.get_logger(__name__)
@@ -223,15 +219,7 @@ class Config(object):
     @property
     @util.lru_cache()
     def verifier(self):
-        verifier_name = self.config['verifier']['name']
-        if verifier_name == 'testinfra':
-            return testinfra.Testinfra(self)
-        elif verifier_name == 'inspec':
-            return inspec.Inspec(self)
-        elif verifier_name == 'goss':
-            return goss.Goss(self)
-        elif verifier_name == 'ansible':
-            return ansible_verifier.Ansible(self)
+        return api.verifiers(self).get(self.config['verifier']['name'], None)
 
     def _get_driver_name(self):
         driver_from_state_file = self.state.driver

--- a/molecule/verifier/base.py
+++ b/molecule/verifier/base.py
@@ -41,6 +41,7 @@ class Verifier(object):
         :returns: None
         """
         self._config = config
+        self.default_linter = 'ansible-lint'
 
     @abc.abstractproperty
     def name(self):  # pragma: no cover

--- a/molecule/verifier/goss.py
+++ b/molecule/verifier/goss.py
@@ -101,6 +101,7 @@ class Goss(Verifier):
         :return: None
         """
         super(Goss, self).__init__(config)
+        self.default_linter = 'yamllint'
         if config:
             self._tests = self._get_tests()
 

--- a/molecule/verifier/inspec.py
+++ b/molecule/verifier/inspec.py
@@ -87,6 +87,7 @@ class Inspec(Verifier):
         :return: None
         """
         super(Inspec, self).__init__(config)
+        self.default_linter = 'rubocop'
         if config:
             self._tests = self._get_tests()
 

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -98,6 +98,7 @@ class Testinfra(Verifier):
         :return: None
         """
         super(Testinfra, self).__init__(config)
+        self.default_linter = 'flake8'
         self._testinfra_command = None
         if config:
             self._tests = self._get_tests()


### PR DESCRIPTION
Instead of knowing which linter is used by each verifier, this is now
a property of the verifier itself.
