### PR TITLE
Include registry in default base test images

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -17,7 +17,7 @@ platforms:
     size_id: s-1vcpu-1gb
 {%- elif cookiecutter.driver_name == 'docker' %}
   - name: instance
-    image: centos:7
+    image: docker.io/centos:7
 {%- elif cookiecutter.driver_name == 'ec2' %}
   - name: instance
     image: ami-a5b196c0
@@ -44,7 +44,7 @@ platforms:
     flavor: NO-Nano
 {%- elif cookiecutter.driver_name == 'podman' %}
   - name: instance
-    image: centos:7
+    image: docker.io/centos:7
 {%- elif cookiecutter.driver_name == 'vagrant' %}
   - name: instance
     box: ubuntu/xenial64

--- a/molecule/test/functional/docker/test_scenarios.py
+++ b/molecule/test/functional/docker/test_scenarios.py
@@ -221,7 +221,7 @@ def test_command_test_builds_local_molecule_image(
     scenario_to_test, with_scenario, scenario_name, driver_name
 ):
     try:
-        image = os.environ.get('TEST_BASE_IMAGE', "pycontribs/centos:7")
+        image = os.environ.get('TEST_BASE_IMAGE', "docker.io/pycontribs/centos:7")
         cmd = sh.docker.bake('rmi', 'molecule_local/{}'.format(image), '--force')
         pytest.helpers.run_command(cmd)
     except sh.ErrorReturnCode:

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv = *
 setenv =
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
     PYTHONDONTWRITEBYTECODE=1
-    TEST_BASE_IMAGE=pycontribs/centos:7
+    TEST_BASE_IMAGE=docker.io/pycontribs/centos:7
     # -n auto used only on unit as is not supported by functional yet
     unit: PYTEST_ADDOPTS=molecule/test/unit/ --cov={toxinidir}/molecule/ --no-cov-on-fail {env:PYTEST_ADDOPTS:-n auto}
     functional: PYTEST_ADDOPTS=molecule/test/functional/ {env:PYTEST_ADDOPTS:}


### PR DESCRIPTION
By including the registry in the base test image we assure that we
can use it with both docker and podman as the former one may not have
a default registry already configured.
