### PR TITLE
Fixed typo on OVERRIDEN

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Unreleased
 ==========
 
 * MAJOR: Removed LXC and LXD providers
+* MINOR: Fixed typo with OVERRIDDEN placeholder in templates
 * Supported Ansible versions are now 2.9, 2.8, 2.7
 * The Linode driver now uses the ``linode_v4`` module.
 * Removed goss verifier

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,7 +46,7 @@ Driver
 Molecule uses `Ansible`_ to manage instances to operate on.  Molecule supports
 any provider `Ansible`_ supports.  This work is offloaded to the `provisioner`.
 
-The driver's name is specified in `molecule.yml`, and can be overriden on the
+The driver's name is specified in `molecule.yml`, and can be overridden on the
 command line.  Molecule will remember the last successful driver used, and
 
 continue to use the driver for all subsequent subcommands, or until the

--- a/molecule/cookiecutter/molecule/cookiecutter.json
+++ b/molecule/cookiecutter/molecule/cookiecutter.json
@@ -1,12 +1,12 @@
 {
     "molecule_directory": "molecule",
-    "dependency_name": "OVERRIDEN",
-    "driver_name": "OVERRIDEN",
-    "lint_name": "OVERRIDEN",
-    "provisioner_name": "OVERRIDEN",
+    "dependency_name": "OVERRIDDEN",
+    "driver_name": "OVERRIDDEN",
+    "lint_name": "OVERRIDDEN",
+    "provisioner_name": "OVERRIDDEN",
     "provisioner_lint_name": "ansible-lint",
-    "scenario_name": "OVERRIDEN",
-    "role_name": "OVERRIDEN",
-    "verifier_name": "OVERRIDEN",
+    "scenario_name": "OVERRIDDEN",
+    "role_name": "OVERRIDDEN",
+    "verifier_name": "OVERRIDDEN",
     "verifier_lint_name": "flake8"
 }

--- a/molecule/cookiecutter/role/cookiecutter.json
+++ b/molecule/cookiecutter/role/cookiecutter.json
@@ -1,4 +1,4 @@
 {
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/delegated/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/delegated/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/digitalocean/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/digitalocean/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/docker/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/docker/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/ec2/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/ec2/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/gce/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/gce/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/hetznercloud/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/hetznercloud/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/linode/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/linode/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/openstack/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/openstack/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/podman/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/podman/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/driver/vagrant/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/vagrant/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/cookiecutter/scenario/verifier/ansible/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/verifier/ansible/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "molecule_directory": "molecule",
 
-    "role_name": "OVERRIDEN",
+    "role_name": "OVERRIDDEN",
     "scenario_name": "default"
 }

--- a/molecule/cookiecutter/scenario/verifier/testinfra/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/verifier/testinfra/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "molecule_directory": "molecule",
 
-    "role_name": "OVERRIDEN",
+    "role_name": "OVERRIDDEN",
     "scenario_name": "default",
     "verifier_directory": "tests"
 }

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -82,7 +82,7 @@ class Ansible(base.Base):
 
     The create/destroy playbooks for Docker and Vagrant are bundled with
     Molecule.  These playbooks have a clean API from `molecule.yml`, and
-    are the most commonly used.  The bundled playbooks can still be overriden.
+    are the most commonly used.  The bundled playbooks can still be overridden.
 
     The playbook loading order is:
 

--- a/molecule/test/resources/custom_role_template/cookiecutter.json
+++ b/molecule/test/resources/custom_role_template/cookiecutter.json
@@ -1,4 +1,4 @@
 {
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/test/resources/custom_scenario_template/docker/cookiecutter.json
+++ b/molecule/test/resources/custom_scenario_template/docker/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/test/resources/invalid_role_template/cookiecutter.json
+++ b/molecule/test/resources/invalid_role_template/cookiecutter.json
@@ -1,4 +1,4 @@
 {
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/test/resources/invalid_scenario_template/docker/cookiecutter.json
+++ b/molecule/test/resources/invalid_scenario_template/docker/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "molecule_directory": "molecule",
-    "role_name": "OVERRIDEN",
-    "scenario_name": "OVERRIDEN"
+    "role_name": "OVERRIDDEN",
+    "scenario_name": "OVERRIDDEN"
 }

--- a/molecule/test/unit/test_scenario.py
+++ b/molecule/test/unit/test_scenario.py
@@ -210,13 +210,13 @@ def test_ephemeral_directory():
     assert os.access(scenario.ephemeral_directory('foo/bar'), os.W_OK)
 
 
-def test_ephemeral_directory_overriden_via_env_var(monkeypatch):
+def test_ephemeral_directory_OVERRIDDEN_via_env_var(monkeypatch):
     monkeypatch.setenv('MOLECULE_EPHEMERAL_DIRECTORY', 'foo/bar')
 
     assert os.access(scenario.ephemeral_directory('foo/bar'), os.W_OK)
 
 
-def test_ephemeral_directory_overriden_via_env_var_uses_absolute_path(monkeypatch):
+def test_ephemeral_directory_OVERRIDDEN_via_env_var_uses_absolute_path(monkeypatch):
     monkeypatch.setenv('MOLECULE_EPHEMERAL_DIRECTORY', "foo/bar")
 
     assert os.path.isabs(scenario.ephemeral_directory())

--- a/molecule/test/unit/verifier/test_testinfra.py
+++ b/molecule/test/unit/verifier/test_testinfra.py
@@ -165,7 +165,7 @@ def _verifier_testinfra_directory_section_data():
 @pytest.mark.parametrize(
     'config_instance', ['_verifier_testinfra_directory_section_data'], indirect=True
 )
-def test_directory_property_overriden(_instance):
+def test_directory_property_overridden(_instance):
     assert '/tmp/foo/bar' == _instance.directory
 
 


### PR DESCRIPTION
Correct spelling is OVERRIDDEN, not OVERRIDEN.

