### PR TITLE
Remove code that modifies ansible import paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ tests/fixtures/resources/.extensions/
 
 # docs output
 _readthedocs/
+.ansible

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -93,7 +93,7 @@ alter them when needed.
 
 Yes, roles contained in a
 [monorepo](https://en.wikipedia.org/wiki/Monorepo) with other roles are
-automatically picked up and `ANSIBLE_ROLES_PATH` is set accordingly. See
+automatically picked up. See
 [this
 page](guides/monolith.md)
 for more information.

--- a/docs/guides/monolith.md
+++ b/docs/guides/monolith.md
@@ -41,9 +41,6 @@ $ molecule --debug test
 DEBUG: ANSIBLE ENVIRONMENT
 ---
 ANSIBLE_CONFIG: /private/tmp/monolith-repo/roles/baz/molecule/default/.molecule/ansible.cfg
-ANSIBLE_FILTER_PLUGINS: /Users/jodewey/.pyenv/versions/2.7.13/lib/python2.7/site-packages/molecule/provisioner/ansible/plugins/filters:/private/tmp/monolith-repo/roles/baz/plugins/filters:/private/tmp/monolith-repo/roles/baz/molecule/default/.molecule/plugins/filters
-ANSIBLE_LIBRARY: /Users/jodewey/.pyenv/versions/2.7.13/lib/python2.7/site-packages/molecule/provisioner/ansible/plugins/libraries:/private/tmp/monolith-repo/roles/baz/library:/private/tmp/monolith-repo/roles/baz/molecule/default/.molecule/library
-ANSIBLE_ROLES_PATH: /private/tmp/monolith-repo/roles:/private/tmp/monolith-repo/roles/baz/molecule/default/.molecule/roles
 ```
 
 Molecule can be customized any number of ways. Updating the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ arg-type-hints-in-docstring = false
 baseline = ".config/pydoclint-baseline.txt"
 check-return-types = false
 check-yield-types = false
-exclude = '\.cache|\.git|\.tox|build|out|venv'
+exclude = '\.ansible|\.cache|\.git|\.tox|build|out|venv'
 quiet = true # no need to print out the files being checked
 should-document-private-class-attributes = true
 show-filenames-in-every-violation-message = true
@@ -344,13 +344,13 @@ fail-on = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra --showlocals --durations=10"
+addopts = "-ra --showlocals --durations=10 --instafail"
 cache_dir = "./.cache/.pytest"
 markers = [
   "serial: Run this test serially via filelock.",
   "extensive: marks tests that we want to skip by default, as they are indirectly covered by other tests"
 ]
-norecursedirs = ["scenarios"]
+norecursedirs = ["scenarios", ".ansible"]
 testpaths = "tests"
 verbosity_assertions = 2
 

--- a/tests/fixtures/integration/test_command/scenarios/dependency/molecule/shell/molecule.yml
+++ b/tests/fixtures/integration/test_command/scenarios/dependency/molecule/shell/molecule.yml
@@ -3,8 +3,8 @@ dependency:
   name: shell
   command: >
     bash -c "
-    ansible-galaxy collection install -p '${MOLECULE_EPHEMERAL_DIRECTORY}/collections' community.molecule --force &&
-    ansible-galaxy role install -p '${MOLECULE_EPHEMERAL_DIRECTORY}/roles' ssbarnea.ansible_role_helloworld
+    ansible-galaxy collection install community.molecule --force &&
+    ansible-galaxy role install ssbarnea.ansible_role_helloworld
     "
 driver:
   name: default

--- a/tests/unit/verifier/test_testinfra.py
+++ b/tests/unit/verifier/test_testinfra.py
@@ -147,9 +147,6 @@ def test_additional_files_or_dirs_property(_instance):  # type: ignore[no-untype
 def test_testinfra_env_property(_instance):  # type: ignore[no-untyped-def]  # noqa: ANN201, PT019, D103
     assert _instance.env["FOO"] == "bar"
     assert "ANSIBLE_CONFIG" in _instance.env
-    assert "ANSIBLE_ROLES_PATH" in _instance.env
-    assert "ANSIBLE_LIBRARY" in _instance.env
-    assert "ANSIBLE_FILTER_PLUGINS" in _instance.env
 
 
 def test_testinfra_name_property(_instance):  # type: ignore[no-untyped-def]  # noqa: ANN201, PT019, D103

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ pass_env =
     TERM
     USER
 set_env =
+    ANSIBLE_HOME = {toxinidir}/.ansible
     COVERAGE_COMBINED = {envdir}/.coverage
     COVERAGE_FILE = {env:COVERAGE_FILE:{envdir}/.coverage.{envname}}
     COVERAGE_PROCESS_START = {toxinidir}/pyproject.toml


### PR DESCRIPTION
As part of new test-isolation strategy, molecule will no longer take
care itself about modification of:

- ANSIBLE_COLLECTIONS_PATH
- ANSIBLE_ROLES_PATH
- ANSIBLE_LIBRARY
- ANSIBLE_FILTER_PLUGINS

Test isolation is supposed to be covered transparently by ansible-compat runtime when code runs inside a virtual environment. Molecule is already using it for running all its external commands.

Related: https://ansible.readthedocs.io/projects/dev-tools/user-guide/test-isolation/
