### PR TITLE
Update tox.yml

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,181 +2,20 @@
 name: tox
 
 on:
-  push: # only publishes pushes to the main branch to TestPyPI
-    branches: # any integration branch but not tag
+  push:
+    branches:
       - "main"
   pull_request:
+    branches:
+      - "main"
   workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+
 jobs:
-  pre:
-    name: pre
-    runs-on: ubuntu-22.04
-    outputs:
-      matrix: ${{ steps.generate_matrix.outputs.matrix }}
-    steps:
-      - name: Determine matrix
-        id: generate_matrix
-        uses: coactions/dynamic-matrix@v1
-        with:
-          min_python: "3.10"
-          max_python: "3.12"
-          default_python: "3.10" # used by jobs in other_names
-          other_names: |
-            lint
-            docs
-            pkg
-            eco
-
-  build:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
-    needs: pre
-    defaults:
-      run:
-        shell: ${{ matrix.shell || 'bash'}}
-    # limit potential endless looks like we had with build-containers
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.pre.outputs.matrix) }}
-
-    env:
-      PYTEST_REQPASS: 453
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # needed by setuptools-scm
-          submodules: true
-
-      - name: Set pre-commit cache
-        uses: actions/cache@v4
-        if: ${{ matrix.passed_name == 'lint' }}
-        with:
-          path: |
-            ~/.cache/pre-commit
-          key: pre-commit-${{ matrix.name || matrix.passed_name }}-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Install system dependencies
-        # remove broken .deb ansible and replace with pip version:
-        # https://github.com/actions/virtual-environments/issues/3001
-        run: |
-          sudo apt-get remove -y ansible \
-          && sudo apt-get update \
-          && sudo apt-get install -y libvirt-dev python3-cryptography python3-jinja2 python3-yaml virtualenv \
-          && pip3 install --user ansible-core ansible-lint\
-          && echo "$HOME/.local/bin" >> $GITHUB_PATH
-        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
-      - name: Validate that ansible works
-        run: |
-          ansible --version \
-          && virtualenv foo \
-          && source foo/bin/activate \
-          && ansible --version
-      - name: Set up Python ${{ matrix.python_version || '3.10' }}
-        if: "!contains(matrix.shell, 'wsl')"
-        uses: actions/setup-python@v5
-        with:
-          cache: pip
-          python-version: ${{ matrix.python_version || '3.10' }}
-
-      - name: Install tox
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade "tox>=4.0.0"
-
-      - name: Log installed dists
-        run: python3 -m pip freeze --all
-
-      - name: Initialize tox envs ${{ matrix.passed_name }}
-        run: python3 -m tox --notest --skip-missing-interpreters false -vv -e ${{ matrix.passed_name }}
-        timeout-minutes: 5 # average is under 1, but macos can be over 3
-
-      # sequential run improves browsing experience (almost no speed impact)
-      - name: tox -e ${{ matrix.passed_name }}
-        run: python3 -m tox -e ${{ matrix.passed_name }}
-
-      - name: Archive logs
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-${{ matrix.name }}.zip
-          path: |
-            .tox/**/log/
-            .tox/**/.coverage*
-            .tox/**/coverage.xml
-
-      - name: Report failure if git reports dirty status
-        run: |
-          if [[ -n $(git status -s) ]]; then
-            # shellcheck disable=SC2016
-            echo -n '::error file=git-status::'
-            printf '### Failed as git reported modified and/or untracked files\n```\n%s\n```\n' "$(git status -s)" | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 99
-          fi
-        # https://github.com/actions/toolkit/issues/193
-
-  check:
-    if: always()
-    permissions:
-      id-token: write
-      checks: read
-
-    needs:
-      - build
-    runs-on: ubuntu-latest
-
-    steps:
-      # checkout needed for codecov action which needs codecov.yml file
-      - uses: actions/checkout@v4
-
-      - name: Set up Python # likely needed for coverage
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - run: pip3 install 'coverage>=7.5.1'
-
-      - name: Merge logs into a single archive
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: logs.zip
-          pattern: logs-*.zip
-          # artifacts like py312.zip and py312-macos do have overlapping files
-          separate-directories: true
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: logs.zip
-          path: .
-
-      - name: Check for expected number of coverage.xml reports
-        run: |
-          JOBS_PRODUCING_COVERAGE=3
-          if [ "$(find . -name coverage.xml | wc -l | bc)" -ne "${JOBS_PRODUCING_COVERAGE}" ]; then
-            echo "::error::Number of coverage.xml files was not the expected one (${JOBS_PRODUCING_COVERAGE}): $(find . -name coverage.xml |xargs echo)"
-            exit 1
-          fi
-
-      - name: Upload coverage data
-        uses: codecov/codecov-action@v4
-        with:
-          name: ${{ matrix.passed_name }}
-          fail_ci_if_error: true
-          use_oidc: true # cspell:ignore oidc
-
-      - name: Check codecov.io status
-        if: github.event_name == 'pull_request'
-        uses: coactions/codecov-status@main
-
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
-
-      - name: Delete Merged Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          delete-merged: true
+  tox:
+    uses: ansible/team-devtools/.github/workflows/tox.yml@main
+    with:
+      other_names_also: "eco"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ markers = [
 ]
 norecursedirs = ["scenarios"]
 testpaths = "test"
