### PR TITLE
Fix config file in proj dirrectory

### DIFF
--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -324,7 +324,9 @@ def _filter_platforms(config, platform_name):
 
 @cache
 def find_vcs_root(
-    location="", dirs=(".git", ".hg", ".svn", ".config"), default=None,
+    location="",
+    dirs=(".git", ".hg", ".svn", ".config"),
+    default=None,
 ) -> str:
     """Return current repository root directory."""
     if not location:

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -323,7 +323,9 @@ def _filter_platforms(config, platform_name):
 
 
 @cache
-def find_vcs_root(location="", dirs=(".git", ".hg", ".svn"), default=None) -> str:
+def find_vcs_root(
+    location="", dirs=(".git", ".hg", ".svn", ".config"), default=None,
+) -> str:
     """Return current repository root directory."""
     if not location:
         location = os.getcwd()


### PR DESCRIPTION
This resolves the issue raised in Issue #4142 where Molecule does not find the config.yml file the project directory `{project_dir}/.config/molecule/config.yml` but does find it in the home directory.

I ran tests by isolating the 2 functions being called when `LOCAL_CONFIG` variable is defined and verifying that the config file is found when in the project dir.  If there is no `{project_dir}/.config/molecule/config.yml`  then it looks in `~/.config/molecule/config.yml` and finds the config file.

I have not been able to test the full project with the `tox` command as my environment is having issues.  The `tox` tests are not completing even on a freshly cloned repo.

The code in the find_vcs_root function could likely be modified more as it does not appear to be called elsewhere and it searches for ".git", ".hg", ".svn" dirs as well for what appears to be no reason as far as I can tell since it is only used for locating `.config/molecule/config.yml`

Let me know if anything can be improved upon here with my delivery of this as it is my first PR with the project.

Fixes: #4142