### PR TITLE
Community comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![image](https://github.com/ansible-community/molecule/workflows/tox/badge.svg)](https://github.com/ansible-community/molecule/actions)
 [![Python Black Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![Ansible Code of Conduct](https://img.shields.io/badge/Code%20of%20Conduct-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
-[![Discussions](https://img.shields.io/badge/Discussions-silver.svg)](https://github.com/ansible-community/molecule/discussions)
+[![Discussions](https://img.shields.io/badge/Discussions-silver.svg)](https://forum.ansible.com/tag/molecule)
 [![Repository License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 
 Molecule project is designed to aid in the development and testing of
@@ -32,21 +32,14 @@ python3 -m molecule ...  # python module calling method
 
 # Documentation
 
-Read the documentation and more at <https://molecule.readthedocs.io/>.
+Read the documentation and more at <https://ansible.readthedocs.io/projects/molecule/>.
 
 # Get Involved
 
-- Join us in the `#ansible-devtools` irc channel on
-  [libera.chat](https://web.libera.chat/?channel=#ansible-devtools).
-- Check github
-  [discussions](https://github.com/ansible-community/molecule/discussions).
-- Join the community working group by checking the
-  [wiki](https://github.com/ansible/community/wiki/Molecule).
-- Want to know about releases, subscribe to [ansible-announce
-  list](https://groups.google.com/group/ansible-announce).
-- For the full list of Ansible email Lists, IRC channels see the
-  [communication
-  page](https://docs.ansible.com/ansible/latest/community/communication.html).
+See the [Talk to us](https://ansible.readthedocs.io/projects/molecule/contributing/#talk-to-us) section of the documentation to ask questions, find help, and join the conversation.
+
+For complete details, see the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
 
 If you want to get moving fast and make a quick patch:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,16 +1,8 @@
 # Contributing
 
-- To see what's discussed see the [discussions
-  ](https://github.com/ansible-community/molecule/discussions).
-- Join the Molecule [community working
-  group](https://github.com/ansible/community/wiki/molecule) if you
-  would like to influence the direction of the project.
-- Join us in `#ansible-devtools` on
-  [libera.chat](https://web.libera.chat/?channel=#ansible-molecule) matrix/irc,
-  or [molecule discussions](https://github.com/ansible-community/molecule/discussions).
-- The full list of Ansible email lists and IRC channels can be found in
-  the [communication
-  page](https://docs.ansible.com/ansible/latest/community/communication.html).
+Noticed a bug or have an idea to improve Ansible Molecule?
+Want to write some documentation or share your expertise on the forum?
+There are many ways to get involved and contribute, find out how.
 
 ## Guidelines
 
@@ -28,6 +20,30 @@
 - Run all the tests to ensure nothing else was accidentally broken.
 - Reformat the code by following the formatting section below.
 - Submit a pull request.
+
+## Talk to us
+
+Connect with the Ansible community!
+
+Join the Ansible forum to ask questions, get help, and interact with the
+community.
+
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example use the
+  `molecule`, `molecule6`, or `devtools` tags.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
+
+To get release announcements and important changes from the community, see the
+[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+
+You can find more information in the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
+Possible security bugs should be reported via email to
+<mailto:security@ansible.com>.
 
 ## Code Of Conduct
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,9 +49,9 @@ extra:
     - icon: simple/matrix
       link: https://matrix.to/#/#devtools:ansible.com
       name: Matrix
-    - icon: fontawesome/solid/comments
-      link: https://github.com/ansible/molecule/discussions
-      name: Discussions
+    - icon: fontawesome/brands/discourse
+      link: https://forum.ansible.com/c/project/7
+      name: Ansible forum
     - icon: fontawesome/brands/github-alt
       link: https://github.com/ansible/molecule
 


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!