### PR TITLE
Reverts setuptools workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [build-system]
 requires = [
-  "setuptools_scm >= 1.15.0",
-  "setuptools_scm_git_archive >= 1.0",
-  "wheel",
+  "pip >= 19.3.1",
+  "setuptools >= 41.4.0",
+  "setuptools_scm >= 3.3.3",
+  "setuptools_scm_git_archive >= 1.1",
+  "wheel >= 0.33.6",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Goes back to `setuptools >= 41.0.0` for build time as missing to mention
it would generate a failure to install from source in editable mode.
