### PR TITLE
Test ansible 2.9 from stable-2.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,8 @@ setenv =
 deps =
     ansible27: ansible>=2.7,<2.8
     ansible28: ansible>=2.8,<2.9
-    ansible29: ansible>=2.9.0b1,<2.10
+    ansible29: git+https://github.com/ansible/ansible.git@stable-2.9
+    # ^ after release change to ansible>=2.9,<2.10
     ansibledevel: git+https://github.com/ansible/ansible.git
 extras =
     docker


### PR DESCRIPTION
Temporary use stable-29 branch to test ansible 2.9

Avoids being blocked by currently broken pre-releases. We will move to
standard ranges once a release is made.

This unblocks our CI.