### PR TITLE
fix: container was re-created all the time

### DIFF
--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -41,6 +41,11 @@ class Create(base.Base):
         """
         self._config.state.change_state("driver", self._config.driver.name)
 
+        if self._config.state.created:
+            msg = "Skipping, instances already created."
+            LOG.warning(msg)
+            return
+
         self._config.provisioner.create()
 
         self._config.state.change_state("created", True)


### PR DESCRIPTION
### Summary
This PR partially reverts https://github.com/ansible/molecule/pull/3949 to skip container creation if it was already created.

### Why is it needed?
I have a molecule scenario executed with Podman. The base image doesn't not come with Python; therefore, I install it in prepare.yml. The first `molecule converge` worked as expected. However, during subsequent invocations, the `create` step would execute again but not `prepare`, resulting a brand-new container without Python. As a result, molecule failed. This defect was introduced by https://github.com/ansible/molecule/pull/3949 and affects version 6.x.
