### PR TITLE
Remove explicit self types

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -78,7 +78,7 @@ class Base(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def execute(
-        self: Base,
+        self,
         action_args: list[str] | None = None,
     ) -> None:  # pragma: no cover
         """Abstract method to execute the command.

--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -50,13 +50,13 @@ class Scenario:
         self.config = config
         self._setup()  # type: ignore[no-untyped-call]
 
-    def _remove_scenario_state_directory(self: Scenario) -> None:
+    def _remove_scenario_state_directory(self) -> None:
         """Remove scenario cached disk stored state."""
         directory = str(Path(self.ephemeral_directory).parent)
         LOG.info("Removing %s", directory)
         shutil.rmtree(directory)
 
-    def prune(self: Scenario) -> None:
+    def prune(self) -> None:
         """Prune the scenario ephemeral directory files and returns None.
 
         "safe files" will not be pruned, including the ansible configuration

--- a/tests/unit/command/test_base.py
+++ b/tests/unit/command/test_base.py
@@ -43,7 +43,7 @@ FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures" / "unit" / "test_
 class ExtendedBase(base.Base):
     """ExtendedBase Class."""
 
-    def execute(self: ExtendedBase, action_args: list[str] | None = None) -> None:
+    def execute(self, action_args: list[str] | None = None) -> None:
         """No-op the execute method.
 
         Args:


### PR DESCRIPTION
A few remain, but they are all orphaned instance methods, either mocks or in one case a property wrapper, where the type of self is not implicit.