### PR TITLE
Enable release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Management
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should automate create of release notes, so our users will be better informed of what went in on each new release.

This github workflow keeps a draft release updated with all merged
changes so when we want to make a new release we already have the full
changelist created.

I initially adopted this workflow on few other projects and I am really
pleased about the results:

* https://github.com/pycontribs/pytest-molecule/releases
* https://github.com/pycontribs/selinux/releases
* https://github.com/pycontribs/jira/releases

#### PR Type

- Feature Pull Request
