### PR TITLE
lint refresh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/python/black.git
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -17,11 +17,11 @@ repos:
       - id: debug-statements
         language_version: python3
   - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.7.8
+    rev: 3.7.9
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-black
+          - flake8-black>=0.1.1
           - flake8-mypy
         language_version: python3
   - repo: https://github.com/adrienverge/yamllint.git

--- a/molecule/test/unit/test_config.py
+++ b/molecule/test/unit/test_config.py
@@ -376,7 +376,7 @@ def test_set_env_from_file(config_instance):
 
 
 def test_set_env_from_file_returns_original_env_when_env_file_not_found(
-    config_instance
+    config_instance,
 ):
     env = config.set_env_from_file({}, 'file-not-found')
 


### PR DESCRIPTION
Needed for avoiding a false positive of:
```
[BLK100] Black would make changes.
```
This was happening because flake8-black adopted new format of black but we were using an older version of black. They need to be kept in sync in order to avoid such errors. Arguably we could even remove flake8-black in the future because we always run black anyway.
