### PR TITLE
(Need guidance to continue) Make help message more useful byusing config.

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -295,14 +295,16 @@ def click_expand_help(f) -> Callable[[Callable[..., Any]], click.Command]:
     s = molecule.scenarios.Scenarios(get_configs({}, {}), None)
     for scenario in s.all:
         if scenario.name == "default":
-            #print(scenario.side_effect_sequence)
-            #print(scenario.test_sequence)
             try:
                 default_sequence = getattr(scenario, f.__name__ + "_sequence")
-            except AttributeError as e:
-                raise RuntimeError(f"Unable to find property {f.__name__}_sequence in class {type(scenario)}.\n"
-                                    "You might consider adding it with default action for this command.")
-    f.__doc__ += " (" + ", ".join(default_sequence) + ")." #print("self.all[0]:", type(next(iter(s.all))))
+            except AttributeError:
+                raise RuntimeError(
+                    f"Unable to find property {f.__name__}_sequence in class {type(scenario)}.\n"
+                    "You might consider adding it with default action for this command.",
+                )
+    f.__doc__ += (
+        " (" + ", ".join(default_sequence) + ")."
+    )  # print("self.all[0]:", type(next(iter(s.all))))
     return f
 
 

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -289,6 +289,23 @@ def click_command_ex() -> Callable[[Callable[..., Any]], click.Command]:
     )
 
 
+def click_expand_help(f) -> Callable[[Callable[..., Any]], click.Command]:
+    """This decorator add sequence to help message."""
+    # Ask: How to get the scenario name (if help is called) or which scenario name to choose ?
+    s = molecule.scenarios.Scenarios(get_configs({}, {}), None)
+    for scenario in s.all:
+        if scenario.name == "default":
+            #print(scenario.side_effect_sequence)
+            #print(scenario.test_sequence)
+            try:
+                default_sequence = getattr(scenario, f.__name__ + "_sequence")
+            except AttributeError as e:
+                raise RuntimeError(f"Unable to find property {f.__name__}_sequence in class {type(scenario)}.\n"
+                                    "You might consider adding it with default action for this command.")
+    f.__doc__ += " (" + ", ".join(default_sequence) + ")." #print("self.all[0]:", type(next(iter(s.all))))
+    return f
+
+
 def result_callback(*args, **kwargs):
     """Click natural exit callback."""
     # We want to be used we run out custom exit code, regardless if run was

--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -56,10 +56,9 @@ class Check(base.Base):
     default=MOLECULE_PARALLEL,
     help="Enable or disable parallel mode. Default is disabled.",
 )
+@base.click_expand_help
 def check(ctx, scenario_name, parallel):  # pragma: no cover
-    """Use the provisioner to perform a Dry-Run (destroy, dependency, create, \
-    prepare, converge).
-    """
+    """Use the provisioner to perform a Dry-Run"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"parallel": parallel, "subcommand": subcommand}

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -53,9 +53,10 @@ class Cleanup(base.Base):
     default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
+@base.click_expand_help
 def cleanup(ctx, scenario_name="default"):  # pragma: no cover
     """Use the provisioner to cleanup any changes made to external systems during \
-    the stages of testing.
+    the stages of testing
     """
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -51,8 +51,9 @@ class Converge(base.Base):
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
+@base.click_expand_help
 def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
-    """Use the provisioner to configure instances (dependency, create, prepare, converge)."""
+    """Use the provisioner to configure instances"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand}

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -52,7 +52,7 @@ class Converge(base.Base):
 )
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
-    """Use the provisioner to configure instances (dependency, create, prepare converge)."""
+    """Use the provisioner to configure instances (dependency, create, prepare, converge)."""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand}

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -60,8 +60,9 @@ class Create(base.Base):
     type=click.Choice([str(s) for s in drivers()]),
     help=f"Name of driver to use. ({DEFAULT_DRIVER})",
 )
+@base.click_expand_help
 def create(ctx, scenario_name, driver_name):  # pragma: no cover
-    """Use the provisioner to start the instances."""
+    """Use the provisioner to start the instances"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand, "driver_name": driver_name}

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -48,8 +48,9 @@ class Dependency(base.Base):
     default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
+@base.click_expand_help
 def dependency(ctx, scenario_name):  # pragma: no cover
-    """Manage the role's dependencies."""
+    """Manage the role's dependencies"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand}

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -76,8 +76,9 @@ class Destroy(base.Base):
     default=False,
     help="Enable or disable parallel mode. Default is disabled.",
 )
+@base.click_expand_help
 def destroy(ctx, scenario_name, driver_name, __all, parallel):  # pragma: no cover
-    """Use the provisioner to destroy the instances."""
+    """Use the provisioner to destroy the instances"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -113,10 +113,10 @@ class Idempotence(base.Base):
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
+@base.click_expand_help
 def idempotence(ctx, scenario_name, ansible_args):  # pragma: no cover
     """Use the provisioner to configure the instances and parse the output to \
-    determine idempotence.
-    """
+    determine idempotence"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand}

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -122,8 +122,9 @@ class Prepare(base.Base):
     default=False,
     help="Enable or disable force mode. Default is disabled.",
 )
+@base.click_expand_help
 def prepare(ctx, scenario_name, driver_name, force):  # pragma: no cover
-    """Use the provisioner to prepare the instances into a particular starting state."""
+    """Use the provisioner to prepare the instances into a particular starting state"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -56,8 +56,9 @@ class SideEffect(base.Base):
     default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
+@base.click_expand_help
 def side_effect(ctx, scenario_name):  # pragma: no cover
-    """Use the provisioner to perform side-effects to the instances."""
+    """Use the provisioner to perform side-effects to the instances"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand}

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -48,8 +48,9 @@ class Syntax(base.Base):
     default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
+@base.click_expand_help
 def syntax(ctx, scenario_name):  # pragma: no cover
-    """Use the provisioner to syntax check the role."""
+    """Use the provisioner to syntax check the role"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand}

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -83,6 +83,7 @@ class Test(base.Base):
     help="Enable or disable parallel mode. Default is disabled.",
 )
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
+@base.click_expand_help
 def test(
     ctx,
     scenario_name,
@@ -93,7 +94,7 @@ def test(
     ansible_args,
     platform_name,
 ):  # pragma: no cover
-    """Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy)."""
+    """Test"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -48,8 +48,9 @@ class Verify(base.Base):
     default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
     help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
+@base.click_expand_help
 def verify(ctx, scenario_name="default"):  # pragma: no cover
-    """Run automated tests against instances."""
+    """Run automated tests against instances"""
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)
     command_args = {"subcommand": subcommand}


### PR DESCRIPTION
Hello,

At first it was the missing comma that triggered me and then I saw it was just text. Some command missed the action sequence and didn't find in documentation. So I took the step further by automating the update of this docstring.

With this modification now each sequence step command has a correct sequence (updated when source code is update).

I have two case missing, I read default config and it it doesn't exist I fail:
-  access the default default's (the scenario) config (in case no one write code). So I don't write empty sequence.
-  get scenario name (if given) so I can read that scenario config (molecule --help --scenario-name kubevirt).


I believe this will improve UX because it is like matrix command but without asking and it will allow a better discoverability.