### PR TITLE
Disable DCO

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,3 +1,0 @@
----
-require:
-  members: false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -80,7 +80,7 @@ Contribution Guidelines
 * Check for unnecessary whitespace with ``git diff --check`` before committing.
   Please see `formatting`_ and `linting`_ documentation for further commands.
 * Make sure you have added tests for your changes.
-* You must use ``git commit --signoff`` for any commit to be merged, and agree
+* Although not require, it is good to sign off commits using ``git commit --signoff``, and agree
   that usage of ``--signoff`` constitutes agreement with the terms of `DCO 1.1`_.
 
 * Run all the tests to ensure nothing else was accidentally broken.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -80,7 +80,7 @@ Contribution Guidelines
 * Check for unnecessary whitespace with ``git diff --check`` before committing.
   Please see `formatting`_ and `linting`_ documentation for further commands.
 * Make sure you have added tests for your changes.
-* Although not require, it is good to sign off commits using ``git commit --signoff``, and agree
+* Although not required, it is good to sign off commits using ``git commit --signoff``, and agree
   that usage of ``--signoff`` constitutes agreement with the terms of `DCO 1.1`_.
 
 * Run all the tests to ensure nothing else was accidentally broken.


### PR DESCRIPTION
fixes #1548
fixes #1988

Disable DCO as Molecule is viewed to be "small" by certain metrics. And DCO has been a continued bar to entry for contributors.

If/when GitHub makes it easier to do signoff's via the UI we may revisit this

GitHub app has now been disabled for `gh/ansible/molecule`, this PR tidies up the codebase.

Signed-off-by: John Barker <john@johnrbarker.com>


Please include details of what it is, how to use it, how it's been tested
Please include an entry in the CHANGELOG.md if the change will impact users.

#### PR Type


- Feature Pull Request
