### PR TITLE
Support using ~/path/to/foo ansible environment

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -407,6 +407,10 @@ class Ansible(base.Base):
 
     @property
     def default_env(self):
+        # Allow user to use ~/path/to/foo in environment variables
+        for key, value in self._config.env.items():
+            self._config.env[key] = os.path.expanduser(value)
+
         env = util.merge_dicts(os.environ.copy(), self._config.env)
         env = util.merge_dicts(
             env,


### PR DESCRIPTION
Allow for the ability to use ~ in ansible environment variables. For example:

  provisioner:
    name: ansible
    env:
      ANSIBLE_ROLES_PATH: ~/.ansible/roles

#### PR Type

- Bugfix Pull Request