### PR TITLE
Added support for internal CIDR

### DIFF
--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -15,11 +15,13 @@
       - proto: tcp
         from_port: "{{ ssh_port }}"
         to_port: "{{ ssh_port }}"
-        cidr_ip: '0.0.0.0/0'
+        cidr_ip: "{{ molecule_yml.driver.internal_cidr |
+          default('0.0.0.0/0') }}"
       - proto: icmp
         from_port: 8
         to_port: -1
-        cidr_ip: '0.0.0.0/0'
+        cidr_ip: "{{ molecule_yml.driver.internal_cidr |
+          default('0.0.0.0/0') }}"
     security_group_rules_egress:
       - proto: -1
         from_port: 0
@@ -107,7 +109,9 @@
       set_fact:
         instance_conf_dict: {
           'instance': "{{ item.instances[0].tags.instance }}",
-          'address': "{{ item.instances[0].public_ip }}",
+          'address': "{{ item.instances[0].private_ip
+            if molecule_yml.driver.internal_cidr is defined
+            else item.instances[0].public_ip }}",
           'user': "{{ ssh_user }}",
           'port': "{{ ssh_port }}",
           'identity_file': "{{ keypair_path }}",

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -15,12 +15,12 @@
       - proto: tcp
         from_port: "{{ ssh_port }}"
         to_port: "{{ ssh_port }}"
-        cidr_ip: "{{ molecule_yml.driver.internal_cidr |
+        cidr_ip: "{{ molecule_yml.driver.cidr_ip |
           default('0.0.0.0/0') }}"
       - proto: icmp
         from_port: 8
         to_port: -1
-        cidr_ip: "{{ molecule_yml.driver.internal_cidr |
+        cidr_ip: "{{ molecule_yml.driver.cidr_ip |
           default('0.0.0.0/0') }}"
     security_group_rules_egress:
       - proto: -1
@@ -110,7 +110,7 @@
         instance_conf_dict: {
           'instance': "{{ item.instances[0].tags.instance }}",
           'address': "{{ item.instances[0].private_ip
-            if molecule_yml.driver.internal_cidr is defined
+            if molecule_yml.driver.cidr_ip is defined
             else item.instances[0].public_ip }}",
           'user': "{{ ssh_user }}",
           'port': "{{ ssh_port }}",


### PR DESCRIPTION
Right now the ec2 instances created by molecule allow an ingress rule to `0.0.0.0/0` on the ssh port.

As we have a restrictive security policy, we only allow ssh traffic from within the subnet, therefore we need to be able to specify the CIDR that is allowed to ssh into the molecule ec2 instance.

As there can be multiple platforms I've decided to set up the configuration in the `molecule.yml` under the `driver` section. Although I don't know if it's the best place.

```yaml
driver:
  name: ec2
  internal_cidr: 192.168.100.0/24
```

Changes are backward compatible and shouldn't affect current users.

#### PR Type

- Feature Pull Request
