### PR TITLE
Always apply ssh_connection_options

### DIFF
--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -224,14 +224,15 @@ class Delegated(Driver):
 
                 if d.get("identity_file", None):
                     conn_dict["ansible_private_key_file"] = d.get("identity_file")
-                    conn_dict["ansible_ssh_common_args"] = " ".join(
-                        self.ssh_connection_options,
-                    )
                 if d.get("password", None):
                     conn_dict["ansible_password"] = d.get("password")
                     # Based on testinfra documentation, ansible password must be passed via ansible_ssh_pass
                     # issue to fix this can be found https://github.com/pytest-dev/pytest-testinfra/issues/580
                     conn_dict["ansible_ssh_pass"] = d.get("password")
+
+                conn_dict["ansible_ssh_common_args"] = " ".join(
+                    self.ssh_connection_options,
+                )
 
                 return conn_dict
 


### PR DESCRIPTION
Always apply `ssh_connection_options` whether we use `identity_file` or password.

Default `ssh_connection_options` include `UserKnownHostsFile=/dev/null` and ` StrictHostKeyChecking=no` but those options are never applied if no `identity_file` parameter is supplied along with the instance config.

This pull request changes the default driver to always use `ssh_connection_options` whether `identity_file` or `password` is used.