### PR TITLE
Remove use of future

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ ENV PACKAGES="\
     py3-cryptography \
     py3-docutils \
     py3-flake8 \
-    py3-future \
     py3-idna \
     py3-jinja2 \
     py3-mccabe \
@@ -88,7 +87,6 @@ ENV PACKAGES="\
     py3-cryptography \
     py3-docutils \
     py3-flake8 \
-    py3-future \
     py3-idna \
     py3-jinja2 \
     py3-mccabe \

--- a/molecule/api.py
+++ b/molecule/api.py
@@ -1,4 +1,4 @@
-from future.moves.collections import UserList
+from six.moves import UserList
 import pluggy
 from molecule import logger
 from molecule.util import lru_cache


### PR DESCRIPTION
Future was thowing some deprecation warnings (py37), is mainly unmaintained and it wasn't even listed as dependency of molecule. As we already already have six listed as a dependency and used in multiple places we can easily drop it.

#### PR Type

- Bugfix Pull Request

