### PR TITLE
Adding molecule template based on `driver.name`

### DIFF
--- a/src/molecule/data/init-scenario.yml
+++ b/src/molecule/data/init-scenario.yml
@@ -31,3 +31,7 @@
         - templates/scenario/*.j2
       loop_control:
         label: "{{ dest_file | relpath }}"
+      when:
+        - ((driver_name in ['containers', 'docker', 'podman']) and
+          (item | regex_search('create|destroy') is none) or
+          (driver_name not in ['containers', 'docker', 'podman']))

--- a/src/molecule/data/templates/scenario/molecule.yml.j2
+++ b/src/molecule/data/templates/scenario/molecule.yml.j2
@@ -1,6 +1,13 @@
 ---
+driver:
+  name: {{ driver_name }}
 platforms:
   - name: instance
+{% if driver_name in ['containers', 'docker', 'podman'] %}
+    image: quay.io/centos/centos:stream8
+    pre_build_image: true
+{% else %}
     # you might want to add your own variables here based on what provisioning
     # you are doing like:
     # image: quay.io/centos/centos:stream8
+{% endif %}


### PR DESCRIPTION
In past when using `cookicuter` some molecule templates where straight forward to use delegated container drivers, such as `podman` and `docker`. Since it was gone,  every time a new scenario is created it's needed to configure the templates again, by adding the image and the driver, also cleaning the files that will not be used by default such as `create.yml` and `destroy.yml`
 
If we can just init the scenario with a basic template that just works as we had in version `5` would be great.

Here I'm bringing back some of this functionality, e.g:

```bash
ansible-galaxy collection init foo.example
cd foo/example/roles
ansible-galaxy role init bar
cd bar
molecule init scenario -d podman podman
```

This will create a `molecule.yml` as the following:
```yaml
---
driver:
  name: podman
platforms:
  - name: instance
    image: quay.io/centos/centos:stream8
    pre_build_image: true
```

it will also create the molecule scenario with just the `molecule.yml` and the `converge.yml`. e.g:

```bash
tree ./molecule/podman/
./molecule/podman/
├── converge.yml
└── molecule.yml
```

If the scenario was any driver different than `podman`, `docker` or `containers` it will create the scenario with all the default templates from the current `data` structure, e.g:

```bash
molecule init scenario
tree ./molecule/
./molecule/
├── default
│   ├── converge.yml
│   ├── create.yml
│   ├── destroy.yml
│   └── molecule.yml
```

The final scenario tree, after the commands `molecule init scenario -d podman podman` and `molecule init scenario` will look like:

```bash
tree ./molecule/
./molecule/
├── default
│   ├── converge.yml
│   ├── create.yml
│   ├── destroy.yml
│   └── molecule.yml
└── podman
    ├── converge.yml
    └── molecule.yml
```

Fixes: #4128