### PR TITLE
Change molecule_inventory in podman example to remove ansible warning

### DIFF
--- a/molecule/podman/create.yml
+++ b/molecule/podman/create.yml
@@ -5,7 +5,9 @@
     molecule_inventory:
       all:
         hosts: {}
-        molecule: {}
+        children:
+          molecule:
+            hosts: {}
   tasks:
     - name: Create a container
       containers.podman.podman_container:

--- a/molecule/podman/create.yml
+++ b/molecule/podman/create.yml
@@ -8,6 +8,7 @@
         children:
           molecule:
             hosts: {}
+
   tasks:
     - name: Create a container
       containers.podman.podman_container:


### PR DESCRIPTION
Change molecule_inventory var to remove warning generated by ansible default driver at runtime.