### PR TITLE
Add VsCode support for pydoclint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,10 +2,10 @@
   "recommendations": [
     "charliermarsh.ruff",
     "esbenp.prettier-vscode",
+    "gruntfuggly.triggertaskonsave",
     "markis.code-coverage",
     "ms-python.black-formatter",
     "ms-python.debugpy",
-    "ms-python.flake8",
     "ms-python.mypy-type-checker",
     "ms-python.pylint",
     "ms-python.python",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,8 @@
   "pylint.importStrategy": "fromEnvironment",
   "python.testing.pytestArgs": ["tests"],
   "python.testing.pytestEnabled": true,
-  "python.testing.unittestEnabled": false
+  "python.testing.unittestEnabled": false,
+  "triggerTaskOnSave.tasks": {
+    "pydoclint": ["*.py"]
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "pydoclint",
+      "type": "shell",
+      "command": "pydoclint",
+      "args": ["."],
+      "presentation": {
+        "reveal": "never"
+      },
+      "problemMatcher": {
+        "owner": "pydoclint",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.*?):(\\d+):\\s(.*?):\\s(.*)$",
+          "file": 1,
+          "line": 2,
+          "code": 3,
+          "message": 4
+        }
+      },
+      "group": {
+        "kind": "none",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Since flake8 has been removed, VsCode no longer provided feedback during development about new docstring errors.

This PR add a new task called `pydoclint` that runs pydoclint in the background.  Message from pydoclint are parsed with a regex and presented in the problems tab of VsCode by the task.

VsCode does not have native support for running a task on save, so a new extension is added to support that.

The flake8 extension is removed which was an oversight in #4235 

Related #4236 
