### PR TITLE
Enable testing of dockerfile template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,9 @@ jobs:
         - TOXENV=doc
 
     - <<: *lint
-      name: check,build-docker
+      name: check,dockerfile,build-docker
       env:
-        - TOXENV=check,build-docker
+        - TOXENV=check,dockerfile,build-docker
 
     - <<: *py-37
       env:

--- a/molecule/data/validate-dockerfile.yml
+++ b/molecule/data/validate-dockerfile.yml
@@ -1,0 +1,49 @@
+#!/usr/bin/env ansible-playbook
+---
+- hosts: localhost
+  vars:
+    platforms:
+      - image: centos:7
+      - image: centos:8
+      - image: ubuntu:latest
+      - image: debian:latest
+  tasks:
+
+    - name: create temporary dockerfiles
+      tempfile:
+        prefix: "molecule-dockerfile-{{ item.image }}"
+        suffix: build
+      register: temp_dockerfiles
+      with_items: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.image }}"
+
+    - name: expand Dockerfile templates
+      template:
+        src: Dockerfile.j2
+        dest: "{{ temp_dockerfiles.results[index].path }}"
+      register: result
+      with_items: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.image }}"
+
+    - name: Test Dockerfile template
+      docker_image:
+        name: "{{ item.item.image }}"
+        build:
+          path: "."
+          dockerfile: "{{ item.dest }}"
+          from_source: true
+          pull: true
+          nocache: true
+        source: build
+        state: present
+        debug: true
+        force_source: true
+      with_items: "{{ result.results }}"
+      loop_control:
+        label: "{{ item.item.image }}"
+      register: result
+
+    - debug: var=result

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     check
     py{27,35,36,37}-ansible{27,28,29}-{functional,unit}
     doc
+    dockerfile
 skipdist = True
 skip_missing_interpreters = True
 isolated_build = True
@@ -30,6 +31,7 @@ deps =
     ansible29: git+https://github.com/ansible/ansible.git@stable-2.9
     # ^ after release change to ansible>=2.9,<2.10
     ansibledevel: git+https://github.com/ansible/ansible.git
+    dockerfile: ansible>=2.8
 extras =
     docker
     ec2
@@ -78,6 +80,13 @@ commands =
     'docs_dir = pathlib.Path(r"{toxworkdir}") / "docs_out"; index_file = docs_dir / "index.html"; print(f"\nDocumentation available under `file://\{index_file\}`\n\nTo serve docs, use `python3 -m http.server --directory \{docs_dir\} 0`\n")'
 extras =
     docs
+
+[testenv:dockerfile]
+description = Tests validity of embedded Dockerfile template used by docker driver
+commands =
+    ansible-playbook molecule/data/validate-dockerfile.yml
+extras =
+    docker
 
 # generic environment that should cover anything that is not a linter or a unit/functional test
 [testenv:check]


### PR DESCRIPTION
Enable testing of dockerfile template

This should add a new tox environment for testing the validity of our
embedded dockerfile across the supported image list.
