### PR TITLE
Avoid requests 2.32.0 during testing

### DIFF
--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -11,3 +11,4 @@ pytest-plus >= 0.4.0
 pytest-xdist >= 3.1.0
 pytest >= 7.2.0
 check-jsonschema
+requests != 2.32.0 # https://github.com/docker/docker-py/issues/3256


### PR DESCRIPTION
Apparently requests==2.32.0 is incompatible with vendored versions of docker-py from inside community.docker collection. We do not have a direct dependency on that but one of our integration tests fails, so we only update our test dependencies.

Related: https://github.com/docker/docker-py/issues/3256
Related: https://github.com/ansible-collections/community.docker/issues/860
Related: https://github.com/ansible-collections/community.docker/pull/861