### PR TITLE
test: implement workaround for galaxy-install 401 errors

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,12 @@
+import os
+import pytest
+
 pytest_plugins = ['helpers_namespace']
+
+
+@pytest.fixture(scope="session", autouse=True)
+def environ():
+    # disable use of .netrc file to avoid galaxy-install errors with:
+    # [ERROR]: failed to download the file: HTTP Error 401: Unauthorized
+    # https://github.com/ansible/ansible/issues/61666
+    os.environ['NETRC'] = ''


### PR DESCRIPTION
This should address failure to install galaxy roles during testing. You
may need it even for production.

See https://github.com/ansible/ansible/issues/61666
