### PR TITLE
Fixed SG per VPC creation and SSH keypair error on ec2

### DIFF
--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -74,7 +74,8 @@
         description: "{{ security_group_name }}"
         rules: "{{ security_group_rules }}"
         rules_egress: "{{ security_group_rules_egress }}"
-        vpc_id:  "{{ subnet_facts.vpc_id }}"
+        vpc_id:  "{{ item.vpc_id }}"
+      loop: "{{ subnet_facts.results.0.subnets }}"
 
     - name: Test for presence of local keypair
       stat:

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -92,7 +92,6 @@
       stat:
         path: "{{ keypair_path }}.pub"
       register: keypair_public_local
-      when: keypair_local.stat.exists
 
     - name: Upload selected keypair
       ec2_key:


### PR DESCRIPTION
This PR fixes:

- Lack of iterator for subnet facts when creating a security group, introduced by #2405
- Dict breaking when check if a public key existed, introduced by #2389