### PR TITLE
Dockerfile.j2: add python-apt aptitude packages for Debian-based distros

### DIFF
--- a/molecule/test/resources/playbooks/docker/Dockerfile.j2
+++ b/molecule/test/resources/playbooks/docker/Dockerfile.j2
@@ -9,7 +9,7 @@ FROM {{ item.image }}
 ARG testarg=fail
 ENV envarg=$testarg
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 python-apt aptitude && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \


### PR DESCRIPTION
This aims to get rid of warnings like this when installing packages later on, using the [`package`](https://docs.ansible.com/ansible/latest/modules/package_module.html#package-module) ansible module:

```
TASK [ubuntu_tomcat : Install tomcat .deb package] *****************************
[WARNING]: Updating cache and auto-installing missing dependency: python-apt

changed: [ubuntu16.04-8d75d129-86ac-4715-89df-2b4a04733675]
[WARNING]: Could not find aptitude. Using apt-get instead
```

#### PR Type

- Bugfix Pull Request
