### PR TITLE
Added instance_profile_name to ec2 driver

### DIFF
--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -82,6 +82,7 @@
           else {'instance': item.name} }}"
         wait: true
         assign_public_ip: true
+        instance_profile_name: "{{ item.instance_profile_name | default(omit) }}"
         exact_count: 1
         count_tag:
           instance: "{{ item.name }}"

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -87,6 +87,20 @@ class EC2(Driver):
             instance_type: t2.micro
             vpc_subnet_id: subnet-1cb17175
 
+    If you want to attach an IAM role to the Molecule instance:
+
+    .. code-block:: yaml
+
+        driver:
+          name: ec2
+        platforms:
+          - name: instance
+            image_owner: 099720109477
+            image_name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190320
+            instance_type: t2.micro
+            vpc_subnet_id: subnet-1cb17175
+            instance_profile_name: example-iam-role
+
     Use wildcards for getting the latest image. For example, the latest Ubuntu bionic image:
 
     .. code-block:: yaml

--- a/molecule/test/resources/playbooks/ec2/create.yml
+++ b/molecule/test/resources/playbooks/ec2/create.yml
@@ -88,6 +88,7 @@
           instance: "{{ item.name }}"
         wait: true
         assign_public_ip: true
+        instance_profile_name: "{{ item.instance_profile_name | default(omit) }}"
         exact_count: 1
         count_tag:
           instance: "{{ item.name }}"

--- a/molecule/test/scenarios/driver/ec2/molecule/default/molecule.yml
+++ b/molecule/test/scenarios/driver/ec2/molecule/default/molecule.yml
@@ -12,6 +12,7 @@ platforms:
     image: ami-a5b196c0
     instance_type: t2.micro
     vpc_subnet_id: subnet-6456fd1f
+    instance_profile_name: instance-profile
 provisioner:
   name: ansible
   config_options:

--- a/molecule/test/scenarios/driver/ec2/molecule/multi-node/molecule.yml
+++ b/molecule/test/scenarios/driver/ec2/molecule/multi-node/molecule.yml
@@ -12,6 +12,7 @@ platforms:
     image: ami-a5b196c0
     instance_type: t2.micro
     vpc_subnet_id: subnet-6456fd1f
+    instance_profile_name: instance-profile
     groups:
       - foo
       - bar
@@ -19,6 +20,7 @@ platforms:
     image: ami-a5b196c0
     instance_type: t2.micro
     vpc_subnet_id: subnet-6456fd1f
+    instance_profile_name: instance-profile
     groups:
       - foo
       - baz

--- a/molecule/test/unit/driver/test_ec2.py
+++ b/molecule/test/unit/driver/test_ec2.py
@@ -217,6 +217,14 @@ def test_get_instance_config(mocker, _instance):
     assert x == _instance._get_instance_config('foo')
 
 
+def test_get_instance_profile(mocker, _instance):
+    m = mocker.patch('molecule.util.safe_load_file')
+    m.return_value = [{'instance': 'foo', 'instance_profile_name': 'instance-profile'}]
+
+    x = {'instance': 'foo', 'instance_profile_name': 'instance-profile'}
+    assert x == _instance._get_instance_config('foo')
+
+
 def test_created(_instance):
     assert 'false' == _instance._created()
 


### PR DESCRIPTION
- Added instance_profile_name to EC2 driver (optional and backward compatible)

## How to use it

- Create role using EC2 driver: `molecule init role -r test-ec2 -d ec2`
- Add `instance_profile_name` to `platforms` on molecule.yml