### PR TITLE
Fix symlinks creation in ansible provisioneer

### DIFF
--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -904,6 +904,14 @@ class Ansible(base.Base):
             if not os.path.exists(source):
                 msg = f"The source path '{source}' does not exist."
                 util.sysexit_with_message(msg)
+            if os.path.exists(target):
+                if os.path.realpath(target) == os.path.realpath(source):
+                    msg=f"Required symlink {target} to {source} exist, skip creation"
+                    LOG.debug(msg)
+                    continue
+                msg=f"Required symlink {target} exist with another source"
+                LOG.debug(msg)
+                os.remove(target)
             msg = f"Inventory {source} linked to {target}"
             LOG.debug(msg)
             os.symlink(source, target)

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -906,10 +906,10 @@ class Ansible(base.Base):
                 util.sysexit_with_message(msg)
             if os.path.exists(target):
                 if os.path.realpath(target) == os.path.realpath(source):
-                    msg=f"Required symlink {target} to {source} exist, skip creation"
+                    msg = f"Required symlink {target} to {source} exist, skip creation"
                     LOG.debug(msg)
                     continue
-                msg=f"Required symlink {target} exist with another source"
+                msg = f"Required symlink {target} exist with another source"
                 LOG.debug(msg)
                 os.remove(target)
             msg = f"Inventory {source} linked to {target}"


### PR DESCRIPTION
When I use
```yaml
provisioner:
  name: ansible
  ...
  inventory:
    links:
      .files: ../.inventory/.files
      host_vars: ../.inventory/host_vars
      group_vars: ../.inventory/group_vars
```
I receive FileExistError
```shell
Traceback (most recent call last):
  File ".venv/bin/molecule", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File ".venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/molecule/command/test.py", line 113, in test
    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args)
  File ".venv/lib/python3.11/site-packages/molecule/command/base.py", line 124, in execute_cmdline_scenarios
    execute_scenario(scenario)
  File "venv/lib/python3.11/site-packages/molecule/command/base.py", line 167, in execute_scenario
    execute_subcommand(scenario.config, action)
  File ".venv/lib/python3.11/site-packages/molecule/command/base.py", line 157, in execute_subcommand
    return command(config).execute(args)
           ^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/molecule/command/base.py", line 57, in __init__
    self._setup()
  File ".venv/lib/python3.11/site-packages/molecule/command/base.py", line 76, in _setup
    self._config.provisioner.manage_inventory()
  File ".venv/lib/python3.11/site-packages/molecule/provisioner/ansible.py", line 838, in manage_inventory
    self._link_or_update_vars()
  File ".venv/lib/python3.11/site-packages/molecule/provisioner/ansible.py", line 912, in _link_or_update_vars
    os.symlink(source, target)
FileExistsError: [Errno 17] File exists: 'roles/common/molecule/docker-al-8/../.inventory/.files' -> '.cache/molecule/common/docker-al-8/inventory/.files'
```