### PR TITLE
Restore examples in docs

### DIFF
--- a/docs/examples/docker.md
+++ b/docs/examples/docker.md
@@ -11,31 +11,31 @@ installed.
 ## Config playbook
 
 ```yaml title="molecule.yml"
-{!../molecule/docker/molecule.yml!}
+{!docker/molecule.yml!}
 ```
 
 ```yaml title="requirements.yml"
-{!../molecule/docker/requirements.yml!}
+{!docker/requirements.yml!}
 ```
 
 ## Create playbook
 
 ```yaml title="create.yml"
-{!../molecule/docker/create.yml!}
+{!docker/create.yml!}
 ```
 
 ```yaml title="tasks/create-fail.yml"
-{!../molecule/docker/tasks/create-fail.yml!}
+{!docker/tasks/create-fail.yml!}
 ```
 
 ## Converge playbook
 
 ```yaml title="converge.yml"
-{!../molecule/docker/converge.yml!}
+{!docker/converge.yml!}
 ```
 
 ## Destroy playbook
 
 ```yaml title="destroy.yml"
-{!../molecule/docker/destroy.yml!}
+{!docker/destroy.yml!}
 ```

--- a/docs/examples/kubevirt.md
+++ b/docs/examples/kubevirt.md
@@ -71,7 +71,7 @@ You will need to substitute the following placeholders:
 ## Config playbook
 
 ```yaml title="molecule.yml"
-{!../molecule/kubevirt/molecule.yml!}
+{!kubevirt/molecule.yml!}
 ```
 
 Please, replace the following parameters:
@@ -80,31 +80,31 @@ Please, replace the following parameters:
 - `<Kubernetes Node FQDN>`: Change this to the fully qualified domain name (FQDN) of the Kubernetes node that Ansible will attempt to SSH into via the Service NodePort.
 
 ```yaml title="requirements.yml"
-{!../molecule/kubevirt/requirements.yml!}
+{!kubevirt/requirements.yml!}
 ```
 
 ## Create playbook
 
 ```yaml title="create.yml"
-{!../molecule/kubevirt/create.yml!}
+{!kubevirt/create.yml!}
 ```
 
 ```yaml title="tasks/create_vm.yml"
-{!../molecule/kubevirt/tasks/create_vm.yml!}
+{!kubevirt/tasks/create_vm.yml!}
 ```
 
 ```yaml title="tasks/create_vm_dictionary.yml"
-{!../molecule/kubevirt/tasks/create_vm_dictionary.yml!}
+{!kubevirt/tasks/create_vm_dictionary.yml!}
 ```
 
 ## Converge playbook
 
 ```yaml title="converge.yml"
-{!../molecule/kubevirt/converge.yml!}
+{!kubevirt/converge.yml!}
 ```
 
 ## Destroy playbook
 
 ```yaml title="destroy.yml"
-{!../molecule/kubevirt/destroy.yml!}
+{!kubevirt/destroy.yml!}
 ```

--- a/docs/examples/podman.md
+++ b/docs/examples/podman.md
@@ -11,31 +11,31 @@ installed.
 ## Config playbook
 
 ```yaml title="molecule.yml"
-{!../molecule/podman/molecule.yml!}
+{!podman/molecule.yml!}
 ```
 
 ```yaml title="requirements.yml"
-{!../molecule/podman/requirements.yml!}
+{!podman/requirements.yml!}
 ```
 
 ## Create playbook
 
 ```yaml title="create.yml"
-{!../molecule/podman/create.yml!}
+{!podman/create.yml!}
 ```
 
 ```yaml title="tasks/create-fail.yml"
-{!../molecule/podman/tasks/create-fail.yml!}
+{!podman/tasks/create-fail.yml!}
 ```
 
 ## Converge playbook
 
 ```yaml title="converge.yml"
-{!../molecule/podman/converge.yml!}
+{!podman/converge.yml!}
 ```
 
 ## Destroy playbook
 
 ```yaml title="destroy.yml"
-{!../molecule/podman/destroy.yml!}
+{!podman/destroy.yml!}
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,7 @@ plugins:
 
 markdown_extensions:
   - markdown_include.include:
-      base_path: docs
+      base_path: tests/fixtures/integration/test_command/molecule/
   - admonition
   - def_list
   - footnotes


### PR DESCRIPTION
As a result of the project directory restrucutre the examples in the docs were lost.

This should restore the examples.

If additional includes are needed in the future that fall outside of the specified directory it can be modified later.