### PR TITLE
Update util.abs_path to return Path for Paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,6 @@ repos:
     rev: v3.1.0
     hooks:
       - id: add-trailing-comma
-        args:
-          - --py36-plus
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks.git
     rev: v1.5.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,14 +356,14 @@ verbosity_assertions = 2
 [tool.ruff]
 builtins = ["__"]
 cache-dir = "./.cache/.ruff"
-external = [
-  "DOC" # pydoclint
-]
 fix = true
 line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
+external = [
+  "DOC" # pydoclint
+]
 select = ["ALL"]
 
 [tool.ruff.lint.flake8-pytest-style]

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -252,7 +252,7 @@ def get_configs(
     scenario_paths = filter_ignored_scenarios(scenario_paths)
     configs = [
         config.Config(
-            molecule_file=util.abs_path(c),  # type: ignore[arg-type]
+            molecule_file=util.abs_path(c),
             args=args,
             command_args=command_args,
             ansible_args=ansible_args,

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -27,6 +27,7 @@ import logging
 import os
 import shutil
 
+from pathlib import Path
 from typing import Any
 
 from ansible_compat.ports import cached_property
@@ -520,8 +521,8 @@ class Ansible(base.Base):
             os.environ,
             {
                 "ANSIBLE_CONFIG": self._config.provisioner.config_file,
-                "ANSIBLE_ROLES_PATH": ":".join(roles_path_list),  # type: ignore[arg-type]
-                self._config.ansible_collections_path: ":".join(collections_path_list),  # type: ignore[arg-type]
+                "ANSIBLE_ROLES_PATH": ":".join(roles_path_list),
+                self._config.ansible_collections_path: ":".join(collections_path_list),
                 "ANSIBLE_LIBRARY": ":".join(self._get_modules_directories()),
                 "ANSIBLE_FILTER_PLUGINS": ":".join(
                     self._get_filter_plugins_directories(),
@@ -804,17 +805,13 @@ class Ansible(base.Base):
                 vars_target = self.group_vars
 
             if vars_target:
-                target_vars_directory = os.path.join(  # noqa: PTH118
-                    self.inventory_directory,
-                    target,
-                )
-
-                if not os.path.isdir(util.abs_path(target_vars_directory)):  # type: ignore[arg-type]  # noqa: PTH112
-                    os.mkdir(util.abs_path(target_vars_directory))  # type: ignore[arg-type]  # noqa: PTH102
+                target_vars_directory = Path(util.abs_path(Path(self.inventory_directory) / target))
+                if not target_vars_directory.is_dir():
+                    target_vars_directory.mkdir()
 
                 for target in vars_target:  # noqa: PLW2901
                     target_var_content = vars_target[target]
-                    path = os.path.join(util.abs_path(target_vars_directory), target)  # type: ignore[arg-type]  # noqa: PTH118
+                    path = target_vars_directory / target
                     util.write_file(path, util.safe_dump(target_var_content))
 
     def _write_inventory(self):  # type: ignore[no-untyped-def]  # noqa: ANN202

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -805,7 +805,7 @@ class Ansible(base.Base):
                 vars_target = self.group_vars
 
             if vars_target:
-                target_vars_directory = Path(util.abs_path(Path(self.inventory_directory) / target))
+                target_vars_directory = util.abs_path(Path(self.inventory_directory) / target)
                 if not target_vars_directory.is_dir():
                     target_vars_directory.mkdir()
 

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -394,7 +394,7 @@ def filter_verbose_permutation(options: dict[str, Any]) -> dict[str, Any]:
     return {k: options[k] for k in options if not re.match("^[v]+$", k)}
 
 
-def abs_path(path: str | Path | None) -> str | None:
+def abs_path(path: str | Path | None) -> str:
     """Return absolute path.
 
     Args:
@@ -408,7 +408,7 @@ def abs_path(path: str | Path | None) -> str | None:
             path = Path(path)
 
         return str(path.resolve())
-    return None
+    return ""
 
 
 def merge_dicts(a: _T, b: _T) -> _T:

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -29,7 +29,7 @@ import sys
 
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 import jinja2
 import yaml
@@ -394,7 +394,15 @@ def filter_verbose_permutation(options: dict[str, Any]) -> dict[str, Any]:
     return {k: options[k] for k in options if not re.match("^[v]+$", k)}
 
 
-def abs_path(path: str | Path | None) -> str:
+@overload
+def abs_path(path: Path) -> Path: ...
+
+
+@overload
+def abs_path(path: str | None) -> str: ...
+
+
+def abs_path(path: str | Path | None) -> str | Path:
     """Return absolute path.
 
     Args:
@@ -403,12 +411,15 @@ def abs_path(path: str | Path | None) -> str:
     Returns:
         Absolute path of path.
     """
-    if path:
-        if isinstance(path, str):
-            path = Path(path)
+    if not path:
+        return ""
 
-        return str(path.resolve())
-    return ""
+    output_type = type(path)
+    if isinstance(path, str):
+        path = Path(path)
+    path = path.resolve()
+
+    return output_type(path)
 
 
 def merge_dicts(a: _T, b: _T) -> _T:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -329,7 +329,7 @@ def test_abs_path() -> None:
 
 def test_abs_path_with_empty_path() -> None:
     """Test the `abs_path` function with an empty path."""
-    assert util.abs_path("") is None
+    assert util.abs_path("") == ""
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -23,6 +23,7 @@ import binascii
 import os
 import warnings
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -36,7 +37,6 @@ from molecule.text import strip_ansi_escape
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
-    from pathlib import Path
     from typing import Any
     from unittest.mock import Mock
 
@@ -325,6 +325,12 @@ def test_abs_path() -> None:
     """Test the `abs_path` function."""
     test_dir = "/foo/../foo"
     assert util.abs_path(test_dir) == "/foo"
+
+
+def test_abs_path_with_path() -> None:
+    """Test the `abs_path` function."""
+    test_dir = Path("/foo/../foo")
+    assert util.abs_path(test_dir) == Path("/foo")
 
 
 def test_abs_path_with_empty_path() -> None:


### PR DESCRIPTION
Also return empty string instead of None where it would have before.

This allows us to always consume the output, without doing type shenanigans after, and gradually move to Path where it's convenient.