### PR TITLE
Add .venv and .tox dirs to .gitignore and .ansible-lint config files

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 exclude_paths:
+  - .tox
+  - .venv
   - mkdocs.yml # using tags
   # not really playbooks:
 kinds:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .mypy_cache/
 .tox/
 .vagrant/
+.venv/
 .pytest_cache/
 build/
 dist/


### PR DESCRIPTION
I don't have an intricate knowledge all the CI workflows in this repo or the parent `team-devtools`, so if there is rational for including `.venv` then please ignore or cherry-pick this PR. But it would be helpful for local dev given:
- building and installing molecule-*.whl can introduce 3rd party packages into local `.venv` that `ansible-lint` (via `tox -e lint` or `ansible-lint`) will throw errors on and prevent pushing commits.
- creating `.venv` will trigger git to check for changes, while this can be blocked using a global ignore file, not everyone uses or can use it.

I did not edit `.yamllint`, but running it via CLI `yamllint .` will throw similar errors. However, the pre-commit configuration skips these directories. A quick fix to `.yamllint` would be:

```yaml
extends: default
ignore:
  - .tox/
  - .venv/
rules:
...
```
