### PR TITLE
Change location of ephemeral directory

### DIFF
--- a/src/molecule/text.py
+++ b/src/molecule/text.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import re
 
 from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import AnyStr
 
 
@@ -108,3 +111,22 @@ def _to_unicode(data: AnyStr) -> str:
     if isinstance(data, bytes):
         return data.decode("utf-8")
     return data
+
+
+def checksum(data: str | Path, length: int = 5) -> str:
+    """Returns a checksum for the given data.
+
+    Args:
+        data: The data to checksum.
+        length: The length of the checksum.
+
+    Returns:
+        A checksum string.
+    """
+    data = str(data)
+    # Hash the input string using SHA-256
+    hash_object = hashlib.sha256(data.encode("utf-8"))
+    # Convert the hash to a base64-encoded string
+    base64_hash = base64.urlsafe_b64encode(hash_object.digest()).decode("utf-8")
+    # Truncate the result to the desired length
+    return base64_hash[:length]

--- a/tests/unit/test_scenario.py
+++ b/tests/unit/test_scenario.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from molecule import config, util
-from molecule.scenario import Scenario, ephemeral_directory
+from molecule.scenario import Scenario
 
 
 if TYPE_CHECKING:
@@ -235,12 +235,8 @@ def test_setup_creates_ephemeral_and_inventory_directories(  # noqa: D103
 
     assert Path(ephemeral_dir).is_dir()
     assert Path(inventory_dir).is_dir()
-
-
-def test_ephemeral_directory() -> None:  # noqa: D103
     # assure we can write to ephemeral directory
-    path = Path("foo/bar")
-    assert os.access(ephemeral_directory(path), os.W_OK)
+    assert os.access(ephemeral_dir, os.W_OK)
 
 
 def test_ephemeral_directory_overridden_via_env_var(
@@ -255,22 +251,9 @@ def test_ephemeral_directory_overridden_via_env_var(
     """
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("MOLECULE_EPHEMERAL_DIRECTORY", "foo/bar")
+    scenario = Scenario(config.Config(""))
 
-    path = Path("foo/bar")
-    assert os.access(ephemeral_directory(path), os.W_OK)
-
-
-def test_ephemeral_directory_overridden_via_env_var_uses_absolute_path(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Confirm MOLECULE_EPHEMERAL_DIRECTORY uses absolute path.
-
-    Args:
-        monkeypatch: Pytest monkeypatch fixture.
-        tmp_path: Pytest tmp_path fixture.
-    """
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("MOLECULE_EPHEMERAL_DIRECTORY", "foo/bar")
-
-    assert Path(ephemeral_directory()).is_absolute()
+    assert os.access(scenario.ephemeral_directory, os.W_OK)
+    # Confirm MOLECULE_EPHEMERAL_DIRECTORY uses absolute path.
+    assert Path(scenario.ephemeral_directory).is_absolute()
+    assert scenario.ephemeral_directory.endswith("foo/bar")

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ commands =
     coverage xml --data-file={env:COVERAGE_COMBINED} -o {envdir}/coverage.xml --fail-under=0
     coverage lcov --data-file={env:COVERAGE_COMBINED} -o {toxinidir}/.cache/.coverage/lcov.info --fail-under=0
     coverage report --data-file={env:COVERAGE_COMBINED}
+commands_post =
+    git clean -f -d
 allowlist_externals =
     git
     rm


### PR DESCRIPTION
This change is related to https://ansible.readthedocs.io/projects/dev-tools/user-guide/test-isolation/ and makes molecule use the virtualenv for storing its ephemeral data, avoiding use of user level temp directory.

Fixes: https://issues.redhat.com/browse/AAP-37862