### PR TITLE
WIP: Updated linting to run in related test sequence per #2344

### DIFF
--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -77,6 +77,7 @@ class Converge(base.Base):
         :return: None
         """
         self.print_info()
+        self._config.provisioner.lint.execute()
         self._config.provisioner.converge()
         self._config.state.change_state('converged', True)
 

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -72,8 +72,6 @@ class Lint(base.Base):
             l
             for l in [
                 self._config.lint,
-                self._config.verifier.lint,
-                self._config.provisioner.lint,
             ]
             if l
         ]

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -68,6 +68,7 @@ class Verify(base.Base):
         :return: None
         """
         self.print_info()
+        self._config.verifier.lint.execute()
         self._config.verifier.execute()
 
 


### PR DESCRIPTION
Modifying the way that molecule runs linting steps per #2344

- `molecule lint` will now only run the main yamllint against the role
- `molecule verify` and `molecule converge` will now run the linting specified in their respective sections of the molecule.yml file