### PR TITLE
tests: use is_subset to validate loaded data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,12 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          - flake8-absolute-import
           - flake8-black>=0.1.1
           - flake8-mypy
         language_version: python3
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.18.0
+    rev: v1.20.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/molecule/__main__.py
+++ b/molecule/__main__.py
@@ -18,7 +18,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-from .shell import main
+from molecule.shell import main
 
 if __name__ == '__main__':
     main()

--- a/molecule/test/conftest.py
+++ b/molecule/test/conftest.py
@@ -48,6 +48,24 @@ def _rebake_command(cmd, env, out=LOG.out, err=LOG.error):
     return cmd.bake(_env=env, _out=out, _err=err)
 
 
+def is_subset(subset, superset):
+    # Checks if first dict is a subset of the second one
+    if isinstance(subset, dict):
+        return all(
+            key in superset and is_subset(val, superset[key])
+            for key, val in subset.items()
+        )
+
+    if isinstance(subset, list) or isinstance(subset, set):
+        return all(
+            any(is_subset(subitem, superitem) for superitem in superset)
+            for subitem in subset
+        )
+
+    # assume that subset is a plain value if none of the above match
+    return subset == superset
+
+
 @pytest.fixture
 def random_string(l=5):
     return ''.join(random.choice(string.ascii_uppercase) for _ in range(l))

--- a/molecule/test/functional/conftest.py
+++ b/molecule/test/functional/conftest.py
@@ -33,7 +33,7 @@ from subprocess import PIPE
 from molecule import logger
 from molecule import util
 
-from ..conftest import change_dir_to
+from molecule.test.conftest import change_dir_to
 
 LOG = logger.get_logger(__name__)
 

--- a/molecule/test/functional/docker/test_scenarios.py
+++ b/molecule/test/functional/docker/test_scenarios.py
@@ -27,7 +27,7 @@ import shutil
 
 from molecule import util
 
-from ..conftest import change_dir_to
+from molecule.test.conftest import change_dir_to
 
 
 @pytest.fixture

--- a/molecule/test/unit/driver/test_delegated.py
+++ b/molecule/test/unit/driver/test_delegated.py
@@ -24,6 +24,7 @@ import pytest
 
 from molecule import config
 from molecule.driver import delegated
+from molecule.test.conftest import is_subset
 
 
 @pytest.fixture
@@ -190,7 +191,7 @@ def test_login_options_when_managed(mocker, _instance):
 def test_ansible_connection_options(_instance):
     x = {'ansible_connection': 'docker'}
 
-    assert x == _instance.ansible_connection_options('foo')
+    assert is_subset(x, _instance.ansible_connection_options('foo'))
 
 
 @pytest.mark.parametrize(

--- a/molecule/test/unit/driver/test_docker.py
+++ b/molecule/test/unit/driver/test_docker.py
@@ -24,6 +24,7 @@ import pytest
 
 from molecule import config
 from molecule.driver import docker
+from molecule.test.conftest import is_subset
 
 
 @pytest.fixture
@@ -96,7 +97,7 @@ def test_login_options(_instance):
 def test_ansible_connection_options(_instance):
     x = {'ansible_connection': 'docker'}
 
-    assert x == _instance.ansible_connection_options('foo')
+    assert is_subset(x, _instance.ansible_connection_options('foo'))
 
 
 def test_instance_config_property(_instance):

--- a/molecule/test/unit/provisioner/test_ansible.py
+++ b/molecule/test/unit/provisioner/test_ansible.py
@@ -22,6 +22,7 @@ import collections
 import os
 
 import pytest
+from molecule.test.conftest import is_subset
 
 from molecule import config
 from molecule import util
@@ -374,7 +375,7 @@ def test_inventory_property(_instance):
         },
     }
 
-    assert x == _instance.inventory
+    assert is_subset(x, _instance.inventory)
 
 
 @pytest.mark.parametrize(
@@ -409,7 +410,7 @@ def test_inventory_property_handles_missing_groups(temp_dir, _instance):
         },
     }
 
-    assert x == _instance.inventory
+    assert is_subset(x, _instance.inventory)
 
 
 def test_inventory_directory_property(_instance):
@@ -482,7 +483,7 @@ def test_playbooks_side_effect_property(_instance):
 def test_connection_options(_instance):
     x = {'ansible_connection': 'docker', 'foo': 'bar'}
 
-    assert x == _instance.connection_options('foo')
+    assert is_subset(x, _instance.connection_options('foo'))
 
 
 def test_check(_instance, mocker, _patched_ansible_playbook):
@@ -799,7 +800,7 @@ def test_write_inventory(temp_dir, _instance):
         },
     }
 
-    assert x == data
+    assert is_subset(x, data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes recurring problem with tests which failed for users that use `DOCKER_HOST` to point to a remote docker. This happened because in those cases the loaded configuration dictionary looks different as it has extra parameters added to it.

We failed to catch these on CI because we do not use a remote docker connection.