### PR TITLE
Bump ansible-lint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     ansible >= 2.5
-    ansible-lint >= 4.0.2, < 5
+    ansible-lint >= 4.1.1a2, < 5
 
     anyconfig >= 0.9.10
     backports.functools_lru_cache; python_version<"3.3"


### PR DESCRIPTION
This avoids installation errors caused by old version being incompatible
with newer versions of setuptools.