### PR TITLE
Enabled GitHub Sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [decentral1se, ssbarnea]


### PR DESCRIPTION
This should allow users to sponsor people that are core on molecule and that have a github sponsor enabled account.

#### PR Type

- Docs Pull Request

