### PR TITLE
Implement tox setup idempotency test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -351,4 +351,7 @@ jobs:
 before_install:
   - pip install tox-tags
 script:
+  # keep it like this to first create env and later to run again with tests
+  # in order to avoid regressions to run twice on the same environment.
+  - tox --notest
   - tox


### PR DESCRIPTION
As we encountered case where initial creation of the virtualenv with tox
worked fine but attempt to run again on it was trigerring #2350 we
add a CI test that should prevent this from happenign again.