### PR TITLE
Fix: Update default globbing pattern for collection matching

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -47,7 +47,7 @@ jobs:
       matrix: ${{ fromJson(needs.pre.outputs.matrix) }}
 
     env:
-      PYTEST_REQPASS: 453
+      PYTEST_REQPASS: 454
     environment: test
     steps:
       - uses: actions/checkout@v4

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -40,7 +40,7 @@ from molecule import config, logger, text, util
 from molecule.console import should_do_markup
 
 LOG = logging.getLogger(__name__)
-MOLECULE_GLOB = os.environ.get("MOLECULE_GLOB", "molecule/*/molecule.yml")
+MOLECULE_GLOB = os.environ.get("MOLECULE_GLOB", "**/molecule/*/molecule.yml")
 MOLECULE_DEFAULT_SCENARIO_NAME = "default"
 
 
@@ -94,7 +94,7 @@ def execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args=()
     """
     glob_str = MOLECULE_GLOB
     if scenario_name:
-        glob_str = glob_str.replace("*", scenario_name)
+        glob_str = glob_str.replace("/*/", f"/{scenario_name}/")
     scenarios = molecule.scenarios.Scenarios(
         get_configs(args, command_args, ansible_args, glob_str),
         scenario_name,

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -73,7 +73,7 @@ class Config(metaclass=NewInitCaller):
     """Config Class.
 
     Molecule searches the current directory for ``molecule.yml`` files by
-    globbing `molecule/*/molecule.yml`.  The files are instantiated into
+    globbing `**/molecule/*/molecule.yml`.  The files are instantiated into
     a list of Molecule [molecule.config.Config][] objects, and each Molecule subcommand
     operates on this list.
 

--- a/test/a_unit/command/test_base.py
+++ b/test/a_unit/command/test_base.py
@@ -264,7 +264,7 @@ def test_verify_configs_raises_with_no_configs(caplog):
 
     assert e.value.code == 1
 
-    msg = "'molecule/*/molecule.yml' glob failed.  Exiting."
+    msg = "'**/molecule/*/molecule.yml' glob failed.  Exiting."
     assert msg in caplog.text
 
 


### PR DESCRIPTION
This update:
- restricts the glob matching for `molecule test`
- updates the default value for `MOLECULE_GLOB="**/molecule/*/molecule.yml"`

This allows:
- users to call molecule from the collection folder and molecule will use the collection name in the ephemeral cache, `.cache/molecule/COLLECTION_NAME`.

WARNING:
If working within the ANSIBLE_COLLECTIONS_PATH directory, e.g. `~/.ansible/collections/ansible_collections/COLLECTION_NAME` (default), using the new default setting `MOLECULE_GLOB="**/molecule/*/molecule.yml"` will globber clobber and delete the collection folder. This occurs in the presence of a `galaxy.yml` - as molecule calls `ansible_compat.runtime(isolate=False)` and will run `ansible_compat.runtime.prepare_environment`. However, if you delete the `galaxy.yml` OR chdir into `COLLECTION_NAME/extensions` and it will not delete the collection folder.

Currently (v24.2.1):
Calling `molecule list` will find all molecule.yml files within a collection folder that use a nested dir structure, i.e
`COLLECTION_NAME/extensions/molecule/SCENARIO_NAME/molecule.yml`. As it calls `base.get_configs` and sets the argument `glob=str"**/molecule/*/molecule.yml"`.

This does not occur with `molecule test`, as it calls to `base.execute_cmdline_scenarios` and uses
`MOLECULE_GLOB = os.environ.get("MOLECULE_GLOB", "molecule/*/molecule.yml")`.

Attempting to set an env var `MOLECULE_GLOB="**/molecule/*/molecule.yml"` will fail, as `test` attempts to insert the scenario name into every wild-card. But, this fuzzy matching acts as a safe guard against deleting the collection when working within the same ANSIBLE_COLLECTIONS_PATH directory:

	$ MOLECULE_GLOB="**/molecule/*/molecule.yml" molecule test
	CRITICAL 'defaultdefault/molecule/default/molecule.yml' glob failed.