### PR TITLE
Add podman driver to cookiecutter

### DIFF
--- a/molecule/cookiecutter/scenario/driver/podman/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/podman/cookiecutter.json
@@ -1,0 +1,5 @@
+{
+    "molecule_directory": "molecule",
+    "role_name": "OVERRIDEN",
+    "scenario_name": "OVERRIDEN"
+}

--- a/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
+++ b/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile.j2
@@ -1,0 +1,24 @@
+# Molecule managed
+
+{% raw -%}
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi
+{%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Podman driver installation guide
+*******
+
+Requirements
+============
+
+* Podman Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[podman]'

--- a/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/podman/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include {{ cookiecutter.role_name }}"
+      include_role:
+        name: "{{ cookiecutter.role_name }}"


### PR DESCRIPTION
Add podman driver to cookicutter templates.
Test:
```
molecule init scenario -d podman -s podman-test
```
Fixes: #2331

#### PR Type

- Bugfix Pull Request

