### PR TITLE
Pin linkchecker version

### DIFF
--- a/.config/requirements-docs.txt
+++ b/.config/requirements-docs.txt
@@ -1,3 +1,3 @@
 mkdocs-ansible[lock]>=0.1.4
 pipdeptree>=2.4.0
-linkchecker
+linkchecker==10.2.1


### PR DESCRIPTION
In linkchecker 10.3.1, the exit code is 1, but in 10.2.1, it's 0

```log
That's it. 360 links in 424 URLs checked. 65 warnings found. 0 errors found.
Stopped checking at 2023-09-22 09:20:28+000 (35 seconds)
docs: exit 1 (35.79 seconds) /home/runner/work/molecule/molecule> linkchecker -f linkcheckerrc site pid=3833
.pkg: _exit> python /opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
  docs: FAIL code 1 (46.37=setup[2.92]+cmd[7.66,35.79] seconds)
  evaluation failed :( (46.53 seconds)
```