### PR TITLE
Fixed molecule init scenario

### DIFF
--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -155,7 +155,7 @@ def _default_scenario_exists(ctx, param, value):  # pragma: no cover
 @click.option(
     '--driver-name',
     '-d',
-    type=click.Choice(api.drivers()),
+    type=click.Choice([str(s) for s in api.drivers()]),
     default='docker',
     help='Name of driver to initialize. (docker)',
 )


### PR DESCRIPTION
Avoid error like below:

  File ".../site-packages/click/types.py", line 149, in get_metavar
    return '[%s]' % '|'.join(self.choices)
TypeError: sequence item 0: expected str instance, <DriverClass> found

This adopts the same code from init-role which was working correctly.
