### PR TITLE
ec2: add common prefix to allocated resources

### DIFF
--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -8,8 +8,9 @@
   vars:
     ssh_user: ubuntu
     ssh_port: 22
+    default_region: "{{ lookup('env', 'AWS_DEFAULT_REGION') | default('us-east-1', true) }}"
 
-    security_group_name: molecule
+    security_group_name_prefix: molecule
     security_group_description: Security group for testing Molecule
     security_group_rules:
       - proto: tcp
@@ -29,41 +30,64 @@
     keypair_name: molecule_key
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
+    - name: Check subnet
+      ec2_vpc_subnet_facts:
+        region: "{{ item.region|default(default_region) }}"
+        filters:
+          subnet-id: "{{ item.vpc_subnet_id }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: subnet_facts
+
+    - name: Populate subnet vpc
+      set_fact:
+        subnet_dict: "{{ subnet_dict|default({}) | combine({ item.subnets[0].id: item.subnets[0].vpc_id }) }}"
+      with_items: "{{ subnet_facts.results }}"
+
     - name: Create security group
       ec2_group:
-        name: "{{ security_group_name }}"
-        description: "{{ security_group_name }}"
+        name: "{{ security_group_name_prefix }}-{{ subnet_dict[item.vpc_subnet_id] }}"
+        description: "{{ security_group_description }}"
         rules: "{{ security_group_rules }}"
         rules_egress: "{{ security_group_rules_egress }}"
+        vpc_id: "{{ subnet_dict[item.vpc_subnet_id] }}"
+        region: "{{ item.region|default(default_region) }}"
+      with_items: "{{ molecule_yml.platforms }}"
 
     - name: Test for presence of local keypair
       stat:
-        path: "{{ keypair_path }}"
+        path: "{{ keypair_path }}-{{ item.region|default(default_region) }}"
+      with_items: "{{ molecule_yml.platforms }}"
       register: keypair_local
 
     - name: Delete remote keypair
       ec2_key:
         name: "{{ keypair_name }}"
         state: absent
-      when: not keypair_local.stat.exists
+        region: "{{ item.item.region|default(default_region) }}"
+      with_items: "{{ keypair_local.results}}"
+      when: not item.stat.exists
 
     - name: Create keypair
       ec2_key:
         name: "{{ keypair_name }}"
+        region: "{{ item.region|default(default_region) }}"
+      with_items: "{{ molecule_yml.platforms }}"
       register: keypair
 
     - name: Persist the keypair
       copy:
-        dest: "{{ keypair_path }}"
-        content: "{{ keypair.key.private_key }}"
+        dest: "{{ keypair_path }}-{{ item.invocation.module_args.region }}"
+        content: "{{ item.key.private_key }}"
         mode: 0600
-      when: keypair.changed
+      with_items: "{{ keypair.results }}"
+      when: item.key.private_key is defined
 
     - name: Get the ec2 ami(s) by owner and name, if image not set
       ec2_ami_facts:
         owners: "{{ item.image_owner }}"
         filters:
           name: "{{ item.image_name }}"
+        region: "{{ item.region|default(default_region) }}"
       loop: "{{ molecule_yml.platforms }}"
       when: item.image is not defined
       register: ami_facts
@@ -76,15 +100,24 @@
           else (ami_facts.results[index].images | sort(attribute='creation_date', reverse=True))[0].image_id }}"
         instance_type: "{{ item.instance_type }}"
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
-        group: "{{ security_group_name }}"
-        instance_tags: "{{ item.instance_tags | combine({'instance': item.name})
-          if item.instance_tags is defined
-          else {'instance': item.name} }}"
+        group: "{{ security_group_name_prefix }}-{{ subnet_dict[item.vpc_subnet_id] }}"
+        instance_tags: "{{
+            item.instance_tags | combine({
+              'Name': item.name,
+              'ssh_user': item.ssh_user|default(ssh_user)
+            })
+            if item.instance_tags is defined
+            else {
+                'Name': item.name,
+                'ssh_user': item.ssh_user|default(ssh_user)
+            }
+        }}"
         wait: true
         assign_public_ip: true
         exact_count: 1
         count_tag:
-          instance: "{{ item.name }}"
+          Name: "{{ item.name }}"
+        region: "{{ item.region|default(default_region) }}"
       register: server
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
@@ -105,12 +138,14 @@
     - name: Populate instance config dict
       set_fact:
         instance_conf_dict: {
-          'instance': "{{ item.instances[0].tags.instance }}",
-          'address': "{{ item.instances[0].public_ip }}",
-          'user': "{{ ssh_user }}",
+          'instance': "{{ item.tagged_instances[0].tags.Name }}",
+          'address': "{{ item.tagged_instances[0].public_ip }}",
+          'user': "{{ item.tagged_instances[0].tags.ssh_user }}",
           'port': "{{ ssh_port }}",
-          'identity_file': "{{ keypair_path }}",
-          'instance_ids': "{{ item.instance_ids }}", }
+          'identity_file': "{{ keypair_path }}-{{ item.tagged_instances[0].region }}",
+          'instance_id': "{{ item.tagged_instances[0].id }}",
+          'region': "{{ item.tagged_instances[0].region }}",
+        }
       with_items: "{{ ec2_jobs.results }}"
       register: instance_config_dict
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -20,7 +20,8 @@
     - name: Destroy molecule instance(s)
       ec2:
         state: absent
-        instance_ids: "{{ item.instance_ids }}"
+        instance_ids: "{{ item.instance_id }}"
+        region: "{{ item.region }}"
       register: server
       with_items: "{{ instance_conf }}"
       when: not skip_instances
@@ -34,6 +35,7 @@
       until: ec2_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+      when: not skip_instances
 
     # Mandatory configuration for Molecule to function.
 


### PR DESCRIPTION
* support multiple Regions
* support multiple VPCs in one Region
* support CentOS and Debian images
* correctly populate instance name via Tags


> Please include details of what it is, how to use it, how it's been tested
> Please include an entry in the CHANGELOG.md if the change will impact users.

changes are backward compatible and shouldn't affect current users
**NB:** it is needed to modify `molecule/default/molecule.yml` for the right values which are individual for each account.


#### How to test
```
platforms:
  - name: centos-7
    region: eu-central-1
    image: ami-0837950ffca9ae6e8
    vpc_subnet_id: subnet-xxxxxx
    instance_type: t3.micro
    ssh_user: centos
    instance_tags:
      iit-billing-tag: molecule-worker
  - name: rhel-8
    region: us-east-1
    image: ami-098bb5d92c8886ca1
    vpc_subnet_id: subnet-xxxxxx
    instance_type: t2.micro
    ssh_user: ec2-user
    instance_tags:
      iit-billing-tag: jenkins-pg-worker
```

#### PR Type
- Bugfix Pull Request