### PR TITLE
Replace click with argparse (#4292)

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -24,8 +24,6 @@ cfgv==3.4.0
 chardet==5.2.0
 charset-normalizer==3.4.0
 check-jsonschema==0.30.0
-click==8.1.8
-click-help-colors==0.9.4
 colorama==0.4.6
 coverage==7.6.9
 cryptography==44.0.0

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,7 +1,5 @@
 ansible-compat >= 24.6.1
 ansible-core >= 2.15.0
-click >= 8.0, < 9
-click-help-colors
 enrich >= 1.2.7
 jsonschema >= 4.9.1
 Jinja2 >= 2.11.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,8 +87,6 @@ repos:
           - --output-format=colorized
         additional_dependencies:
           - ansible-compat>=24.6.1
-          - click
-          - click-help-colors
           - enrich>=1.2.7
           - filelock
           - jsonschema
@@ -103,8 +101,6 @@ repos:
       - id: mypy
         additional_dependencies:
           - ansible-compat>=24.6.1
-          - click
-          - click-help-colors
           - enrich
           - pytest
           - pytest-mock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ strict = true
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  "click_help_colors", # https://github.com/click-contrib/click-help-colors/issues/20
   "testinfra.*" # https://github.com/pytest-dev/pytest-testinfra/issues/619
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-mock
+molecule

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -20,11 +20,10 @@
 """Cleanup Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.command import base
 
@@ -54,28 +53,31 @@ class Cleanup(base.Base):
             self._config.provisioner.cleanup()
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-def cleanup(
-    ctx: click.Context,
-    scenario_name: str = "default",
-) -> None:  # pragma: no cover
+def cleanup() -> None:  # pragma: no cover
     """Use the provisioner to cleanup any changes.
 
     Any changes made to external systems during the stages of testing.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Use the provisioner to cleanup any changes.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
+
+
+if __name__ == "__main__":
+    cleanup()

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -57,7 +57,7 @@ def converge() -> None:  # pragma: no cover
         ansible_args: Arguments to forward to Ansible.
     """
     parser = argparse.ArgumentParser(
-        description="Use the provisioner to configure instances (dependency, create, prepare converge)."
+        description="Use the provisioner to configure instances (dependency, create, prepare converge).",
     )
     parser.add_argument(
         "--scenario-name",

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -20,11 +20,10 @@
 """Converge Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.command import base
 
@@ -50,29 +49,38 @@ class Converge(base.Base):
         self._config.state.change_state("converged", value=True)
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-@click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
-def converge(
-    ctx: click.Context,
-    scenario_name: str,
-    ansible_args: tuple[str],
-) -> None:  # pragma: no cover
+def converge() -> None:  # pragma: no cover
     """Use the provisioner to configure instances (dependency, create, prepare converge).
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
         ansible_args: Arguments to forward to Ansible.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(
+        description="Use the provisioner to configure instances (dependency, create, prepare converge)."
+    )
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+    parser.add_argument(
+        "ansible_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments to forward to Ansible.",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+    ansible_args = args.ansible_args
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args, ansible_args)
+
+
+if __name__ == "__main__":
+    converge()

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -20,11 +20,10 @@
 """Create Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.api import drivers
 from molecule.command import base
@@ -60,34 +59,37 @@ class Create(base.Base):
         self._config.state.change_state("created", value=True)
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-@click.option(
-    "--driver-name",
-    "-d",
-    type=click.Choice([str(s) for s in drivers()]),
-    help=f"Name of driver to use. ({DEFAULT_DRIVER})",
-)
-def create(
-    ctx: click.Context,
-    scenario_name: str,
-    driver_name: str,
-) -> None:  # pragma: no cover
+def create() -> None:  # pragma: no cover
     """Use the provisioner to start the instances.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
         driver_name: Name of the Molecule driver to use.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Use the provisioner to start the instances.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+    parser.add_argument(
+        "--driver-name",
+        "-d",
+        choices=[str(s) for s in drivers()],
+        help=f"Name of driver to use. ({DEFAULT_DRIVER})",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+    driver_name = args.driver_name
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand, "driver_name": driver_name}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
+
+
+if __name__ == "__main__":
+    create()

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -20,11 +20,10 @@
 """Dependency Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.command import base
 
@@ -49,26 +48,29 @@ class Dependency(base.Base):
             self._config.dependency.execute()
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-def dependency(
-    ctx: click.Context,
-    scenario_name: str,
-) -> None:  # pragma: no cover
+def dependency() -> None:  # pragma: no cover
     """Manage the role's dependencies.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Manage the role's dependencies.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
+
+
+if __name__ == "__main__":
+    dependency()

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -20,12 +20,11 @@
 """Destroy Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 import os
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule import util
 from molecule.api import drivers
@@ -60,48 +59,48 @@ class Destroy(base.Base):
         self._config.state.reset()
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-@click.option(
-    "--driver-name",
-    "-d",
-    type=click.Choice([str(s) for s in drivers()]),
-    help=f"Name of driver to use. ({DEFAULT_DRIVER})",
-)
-@click.option(
-    "--all/--no-all",
-    "__all",
-    default=MOLECULE_PARALLEL,
-    help="Destroy all scenarios. Default is False.",
-)
-@click.option(
-    "--parallel/--no-parallel",
-    default=False,
-    help="Enable or disable parallel mode. Default is disabled.",
-)
-def destroy(
-    ctx: click.Context,
-    scenario_name: str | None,
-    driver_name: str,
-    __all: bool,  # noqa: FBT001
-    parallel: bool,  # noqa: FBT001
-) -> None:  # pragma: no cover
+def destroy() -> None:  # pragma: no cover
     """Use the provisioner to destroy the instances.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
         driver_name: Molecule driver to use.
         __all: Whether molecule should target scenario_name or all scenarios.
         parallel: Whether the scenario(s) should be run in parallel mode.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Use the provisioner to destroy the instances.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+    parser.add_argument(
+        "--driver-name",
+        "-d",
+        choices=[str(s) for s in drivers()],
+        help=f"Name of driver to use. ({DEFAULT_DRIVER})",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        default=MOLECULE_PARALLEL,
+        help="Destroy all scenarios. Default is False.",
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        default=False,
+        help="Enable or disable parallel mode. Default is disabled.",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+    driver_name = args.driver_name
+    __all = args.all
+    parallel = args.parallel
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
         "parallel": parallel,
@@ -115,4 +114,8 @@ def destroy(
     if parallel:
         util.validate_parallel_cmd_args(command_args)
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
+
+
+if __name__ == "__main__":
+    destroy()

--- a/src/molecule/command/drivers.py
+++ b/src/molecule/command/drivers.py
@@ -20,37 +20,34 @@
 """Create Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
-import click
-
 from molecule import api
-from molecule.command import base
 from molecule.console import console
 
 
 LOG = logging.getLogger(__name__)
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--format",
-    "-f",
-    type=click.Choice(["simple", "plain"]),
-    default="simple",
-    help="Change output format. (simple)",
-)
-def drivers(
-    ctx: click.Context,  # noqa: ARG001
-    format: str,  # noqa: A002
-) -> None:  # pragma: no cover
+def drivers() -> None:  # pragma: no cover
     """List drivers.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         format: Output format to use.
     """
