### PR TITLE
ec2 provider: Add support for specifying ssh keypair

### DIFF
--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -27,7 +27,10 @@
         cidr_ip: '0.0.0.0/0'
 
     keypair_name: molecule_key
-    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+    molecule_keypair_path: "{{
+      lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+    keypair_path: "{{
+      molecule_yml.driver.keypair_path | default(molecule_keypair_path) }}"
   tasks:
     - name: Create security group
       ec2_group:
@@ -47,17 +50,35 @@
         state: absent
       when: not keypair_local.stat.exists
 
+    - name: Test for presence of local keypair public key
+      stat:
+        path: "{{ keypair_path }}.pub"
+      register: keypair_public_local
+      when: keypair_local.stat.exists
+
+    - name: Upload selected keypair
+      ec2_key:
+        name: "{{ keypair_name }}"
+        key_material: "{{ lookup('file', '{{ keypair_path }}.pub') }}"
+      register: keypair
+      when:
+        - keypair_local.stat.exists
+        - keypair_public_local.stat.exists
+
     - name: Create keypair
       ec2_key:
         name: "{{ keypair_name }}"
       register: keypair
+      when: not keypair_public_local.stat.exists
 
     - name: Persist the keypair
       copy:
         dest: "{{ keypair_path }}"
         content: "{{ keypair.key.private_key }}"
         mode: 0600
-      when: keypair.changed
+      when:
+        - keypair.changed
+        - not keypair_public_local.stat.exists
 
     - name: Get the ec2 ami(s) by owner and name, if image not set
       ec2_ami_facts:


### PR DESCRIPTION
Right now each time a molecule job is run with the ec2 provider, a new key ssh key is created into AWS with the name `molecule_key`.

This means that if several CI jobs are run at the same time, they will have a racing condition, and one of them is going to fail because it can't connect to the created instance.

So in this PR, I add the opportunity to use a specific ssh private key, instead of generating one each job.

As there can be multiple platforms I've decided to set up the configuration in the `molecule.yml` under the `driver` section. 

```yaml
driver:
  name: ec2
  keypair_path: /path/to/ssh/private/key
```

Changes are backward compatible and shouldn't affect current users.

#### PR Type

- Feature Pull Request