### PR TITLE
Removed ansible27 with py38 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,11 +105,6 @@ jobs:
         - TOXENV=ansible28-unit
       name: unit tests, Ansible 2.8, Python 3.8
 
-    - <<: *py-38
-      env:
-        - TOXENV=ansible27-unit
-      name: unit tests, Ansible 2.7, Python 3.8
-
     - <<: *py-37
       env:
         - TOXENV=ansible29-unit

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     lint
     check
     py{27,35,36,37}-ansible{27,28,29}-{functional,unit}
+    py38-ansible{28,29}-{functional,unit}
     doc
     dockerfile
 skipdist = True


### PR DESCRIPTION
The first version of ansible to support Python 3.8 is 2.8, previous ones
being broken. This affected our testing.
