### PR TITLE
Fix: MOLECULE_GLOB not respected in list command

### DIFF
--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -65,7 +65,7 @@ def list(ctx, scenario_name, format):  # pragma: no cover
 
     statuses = []
     s = scenarios.Scenarios(
-        base.get_configs(args, command_args, glob_str="**/molecule/*/molecule.yml"),
+        base.get_configs(args, command_args, glob_str=os.environ.get("MOLECULE_GLOB", "molecule/*/molecule.yml")),
         scenario_name,
     )
     for scenario in s:

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -65,7 +65,11 @@ def list(ctx, scenario_name, format):  # pragma: no cover
 
     statuses = []
     s = scenarios.Scenarios(
-        base.get_configs(args, command_args, glob_str=os.environ.get("MOLECULE_GLOB", "molecule/*/molecule.yml")),
+        base.get_configs(
+            args,
+            command_args,
+            glob_str=os.environ.get("MOLECULE_GLOB", "molecule/*/molecule.yml"),
+        ),
         scenario_name,
     )
     for scenario in s:


### PR DESCRIPTION
Molecule allows to change the config folder by setting MOLECULE_GLOB env. This is working for most parts but not for the list command. 