### PR TITLE
Adds vpc_id to ec2_group, from subnet facts, and allows to specify SG ip cidr

### DIFF
--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -32,12 +32,47 @@
     keypair_path: "{{
       molecule_yml.driver.keypair_path | default(molecule_keypair_path) }}"
   tasks:
+    - name: Get current public IP
+      ipify_facts:
+
+    - name: Set allowed ingress Security Group IP from current public IP
+      set_fact:
+        allowed_ip_cidr: "{{ ipify_public_ip }}/32"
+      when: (item.auto_public_ip is defined) and (item.auto_public_ip == True)
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Set allowed ingress Security Group IP
+      set_fact:
+        allowed_ip_cidr: "{{ item.allowed_ip_cidr }}"
+      when: item.allowed_ip_cidr is defined
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Set Security Group Rules for allowed ingress IP
+      set_fact:
+        security_group_rules:
+          - proto: tcp
+            from_port: "{{ ssh_port }}"
+            to_port: "{{ ssh_port }}"
+            cidr_ip: "{{ allowed_ip_cidr }}"
+          - proto: icmp
+            from_port: 8
+            to_port: -1
+            cidr_ip: "{{ allowed_ip_cidr }}"
+      when: allowed_ip_cidr is defined
+
+    - name: Gather facts about VPC from vpc_subnet_id
+      ec2_vpc_subnet_facts:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ molecule_yml.platforms }}"
+      register: subnet_facts
+
     - name: Create security group
       ec2_group:
         name: "{{ security_group_name }}"
         description: "{{ security_group_name }}"
         rules: "{{ security_group_rules }}"
         rules_egress: "{{ security_group_rules_egress }}"
+        vpc_id:  "{{ subnet_facts.vpc_id }}"
 
     - name: Test for presence of local keypair
       stat:


### PR DESCRIPTION
- Added VPC ID to EC2 Group (otherwise, it creates an EC2-Classic Security Group)
Based on #2230
- Added support for other IP CIDRs different than 0.0.0.0/0

## How to use it

### VPC ID
- Create role using EC2 driver: `molecule init role -r test-ec2 -d ec2`
- Include `vpc_subnet_id` to your platform on `molecule.yml`

### IP CIDR
- Create role using EC2 driver: `molecule init role -r test-ec2 -d ec2
- Either include `allowed_ip_cidr` to the platforms (to specify a CIDR) or `auto_public_ip` (to make it use your current public IP). If you include none of these, the default will be 0.0.0.0/0.