### PR TITLE
Set ANSIBLE_FORCE_COLOR sooner to fix missing color output in tmux

### DIFF
--- a/src/molecule/console.py
+++ b/src/molecule/console.py
@@ -72,6 +72,12 @@ def should_do_markup() -> bool:
     return sys.stdout.isatty()
 
 
+# Define ANSIBLE_FORCE_COLOR if markup is enabled and another value is not
+# already given. This assures that Ansible subprocesses are still colored,
+# even if they do not run with a real TTY.
+if should_do_markup():
+    os.environ["ANSIBLE_FORCE_COLOR"] = os.environ.get("ANSIBLE_FORCE_COLOR", "1")
+
 console_options: dict[str, Any] = {"emoji": False, "theme": theme, "soft_wrap": True}
 
 console = Console(
@@ -83,9 +89,3 @@ console = Console(
 console_options_stderr = console_options.copy()
 console_options_stderr["stderr"] = True
 console_stderr: Console = Console(**console_options_stderr)
-
-# Define ANSIBLE_FORCE_COLOR if markup is enabled and another value is not
-# already given. This assures that Ansible subprocesses are still colored,
-# even if they do not run with a real TTY.
-if should_do_markup():
-    os.environ["ANSIBLE_FORCE_COLOR"] = os.environ.get("ANSIBLE_FORCE_COLOR", "1")


### PR DESCRIPTION
What
---
This fixes a strange issue of missing colored output I was experiencing when using tmux by moving code to set the `ANSIBLE_FORCE_COLOR` environment variable if it didn't already exist when `should_do_markup()` returned `True`.

Why
---
I was going insane investigating why I wasn't getting colored output in my normal environment, but got it just fine when I tried it without outside of tmux.

I've narrowed it down to `should_do_markup()` returning `True` at first, but then switching to `False` once `console` has been set in `console.py`, thus moving the code that sets `ANSIBLE_FORCE_COLOR` if it doesn't exist to before `console` is set rather than after essentially makes the `True` "stick" since `should_do_markup()` checks for it. This presumably should have no effect outside of fixing my issue, although I admittedly still don't know what actually caused it so what do I know...

Other things I've tried:
- Setting my `$TERM` to containing `xterm` gives expected colored output, but based on some googling it seems it's preferred to let tmux identify itself as `screen-256color` as mine does.
- Funnily, making `should_do_markup()` check for `color` in `$TERM` gave me colored Ansible output, but uncolored molecule output...
- Making `should_do_markup()` a boolean instead of a function, and setting it once using the same function code it currently has. This worked, but some tests were failing (apparently the now-fixed `should_do_markup` was returning `False` when `PY_COLORS` was set or when `$TERM` included `xterm`) and I quickly gave up figuring out why...

Testing
---
I just did a full run of `tox` on my branch and everything passed :tada: 

I didn't add any tests because my change only moved a code block up within the same file, and this functionality is already well covered in existing tests (which, again, still pass).