### PR TITLE
Fix test method name.

### DIFF
--- a/test/a_unit/provisioner/test_ansible.py
+++ b/test/a_unit/provisioner/test_ansible.py
@@ -762,7 +762,7 @@ def test_get_filter_plugins_directories_default(_instance, monkeypatch):
     assert re.search(r"/usr/share/ansible/plugins/filter$", paths[4])
 
 
-def tes_get_filter_plugins_directories_single_ansible_filter_plugins(
+def test_get_filter_plugins_directories_single_ansible_filter_plugins(
     _instance,
     monkeypatch,
 ):


### PR DESCRIPTION
This appears to have been missed while reviewing #4135. If I understand the [pytest docs](https://docs.pytest.org/en/8.0.x/explanation/goodpractices.html#test-discovery) correctly, the method is not recognized as a test without the change.