### PR TITLE
Temporarily limit setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >= 41.0.0",
+  "setuptools == 41.0.0",  # See https://github.com/ansible/molecule/issues/2350
   "setuptools_scm >= 1.15.0",
   "setuptools_scm_git_archive >= 1.0",
   "wheel",


### PR DESCRIPTION
See https://github.com/ansible/molecule/issues/2350.

In the absence of any answers right now, let's keep the ball rolling with this temporary  fix.