### PR TITLE
Remove anyconfig dependency

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -21,7 +21,6 @@
 from uuid import uuid4
 import os
 
-import anyconfig
 from ansible.module_utils.parsing.convert_bool import boolean
 import six
 
@@ -44,7 +43,6 @@ LOG = logger.get_logger(__name__)
 MOLECULE_DEBUG = boolean(os.environ.get('MOLECULE_DEBUG', 'False'))
 MOLECULE_DIRECTORY = 'molecule'
 MOLECULE_FILE = 'molecule.yml'
-MERGE_STRATEGY = anyconfig.MS_DICTS
 MOLECULE_KEEP_STRING = 'MOLECULE_'
 
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -257,7 +257,7 @@ class Config(object):
 
         :return: dict
         """
-        env = util.merge_dicts(os.environ.copy(), self.env)
+        env = util.merge_dicts(os.environ, self.env)
         env = set_env_from_file(env, self.env_file)
 
         return self._combine(env=env)

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -106,7 +106,7 @@ class AnsibleGalaxy(base.Base):
 
     @property
     def default_env(self):
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """

--- a/molecule/dependency/gilt.py
+++ b/molecule/dependency/gilt.py
@@ -81,7 +81,7 @@ class Gilt(base.Base):
 
     @property
     def default_env(self):
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """

--- a/molecule/dependency/shell.py
+++ b/molecule/dependency/shell.py
@@ -85,7 +85,7 @@ class Shell(base.Base):
 
     @property
     def default_env(self):
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """

--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -103,7 +103,7 @@ class Yamllint(base.Base):
 
     @property
     def default_env(self):
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -19,7 +19,6 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import collections
-import copy
 import functools
 import re
 
@@ -505,22 +504,20 @@ def pre_validate(stream, env, keep_string):
 
 
 def validate(c):
-    schema = copy.deepcopy(base_schema)
-
-    util.merge_dicts(schema, base_schema)
+    schema = base_schema
 
     # Dependency
     if c['dependency']['name'] == 'shell':
-        util.merge_dicts(schema, dependency_command_nullable_schema)
+        schema = util.merge_dicts(schema, dependency_command_nullable_schema)
 
     # Driver
     if c['driver']['name'] == 'docker':
-        util.merge_dicts(schema, platforms_docker_schema)
+        schema = util.merge_dicts(schema, platforms_docker_schema)
     elif c['driver']['name'] == 'podman':
-        util.merge_dicts(schema, platforms_podman_schema)
+        schema = util.merge_dicts(schema, platforms_podman_schema)
 
     # Verifier
-    util.merge_dicts(schema, api.verifiers()[c['verifier']['name']].schema())
+    schema = util.merge_dicts(schema, api.verifiers()[c['verifier']['name']].schema())
 
     v = Validator(allow_unknown=True)
     v.validate(c, schema)

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -407,9 +407,8 @@ class Ansible(base.Base):
 
     @property
     def default_env(self):
