### PR TITLE
Bumped linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v2.2.3
+    rev: v2.3.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -24,7 +24,7 @@ repos:
           - flake8-mypy
         language_version: python3
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.16.0
+    rev: v1.18.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/.yamllint
+++ b/.yamllint
@@ -13,4 +13,7 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
+  document-start: disable
   line-length: disable
+  truthy:
+    allowed-values: ['true', 'false', 'on']


### PR DESCRIPTION
Also includes two linting changes needed for enabling github workflows
because updating these is not possible with normal pull requests. This
means that we first need to update lint config in order to make
https://github.com/ansible/molecule/pull/2367 pass CI testing.
