### PR TITLE
Issue #4058 - Docs Bug for docker/podman

### DIFF
--- a/molecule/docker/create.yml
+++ b/molecule/docker/create.yml
@@ -42,7 +42,7 @@
                     ansible_connection: community.docker.docker
       ansible.builtin.set_fact:
         molecule_inventory: >
-          {{ molecule_inventory | combine(inventory_partial_yaml | from_yaml) }}
+          {{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"

--- a/molecule/podman/create.yml
+++ b/molecule/podman/create.yml
@@ -43,7 +43,7 @@
                     ansible_connection: containers.podman.podman
       ansible.builtin.set_fact:
         molecule_inventory: >
-          {{ molecule_inventory | combine(inventory_partial_yaml | from_yaml) }}
+          {{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"


### PR DESCRIPTION
Previous behavior is your molecule group would only contain the last platform since the elements were not merging:
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/combine_filter.html


```
TASK [Display uname info] ******************************************************
ok: [foo] => {
    "msg": "Linux...\n"
}
```

New behavior is all of your platforms will be in the host inventory

```
TASK [Display uname info] ******************************************************
ok: [foo] => {
    "msg": "Linux...\n"
}
ok: [bar] => {
    "msg": "Linux...\n"
}
```

Fixes: #4058