### PR TITLE
Respect ANSIBLE_COLLECTIONS_PATH

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,4 +1,4 @@
-ansible-compat >= 4.1.8
+ansible-compat >= 24.6.0
 ansible-core >= 2.12.10
 click >= 8.0, < 9
 click-help-colors >= 0.9

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,4 +1,4 @@
-ansible-compat >= 24.6.0
+ansible-compat >= 24.6.1
 ansible-core >= 2.12.10
 click >= 8.0, < 9
 click-help-colors >= 0.9

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -141,6 +141,7 @@ def run_command(
         env=env,
         cwd=cwd,
         tee=True,
+        set_acp=False,
     )
     if result.returncode != 0 and check:
         raise CalledProcessError(


### PR DESCRIPTION
Inform ansible compat that the ANSIBLE_COLLECTIONS_PATH does not need to be set.

The change in compat behaviour changed here: https://github.com/ansible/ansible-compat/commit/32ce03c9989698544353a24a5f8b7399c1a0b8a0#diff-52de7db791930eca228ba958a8fe0d53d2695de26a1d6e1aa1906da28f607892R395

and was released in 24.6.0
