### PR TITLE
Avoid adding UUID twice to platform in parallel mode

### DIFF
--- a/molecule/provisioner/ansible/plugins/filter/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filter/molecule_core.py
@@ -43,9 +43,7 @@ def from_yaml(data):
     i = interpolation.Interpolator(interpolation.TemplateWithDefaults, env)
     interpolated_data = i.interpolate(data)
 
-    loaded_data = util.safe_load(interpolated_data)
-    loaded_data = _parallelize_config(loaded_data)
-    return loaded_data
+    return util.safe_load(interpolated_data)
 
 
 def to_yaml(data):
@@ -65,15 +63,6 @@ def get_docker_networks(data):
                     name = network['name']
                     network_list.append(name)
     return network_list
-
-
-def _parallelize_config(data):
-    if 'platforms' not in data:
-        return data
-    state = util.safe_load_file(os.environ['MOLECULE_STATE_FILE'])
-    if state.get('is_parallel', False):
-        data['platforms'] = util._parallelize_platforms(data, state['run_uuid'])
-    return data
 
 
 class FilterModule(object):


### PR DESCRIPTION
Since commit 3b8c8d03, we are placing merged molecule config into the ephemeral directory of the scenario currently being acted upon. This configuration file already contains preprocessed platform names if we run molecule in parallel mode.

Because we forgot to remove the platform name mangling from the filter that is responsible for loading the config file and exposing its content to the playbook tasks, platform names suddenly started having two identical suffixes.

Because those suffixes are relatively long, having two copies hit the upper limit of the hostname length (63 characters). This caused docker to die while trying to create new instances. The exact error message was:

    Error starting container 123...901: 500 Server Error: Internal
    Server Error (\"OCI runtime create failed: container_linux.go:345:
    starting container process caused \"process_linux.go:430: container
    init caused \\\"sethostname: invalid argument\\\"\": unknown\")

If we remove the preprocessing of platform names from the filter function, things go back to normal.

#### PR Type

- Bugfix Pull Request