### PR TITLE
Focus on CentOS 7 for CI testing

### DIFF
--- a/molecule/test/functional/docker/test_scenarios.py
+++ b/molecule/test/functional/docker/test_scenarios.py
@@ -221,7 +221,10 @@ def test_command_test_builds_local_molecule_image(
     scenario_to_test, with_scenario, scenario_name, driver_name
 ):
     try:
-        cmd = sh.docker.bake('rmi', 'molecule_local/centos:latest', '--force')
+        version = os.environ.get('TEST_CENTOS_VERSION', 7)
+        cmd = sh.docker.bake(
+            'rmi', 'molecule_local/centos:{}'.format(version), '--force'
+        )
         pytest.helpers.run_command(cmd)
     except sh.ErrorReturnCode:
         pass

--- a/molecule/test/resources/molecule_docker.yml
+++ b/molecule/test/resources/molecule_docker.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   lint:

--- a/molecule/test/resources/playbooks/delegated/create/docker.yml
+++ b/molecule/test/resources/playbooks/delegated/create/docker.yml
@@ -3,7 +3,7 @@
   docker_container:
     name: delegated-instance-docker
     hostname: delegated-instance-docker
-    image: molecule_local/centos:latest
+    image: molecule_local/centos:${TEST_CENTOS_VERSION}
     recreate: false
     log_driver: json-file
     command: sleep infinity

--- a/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/cleanup/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     command: /sbin/init
     privileged: true
 provisioner:

--- a/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/ansible-galaxy/molecule.yml
@@ -14,7 +14,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/dependency/molecule/gilt/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/gilt/molecule.yml
@@ -14,7 +14,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/molecule/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -15,7 +15,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/driver/docker/molecule/ansible-verifier/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/ansible-verifier/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     networks:
       - name: foo
       - name: bar

--- a/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     networks:
       - name: foo
       - name: bar

--- a/molecule/test/scenarios/driver/docker/molecule/multi-node/molecule.yml
+++ b/molecule/test/scenarios/driver/docker/molecule/multi-node/molecule.yml
@@ -9,14 +9,14 @@ lint:
     config-file: ../../../resources/.yamllint
 platforms:
   - name: instance-1
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     groups:
       - foo
       - bar
     buildargs:
       testarg: this_is_a_test
   - name: instance-2
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     groups:
       - foo
       - baz

--- a/molecule/test/scenarios/host_group_vars/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/host_group_vars/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     groups:
       - example
     children:

--- a/molecule/test/scenarios/host_group_vars/molecule/links/molecule.yml
+++ b/molecule/test/scenarios/host_group_vars/molecule/links/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     groups:
       - example
     children:

--- a/molecule/test/scenarios/idempotence/molecule/raises/molecule.yml
+++ b/molecule/test/scenarios/idempotence/molecule/raises/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/interpolation/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: $INSTANCE_NAME
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/overrride_driver/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/overrride_driver/molecule/default/molecule.yml
@@ -12,7 +12,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/plugins/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/plugins/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/side_effect/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     command: /sbin/init
     privileged: true
 provisioner:

--- a/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/verifier/molecule/testinfra-pre-commit/molecule.yml
+++ b/molecule/test/scenarios/verifier/molecule/testinfra-pre-commit/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/test/scenarios/verifier/molecule/testinfra/molecule.yml
+++ b/molecule/test/scenarios/verifier/molecule/testinfra/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: ../../resources/.yamllint
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/unit/model/v2/test_pre_validate.py
+++ b/molecule/test/unit/model/v2/test_pre_validate.py
@@ -97,7 +97,7 @@ lint:
   name: $MOLECULE_LINT_NAME
 platforms:
   - name: instance
-    image: centos:latest
+    image: centos:${TEST_CENTOS_VERSION}
     networks:
       - name: foo
       - name: bar

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ passenv = *
 setenv =
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     PYTHONDONTWRITEBYTECODE=1
+    TEST_CENTOS_VERSION=7
     # -n auto used only on unit as is not supported by functional yet
     unit: PYTEST_ADDOPTS=molecule/test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {env:PYTEST_ADDOPTS:-n auto}
     functional: PYTEST_ADDOPTS=molecule/test/functional/ {env:PYTEST_ADDOPTS:}


### PR DESCRIPTION
Closes https://github.com/ansible/molecule/issues/2349.

Of course, we don't resolve the issue that anyone using CentOS 8 docker images will now have their builds broken by Molecule because it cannot match the packages that are pre-installed but we leave that until the bug report rolls in (or someone gets to it). 

This fixes the CI now as we will simply support CentOS 7 images (`:7` tag) in testing.

We can control this from the environment now with `TEST_CENTOS_VERSION`.