### PR TITLE
Disable galaxy role installation during testing

### DIFF
--- a/molecule/test/functional/test_command.py
+++ b/molecule/test/functional/test_command.py
@@ -125,6 +125,9 @@ def test_command_create(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
+@pytest.mark.skip(
+    reason="Disabled due to https://github.com/ansible/galaxy/issues/2030"
+)
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [


### PR DESCRIPTION
Workaround-For: https://github.com/ansible/galaxy/issues/2030
Fixes: #2334

