### PR TITLE
Update docs to remove references to Docker being the default driver

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -39,7 +39,7 @@ scenario's generated `molecule.yml` file.
 
 ## Docker With Non-Privileged User
 
-The default Molecule Docker driver executes Ansible playbooks as the
+The Molecule Docker driver executes Ansible playbooks as the
 root user. If your workflow requires adding support for running as a
 non-privileged user, then adapt `molecule.yml` and `Dockerfile.j2` as
 follows.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,8 +118,8 @@ components that Molecule provides. These are:
   uses [galaxy development guide]
   by default to resolve your role dependencies.
 - The [driver](configuration.md#driver) provider. Molecule uses
-  [Docker](https://docs.docker.com/) by default. Molecule uses the
-  driver to delegate the task of creating instances.
+  the [Delegated](configuration.md#delegated) driver by default.
+  Molecule uses the driver to delegate the task of creating instances.
 - The [platforms](configuration.md#platforms) definitions. Molecule
   relies on this to know which instances to create, name and to which
   group each instance belongs. If you need to test your role against

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -32,7 +32,7 @@ LOG = logging.getLogger(__name__)
 class Delegated(Driver):
     r"""The class responsible for managing default instances.
 
-    Delegated is `not` the default driver used in Molecule.
+    Delegated is the default driver used in Molecule.
 
     Under this driver, it is the developers responsibility to implement the
     create and destroy playbooks.  ``Managed`` is the default behaviour of all


### PR DESCRIPTION
Fixes https://github.com/ansible/molecule/issues/4059

There are probably other, subtler references I'm not aware of