+    parser = argparse.ArgumentParser(description="List drivers.")
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["simple", "plain"],
+        default="simple",
+        help="Change output format. (simple)",
+    )
+
+    args = parser.parse_args()
+    format = args.format
+
     drivers = []  # pylint: disable=redefined-outer-name
     for driver in api.drivers().values():
         description = str(driver)
@@ -58,3 +55,7 @@ def drivers(
             description = f"{driver!s:16s}[logging.level.notset] {driver.title} Version {driver.version} from {driver.module} python module.)[/logging.level.notset]"  # noqa: E501
         drivers.append([driver, description])
         console.print(description)
+
+
+if __name__ == "__main__":
+    drivers()

--- a/src/molecule/command/init/init.py
+++ b/src/molecule/command/init/init.py
@@ -22,16 +22,9 @@ from __future__ import annotations
 
 import logging
 
-from molecule.command import base
-from molecule.command.init import scenario
-
 
 LOG = logging.getLogger(__name__)
 
 
-@base.click_group_ex()
 def init() -> None:  # pragma: no cover
     """Initialize a new scenario."""
-
-
-init.add_command(scenario.scenario)

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -20,14 +20,13 @@
 """Login Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 import os
 import shlex
 import subprocess
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule import scenarios, util
 from molecule.command import base
@@ -121,31 +120,38 @@ class Login(base.Base):
         subprocess.run(cmd, check=False)
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option("--host", "-h", help="Host to access.")
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-def login(
-    ctx: click.Context,
-    host: str,
-    scenario_name: str,
-) -> None:  # pragma: no cover
+def login() -> None:  # pragma: no cover
     """Log in to one instance.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         host: Host to access.
         scenario_name: Name of the scenario to target.
     """
-    args = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Log in to one instance.")
+    parser.add_argument(
+        "--host",
+        "-h",
+        help="Host to access.",
+    )
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+
+    args = parser.parse_args()
+    host = args.host
+    scenario_name = args.scenario_name
+
+    args_dict = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand, "host": host}
 
-    s = scenarios.Scenarios(base.get_configs(args, command_args), scenario_name)
+    s = scenarios.Scenarios(base.get_configs(args_dict, command_args), scenario_name)
     for scenario in s.all:
         base.execute_subcommand(scenario.config, subcommand)
+
+
+if __name__ == "__main__":
+    login()

--- a/src/molecule/command/matrix.py
+++ b/src/molecule/command/matrix.py
@@ -20,18 +20,17 @@
 """Matrix Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule import scenarios
 from molecule.command import base
 
 
 if TYPE_CHECKING:
-    from molecule.types import CommandArgs, MoleculeArgs
+    from molecule.types import CommandArgs
 
 
 LOG = logging.getLogger(__name__)
@@ -73,26 +72,35 @@ class Matrix(base.Base):
     """
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option("--scenario-name", "-s", help="Name of the scenario to target.")
-# NOTE(retr0h): Cannot introspect base.Base for `click.Choice`, since
-# subclasses have not all loaded at this point.
-@click.argument("subcommand", nargs=1, type=click.UNPROCESSED)
-def matrix(
-    ctx: click.Context,
-    scenario_name: str,
-    subcommand: str,
-) -> None:  # pragma: no cover
+def matrix() -> None:  # pragma: no cover
     """List matrix of steps used to test instances.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
         subcommand: Subcommand to target.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="List matrix of steps used to test instances.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        help="Name of the scenario to target.",
+    )
+    parser.add_argument(
+        "subcommand",
+        nargs=1,
+        help="Subcommand to target.",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+    subcommand = args.subcommand
+
+    args_dict = {"args": vars(args)}
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    s = scenarios.Scenarios(base.get_configs(args, command_args), scenario_name)
+    s = scenarios.Scenarios(base.get_configs(args_dict, command_args), scenario_name)
     s.print_matrix()
+
+
+if __name__ == "__main__":
+    matrix()

--- a/src/molecule/command/reset.py
+++ b/src/molecule/command/reset.py
@@ -20,11 +20,10 @@
 """Lint Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.api import drivers
 from molecule.command import base
@@ -37,28 +36,31 @@ if TYPE_CHECKING:
 LOG = logging.getLogger(__name__)
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-def reset(
-    ctx: click.Context,
-    scenario_name: str,
-) -> None:  # pragma: no cover
+def reset() -> None:  # pragma: no cover
     """Reset molecule temporary folders.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Reset molecule temporary folders.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
     for driver in drivers().values():
         driver.reset()
+
+
+if __name__ == "__main__":
+    reset()

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -20,11 +20,10 @@
 """Side-effect Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.command import base
 
@@ -57,26 +56,31 @@ class SideEffect(base.Base):
             self._config.provisioner.side_effect(action_args)
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-def side_effect(
-    ctx: click.Context,
-    scenario_name: str,
-) -> None:  # pragma: no cover
+def side_effect() -> None:  # pragma: no cover
     """Use the provisioner to perform side-effects to the instances.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
     """
-    args = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(
+        description="Use the provisioner to perform side-effects to the instances."
+    )
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+
+    args_dict = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
+
+
+if __name__ == "__main__":
+    side_effect()

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -63,7 +63,7 @@ def side_effect() -> None:  # pragma: no cover
         scenario_name: Name of the scenario to target.
     """
     parser = argparse.ArgumentParser(
-        description="Use the provisioner to perform side-effects to the instances."
+        description="Use the provisioner to perform side-effects to the instances.",
     )
     parser.add_argument(
         "--scenario-name",

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -20,11 +20,10 @@
 """Syntax Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.command import base
 
@@ -49,26 +48,29 @@ class Syntax(base.Base):
             self._config.provisioner.syntax()
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-def syntax(
-    ctx: click.Context,
-    scenario_name: str,
-) -> None:  # pragma: no cover
+def syntax() -> None:  # pragma: no cover
     """Use the provisioner to syntax check the role.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Use the provisioner to syntax check the role.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
+
+
+if __name__ == "__main__":
+    syntax()

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -65,7 +65,7 @@ def test() -> None:  # pragma: no cover
         platform_name: Name of the platform to use.
     """  # noqa: E501
     parser = argparse.ArgumentParser(
-        description="Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy)."
+        description="Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy).",
     )
     parser.add_argument(
         "--scenario-name",

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -20,11 +20,10 @@
 """Verify Command Module."""
 from __future__ import annotations
 
+import argparse
 import logging
 
 from typing import TYPE_CHECKING
-
-import click
 
 from molecule.command import base
 
@@ -48,26 +47,29 @@ class Verify(base.Base):
         self._config.verifier.execute(action_args)
 
 
-@base.click_command_ex()
-@click.pass_context
-@click.option(
-    "--scenario-name",
-    "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
-)
-def verify(
-    ctx: click.Context,
-    scenario_name: str = "default",
-) -> None:  # pragma: no cover
+def verify() -> None:  # pragma: no cover
     """Run automated tests against instances.
 
     Args:
-        ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
     """
-    args: MoleculeArgs = ctx.obj.get("args")
+    parser = argparse.ArgumentParser(description="Run automated tests against instances.")
+    parser.add_argument(
+        "--scenario-name",
+        "-s",
+        default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
+        help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    )
+
+    args = parser.parse_args()
+    scenario_name = args.scenario_name
+
+    args_dict: MoleculeArgs = {"args": vars(args)}
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args_dict, command_args)
+
+
+if __name__ == "__main__":
+    verify()


### PR DESCRIPTION
- Replaced click with argparse 
- Updated test_converge.py and test_coverage.py for the switch from click to argparse
- Added requirements.txt for dependency management
- Tested by running the unit tests with the updated code 