### PR TITLE
Modify the type of winrm_server_cert_validation described in the docu…

### DIFF
--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -63,7 +63,7 @@ class Delegated(Driver):
           winrm_transport: ntlm/credssp/kerberos
           winrm_cert_pem: <path to the credssp public certificate key>
           winrm_cert_key_pem: <path to the credssp private certificate key>
-          winrm_server_cert_validation: True/False
+          winrm_server_cert_validation: validate/ignore
 
     This article covers how to configure and use WinRM with Ansible:
     https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html


### PR DESCRIPTION
This PR will modify the configuration description of the delegated driver.
In the description of the delegated driver settings, the type that can be specified for winrm_server_cert_validation is written as `bool`.

https://molecule.readthedocs.io/en/stable/configuration.html#delegated

But, in the ansible document, what can be specified for winrm_server_cert_validation is written as `ignore` or `validate`.

https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html#inventory-options

If to execute the test with winrm_server_cert_validation set to `True`, the following error will occur.

```
(snip)
--> Scenario: 'default'
--> Action: 'prepare'
Skipping, prepare playbook not configured.
--> Scenario: 'default'
--> Action: 'converge'

    PLAY [Converge] ****************************************************************

    TASK [Gathering Facts] *********************************************************
    fatal: [instance]: UNREACHABLE! => {"changed": false, "msg": "ntlm: invalid server_cert_validation mode: True", "unreachable": true}

    PLAY RECAP *********************************************************************
    instance                   : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0

ERROR:
(snip)
```

If to execute the test with winrm_server_cert_validation set to `False`, the following error will occur.

```
(snip)
--> Scenario: 'default'
--> Action: 'prepare'
Skipping, prepare playbook not configured.
--> Scenario: 'default'
--> Action: 'converge'

    PLAY [Converge] ****************************************************************

    TASK [Gathering Facts] *********************************************************
    fatal: [instance]: UNREACHABLE! => {"changed": false, "msg": "ntlm: HTTPSConnectionPool(host='192.168.0.10', port=5986): Max retries exceeded with url: /wsman (Caused by SSLError(SSLError(\"bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)\",),))", "unreachable": true}

    PLAY RECAP *********************************************************************
    instance                   : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0

ERROR:
(snip)
```

If to specify `ignore`, the connection to the test instance will succeed.

#### PR Type
- Docs Pull Request
