### PR TITLE
Docs: highlight importance of `ansible_collections` at root dir

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ familiar with the basics of how to use Molecule and what it can offer.
 
 1.  Create a collection
 
-    One of the recommended ways to create a collection is to place it under the `collections/ansible_collections` directory.
+    One of the recommended ways to create a collection is to place it under a `collections/ansible_collections` directory. If you don't put your collection into a directory named `ansible_collections`, *molecule won't be able to find your role*.
 
     ```bash
       ansible-galaxy collection init foo.bar

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ familiar with the basics of how to use Molecule and what it can offer.
 
 1.  Create a collection
 
-    One of the recommended ways to create a collection is to place it under a `collections/ansible_collections` directory. If you don't put your collection into a directory named `ansible_collections`, *molecule won't be able to find your role*.
+    One of the recommended ways to create a collection is to place it under a `collections/ansible_collections` directory. If you don't put your collection into a directory named `ansible_collections`, _molecule won't be able to find your role_.
 
     ```bash
       ansible-galaxy collection init foo.bar


### PR DESCRIPTION
Hey all,

thank you for providing molecule <3

I tried to follow the getting started guide but got a role-not-found-error. After some experimenting I found out that my mistake was that I didn't name my collection-root `ansible_collections`. Other people might make the same mistake I did. So I propose 2 changes:

- change "the `collections/ansible_collections`" to "a `collections/ansible_collections`", since it doesn't seem to matter where that directory lies and, at least on my system, the two ones that already exist are not writable by a normal user by default.
- Highlight that it is not only recommend, but important that the collections root is named `ansible_collections`. If you put your collections somewhere else, but follow the guide in every other regard, you will get a "role not found" error.