-tmp_path_retention_policy = "failed"
 verbosity_assertions = 2
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,33 +148,15 @@ disable = [
 score = "n"
 
 [tool.pytest.ini_options]
+addopts = "-ra --showlocals --durations=10"
 markers = [
   "serial: Run this test serially via filelock.",
   "extensive: marks tests that we want to skip by default, as they are indirectly covered by other tests",
 ]
-norecursedirs = [
-  ".eggs",
-  ".tox",
-  "build",
-  "dist",
-  "doc",
-  "test/resources",
-  "test/scenarios",
-]
-addopts = "--doctest-modules --durations 10 --color=yes"
-doctest_optionflags = ["ALLOW_UNICODE", "ELLIPSIS"]
-junit_suite_name = "molecule_test_suite"
-testpaths = "test/"
-filterwarnings = [
-  # treat warnings as errors unless we add them below
-  "error",
-  # https://github.com/certifi/python-certifi/pull/193
-  "ignore:path is deprecated.*:DeprecationWarning",
-  # https://github.com/pytest-dev/pytest-cov/issues/557
-  "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
-  # ignore::UserWarning
-
-]
+norecursedirs = ["scenarios"]
+testpaths = "test"
+tmp_path_retention_policy = "failed"
+verbosity_assertions = 2
 
 [tool.ruff]
 ignore = [

--- a/test/a_unit/command/test_base.py
+++ b/test/a_unit/command/test_base.py
@@ -305,8 +305,8 @@ def test_command_completion(shell: str) -> None:
     result = util.run_command(["molecule"], env=env)
 
     if "bash" in shell and (float(bash_version) < 4.4):
-        assert result.returncode == 1
-        assert "Found config file" not in result.stdout
+        string = "Shell completion is not supported for Bash versions older than 4.4"
+        assert string not in result.stdout
     else:
         assert result.returncode == 0
         assert "Found config file" not in result.stdout

--- a/test/b_functional/test_command.py
+++ b/test/b_functional/test_command.py
@@ -34,8 +34,7 @@ from test.b_functional.conftest import (  # pylint:disable=C0411
     run_test,
     verify,
 )
-
-from ..conftest import mac_on_gh  # noqa: TID252
+from test.conftest import mac_on_gh  # pylint:disable=C0411
 
 
 @pytest.fixture()

--- a/test/b_functional/test_command.py
+++ b/test/b_functional/test_command.py
@@ -35,6 +35,8 @@ from test.b_functional.conftest import (  # pylint:disable=C0411
     verify,
 )
 
+from ..conftest import mac_on_gh  # noqa: TID252
+
 
 @pytest.fixture()
 def scenario_to_test(request):
@@ -381,6 +383,7 @@ def test_with_and_without_gitignore(
         assert scenario_name in names
 
 
+@mac_on_gh
 def test_podman() -> None:
     assert (
         run_command(
@@ -390,6 +393,7 @@ def test_podman() -> None:
     )
 
 
+@mac_on_gh
 def test_docker() -> None:
     assert (
         run_command(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,7 @@
 
 import contextlib
 import os
+import platform
 import random
 import string
 
@@ -29,6 +30,9 @@ from filelock import FileLock
 from molecule import config
 from molecule.scenario import ephemeral_directory
 
+# Marker to skip tests on macos when running on GH
+mac_on_gh = pytest.mark.skipif(platform.system() == "Darwin" and "CI" in os.environ,
+    reason="Podman and docker not currently available for macOS on Github")
 
 def is_subset(subset, superset):
     # Checks if first dict is a subset of the second one

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,8 +31,11 @@ from molecule import config
 from molecule.scenario import ephemeral_directory
 
 # Marker to skip tests on macos when running on GH
-mac_on_gh = pytest.mark.skipif(platform.system() == "Darwin" and "CI" in os.environ,
-    reason="Podman and docker not currently available for macOS on Github")
+mac_on_gh = pytest.mark.skipif(
+    platform.system() == "Darwin" and "CI" in os.environ,
+    reason="Podman and docker not currently available for macOS on Github",
+)
+
 
 def is_subset(subset, superset):
     # Checks if first dict is a subset of the second one

--- a/test/scenarios/dependency/molecule/shell/converge.yml
+++ b/test/scenarios/dependency/molecule/shell/converge.yml
@@ -8,6 +8,14 @@
         name: molecule
       delegate_to: localhost
 
+    - name: Print the envars
+      ansible.builtin.debug:
+        msg: "{{ lookup('pipe', 'env') | split('\n') | sort }}"
+
+    - name: Dump the ansible configuration
+      ansible.builtin.debug:
+        msg: "{{ lookup('pipe', 'ANSIBLE_FORCE_COLOR=0;NO_COLOR=1 ansible-config dump') | split('\n') }}"
+
     - name: Validate that collection was installed
       ansible.builtin.debug:
         msg: "{{ 'foo' | community.molecule.header }}"

--- a/test/scenarios/dependency/molecule/shell/converge.yml
+++ b/test/scenarios/dependency/molecule/shell/converge.yml
@@ -8,14 +8,6 @@
         name: molecule
       delegate_to: localhost
 
-    - name: Print the envars
-      ansible.builtin.debug:
-        msg: "{{ lookup('pipe', 'env') | split('\n') | sort }}"
-
-    - name: Dump the ansible configuration
-      ansible.builtin.debug:
-        msg: "{{ lookup('pipe', 'ANSIBLE_FORCE_COLOR=0;NO_COLOR=1 ansible-config dump') | split('\n') }}"
-
     - name: Validate that collection was installed
       ansible.builtin.debug:
         msg: "{{ 'foo' | community.molecule.header }}"

--- a/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -13,9 +13,6 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      collections_paths: ${MOLECULE_EPHEMERAL_DIRECTORY}/collections
 scenario:
   name: shell
 verifier:

--- a/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -13,6 +13,9 @@ platforms:
     image: ${TEST_BASE_IMAGE}
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      collections_path: ${MOLECULE_EPHEMERAL_DIRECTORY}/collections
 scenario:
   name: shell
 verifier:

--- a/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -3,7 +3,7 @@ dependency:
   name: shell
   command: >
     bash -c "
-    ansible-galaxy collection install -p '${MOLECULE_EPHEMERAL_DIRECTORY}/collections' community.molecule &&
+    ansible-galaxy collection install -p '${MOLECULE_EPHEMERAL_DIRECTORY}/collections' community.molecule --force &&
     ansible-galaxy role install -p '${MOLECULE_EPHEMERAL_DIRECTORY}/roles' ssbarnea.ansible_role_helloworld
     "
 driver:

--- a/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -15,7 +15,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      collections_path: ${MOLECULE_EPHEMERAL_DIRECTORY}/collections
+      collections_paths: ${MOLECULE_EPHEMERAL_DIRECTORY}/collections
 scenario:
   name: shell
 verifier:


### PR DESCRIPTION
Switch to shared tox.yml

A couple changes for the tests:

Skip the macos podman and docker test as we don't have podman or docker installed
The `test_command_dependency[dependency-default-shell]` fixture was changed to set the collection path for ansible to the directory where the collection is installed.

PYTEST_REQPASS will be reintroduced consistently across the board later