### PR TITLE
Allowing mixing links and inventory variables

### DIFF
--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -832,10 +832,9 @@ class Ansible(base.Base):
         """
         self._write_inventory()
         self._remove_vars()
-        if not self.links:
-            self._add_or_update_vars()
-        else:
-            self._link_or_update_vars()
+        self._link_or_update_vars()
+        self._add_or_update_vars()
+            
 
     def abs_path(self, path: str) -> str | None:
         return util.abs_path(os.path.join(self._config.scenario.directory, path))

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -834,7 +834,6 @@ class Ansible(base.Base):
         self._remove_vars()
         self._link_or_update_vars()
         self._add_or_update_vars()
-            
 
     def abs_path(self, path: str) -> str | None:
         return util.abs_path(os.path.join(self._config.scenario.directory, path))


### PR DESCRIPTION
We can use `links` to specify some default values for group_vars and host_vars. This PR gives user ability to override default values within `molecule.yml` file. This align with Ansible variable precedence convention.

Inspired by https://github.com/ansible/molecule/pull/3501 and fixes https://github.com/ansible/molecule/issues/2759

A few people need this feature including myself but original ticket was closed because issue opener found another solution. I am trying to pickup the work.