-        env = util.merge_dicts(os.environ.copy(), self._config.env)
         env = util.merge_dicts(
-            env,
+            os.environ,
             {
                 'ANSIBLE_CONFIG': self._config.provisioner.config_file,
                 'ANSIBLE_ROLES_PATH': ':'.join(

--- a/molecule/provisioner/lint/ansible_lint.py
+++ b/molecule/provisioner/lint/ansible_lint.py
@@ -56,7 +56,7 @@ class AnsibleLintMixin:
 
     @property
     def default_env(self):
-        env = util.merge_dicts(os.environ.copy(), self._config.env)
+        env = util.merge_dicts(os.environ, self._config.env)
         env = util.merge_dicts(env, self._action_env)
 
         return env

--- a/molecule/test/unit/conftest.py
+++ b/molecule/test/unit/conftest.py
@@ -153,7 +153,7 @@ def molecule_file_fixture(
 def config_instance(molecule_file_fixture, molecule_data, request):
     mdc = copy.deepcopy(molecule_data)
     if hasattr(request, 'param'):
-        util.merge_dicts(mdc, request.getfixturevalue(request.param))
+        mdc = util.merge_dicts(mdc, request.getfixturevalue(request.param))
     pytest.helpers.write_molecule_file(molecule_file_fixture, mdc)
     c = config.Config(molecule_file_fixture)
     c.command_args = {'subcommand': 'test'}

--- a/molecule/test/unit/test_util.py
+++ b/molecule/test/unit/test_util.py
@@ -377,10 +377,23 @@ def test_underscore():
     assert 'foo_bar_baz' == util.underscore('FooBarBaz')
 
 
-def test_merge_dicts():
-    # example taken from python-anyconfig/anyconfig/__init__.py
-    a = {'b': [{'c': 0}, {'c': 2}], 'd': {'e': 'aaa', 'f': 3}}
-    b = {'a': 1, 'b': [{'c': 3}], 'd': {'e': 'bbb'}}
-    x = {'a': 1, 'b': [{'c': 3}], 'd': {'e': "bbb", 'f': 3}}
-
+@pytest.mark.parametrize(
+    'a,b,x',
+    [
+        # Base of recursion scenarios
+        (dict(key=1), dict(key=2), dict(key=2)),
+        (dict(key={}), dict(key=2), dict(key=2)),
+        (dict(key=1), dict(key={}), dict(key={})),
+        # Recursive scenario
+        (dict(a=dict(x=1)), dict(a=dict(x=2)), dict(a=dict(x=2))),
+        (dict(a=dict(x=1)), dict(a=dict(y=2)), dict(a=dict(x=1, y=2))),
+        # example taken from python-anyconfig/anyconfig/__init__.py
+        (
+            {'b': [{'c': 0}, {'c': 2}], 'd': {'e': 'aaa', 'f': 3}},
+            {'a': 1, 'b': [{'c': 3}], 'd': {'e': 'bbb'}},
+            {'a': 1, 'b': [{'c': 3}], 'd': {'e': "bbb", 'f': 3}},
+        ),
+    ],
+)
+def test_merge_dicts(a, b, x):
     assert x == util.merge_dicts(a, b)

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -27,18 +27,21 @@ import re
 import sys
 
 try:
+    from collections.abc import Mapping
+except ImportError:  # Python 2 compatibility
+    from collections import Mapping
+
+try:
     from functools import lru_cache  # noqa
 except ImportError:
     from backports.functools_lru_cache import lru_cache  # noqa
 
-import anyconfig
 import colorama
 import yaml
 
 from molecule.logger import get_logger
 
 LOG = get_logger(__name__)
-MERGE_STRATEGY = anyconfig.MS_DICTS
 
 
 class SafeDumper(yaml.SafeDumper):
@@ -279,39 +282,22 @@ def underscore(string):
 
 def merge_dicts(a, b):
     """
-    Merges the values of B into A and returns a mutated dict A.
-
-    ::
-
-        dict a
-
-        b:
-           - c: 0
-           - c: 2
-        d:
-           e: "aaa"
-           f: 3
-
-        dict b
-
-        a: 1
-        b:
-           - c: 3
-        d:
-           e: "bbb"
-
-    Will give an object such as::
-
-        {'a': 1, 'b': [{'c': 3}], 'd': {'e': "bbb", 'f': 3}}
-
+    Merges the values of b into a and returns a new dict. This function uses
+    the same algorithm as Ansible's `combine(recursive=True)` filter.
 
     :param a: the target dictionary
     :param b: the dictionary to import
     :return: dict
     """
-    anyconfig.merge(a, b, ac_merge=MERGE_STRATEGY)
+    result = a
 
-    return a
+    for k, v in b.items():
+        if k in a and isinstance(a[k], Mapping) and isinstance(v, Mapping):
+            result[k] = merge_dicts(a[k], v)
+        else:
+            result[k] = v
+
+    return result
 
 
 def validate_parallel_cmd_args(cmd_args):

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -289,7 +289,7 @@ def merge_dicts(a, b):
     :param b: the dictionary to import
     :return: dict
     """
-    result = a
+    result = a.copy()
 
     for k, v in b.items():
         if k in a and isinstance(a[k], Mapping) and isinstance(v, Mapping):

--- a/molecule/verifier/ansible.py
+++ b/molecule/verifier/ansible.py
@@ -70,7 +70,7 @@ class Ansible(Verifier):
 
     @property
     def default_env(self):
-        env = util.merge_dicts(os.environ.copy(), self._config.env)
+        env = util.merge_dicts(os.environ, self._config.env)
         return util.merge_dicts(env, self._config.provisioner.env)
 
     def execute(self):

--- a/molecule/verifier/lint/flake8.py
+++ b/molecule/verifier/lint/flake8.py
@@ -89,7 +89,7 @@ class Flake8(base.Base):
 
     @property
     def default_env(self):
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """

--- a/molecule/verifier/lint/precommit.py
+++ b/molecule/verifier/lint/precommit.py
@@ -111,7 +111,7 @@ class PreCommit(base.Base):
     @property
     def default_env(self):
         """Default environment variables for pre-commit tool runtime."""
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """Bake a ready to execute ``pre-commit`` command."""

--- a/molecule/verifier/lint/rubocop.py
+++ b/molecule/verifier/lint/rubocop.py
@@ -93,7 +93,7 @@ class RuboCop(base.Base):
 
     @property
     def default_env(self):
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """

--- a/molecule/verifier/lint/yamllint.py
+++ b/molecule/verifier/lint/yamllint.py
@@ -89,7 +89,7 @@ class Yamllint(base.Base):
 
     @property
     def default_env(self):
-        return util.merge_dicts(os.environ.copy(), self._config.env)
+        return util.merge_dicts(os.environ, self._config.env)
 
     def bake(self):
         """

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -133,7 +133,7 @@ class Testinfra(Verifier):
 
     @property
     def default_env(self):
-        env = util.merge_dicts(os.environ.copy(), self._config.env)
+        env = util.merge_dicts(os.environ, self._config.env)
         env = util.merge_dicts(env, self._config.provisioner.env)
 
         return env

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,6 @@ install_requires =
     ansible >= 2.5
     ansible-lint >= 4.1.1a2, < 5
 
-    anyconfig >= 0.9.10
     backports.functools_lru_cache; python_version<"3.3"
     flake8 >=3.6.0
     cerberus >= 1.3.1


### PR DESCRIPTION
The primary goal of this PR is to get rid of the `anyconfig` package dependency. This is what the first commit in this PR does.

In order to make merge function that we created a bit safer to use, we also included the second commit in this PR. In that commit, we made sure `merge_dicts` function operates on a copy of the first input parameter. If that change is not desired, we can remove the second commit from the PR.

Fixes: #2435