### PR TITLE
docs: avoid simplejson error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ install_requires =
 
 [options.extras_require]
 docs =
+    simplejson
     Sphinx
     sphinx_rtd_theme
 docker =


### PR DESCRIPTION
Avoid what appears to be a bug in anyconfig by installing simplejson library.

Fixes: #2421
