### PR TITLE
docker: add support for devices

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -67,6 +67,8 @@ class Docker(Driver):
             privileged: True|False
             security_opts:
               - seccomp=unconfined
+            devices:
+              - /dev/fuse:/dev/fuse:rwm
             volumes:
               - /sys/fs/cgroup:/sys/fs/cgroup:ro
             keep_volumes: True|False

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -143,6 +143,7 @@
         pid_mode: "{{ item.pid_mode | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"
         security_opts: "{{ item.security_opts | default(omit) }}"
+        devices: "{{ item.devices | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
         tmpfs: "{{ item.tmpfs | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"


### PR DESCRIPTION
This fixes #2307 by adding a "devices" setting in docker platform config. I also updated the documentation accordingly.

I tested my changes on a custom role and I successfully made a fuse mount with the following settings in my docker platform:

```
  - name: debian
    image: debian:latest
    #privileged: True
    devices:
      - /dev/fuse:/dev/fuse:rwm
    capabilities:
      - SYS_ADMIN
    security_opts:
      - apparmor=unconfined
``` 

#### PR Type

- Feature Pull Request
