### PR TITLE
Select and exclude multiple scenarios

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -123,21 +123,22 @@ def execute_cmdline_scenarios(
     Raises:
         SystemExit: If scenario exits prematurely.
     """
-    glob_str = MOLECULE_GLOB
     if excludes is None:
         excludes = []
 
     configs: list[config.Config] = []
     if scenario_names is None:
-        configs = get_configs(args, command_args, ansible_args, glob_str)
+        configs = [
+            config
+            for config in get_configs(args, command_args, ansible_args, MOLECULE_GLOB)
+            if config.scenario.name not in excludes
+        ]
     else:
+        # filter out excludes
+        scenario_names = [name for name in scenario_names if name not in excludes]
         for scenario_name in scenario_names:
-            glob_str = glob_str.replace("*", scenario_name)
-            configs.extend(
-                config
-                for config in get_configs(args, command_args, ansible_args, glob_str)
-                if config.scenario.name not in excludes
-            )
+            glob_str = MOLECULE_GLOB.replace("*", scenario_name)
+            configs.extend(get_configs(args, command_args, ansible_args, glob_str))
 
     scenarios = _generate_scenarios(scenario_names, configs)
 

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -100,10 +100,10 @@ class Base(abc.ABC):
 
 def execute_cmdline_scenarios(
     scenario_names: list[str] | None,
-    excludes: list[str],
     args: MoleculeArgs,
     command_args: CommandArgs,
     ansible_args: tuple[str, ...] = (),
+    excludes: list[str] | None = None,
 ) -> None:
     """Execute scenario sequences based on parsed command-line arguments.
 
@@ -115,10 +115,10 @@ def execute_cmdline_scenarios(
 
     Args:
         scenario_names: Name of scenarios to run, or ``None`` to run all.
-        excludes: Name of scenarios to not run.
         args: ``args`` dict from ``click`` command context
         command_args: dict of command arguments, including the target
         ansible_args: Optional tuple of arguments to pass to the `ansible-playbook` command
+        excludes: Name of scenarios to not run.
 
     Raises:
         SystemExit: If scenario exits prematurely.
@@ -126,6 +126,8 @@ def execute_cmdline_scenarios(
     glob_str = MOLECULE_GLOB
     if scenario_names is None:
         scenario_names = ["*"]
+    if excludes is None:
+        excludes = []
 
     configs: list[config.Config] = []
     for scenario_name in scenario_names:

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -139,19 +139,7 @@ def execute_cmdline_scenarios(
                 if config.scenario.name not in excludes
             )
 
-    scenarios = molecule.scenarios.Scenarios(
-        configs,
-        scenario_names,
-    )
-
-    if scenario_names is not None:
-        for scenario_name in scenario_names:
-            if scenario_name != "*" and scenarios:
-                LOG.info(
-                    "%s scenario test matrix: %s",
-                    scenario_name,
-                    ", ".join(scenarios.sequence(scenario_name)),
-                )
+    scenarios = _generate_scenarios(scenario_names, configs)
 
     for scenario in scenarios:
         if scenario.config.config["prerun"]:
@@ -186,6 +174,36 @@ def execute_cmdline_scenarios(
                 util.sysexit()
             else:
                 raise
+
+
+def _generate_scenarios(
+    scenario_names: list[str] | None,
+    configs: list[config.Config],
+) -> molecule.scenarios.Scenarios:
+    """Generate Scenarios object from names and configs.
+
+    Args:
+        scenario_names: Names of scenarios to include.
+        configs: List of Config objects to consider.
+
+    Returns:
+        Combined Scenarios object.
+    """
+    scenarios = molecule.scenarios.Scenarios(
+        configs,
+        scenario_names,
+    )
+
+    if scenario_names is not None:
+        for scenario_name in scenario_names:
+            if scenario_name != "*" and scenarios:
+                LOG.info(
+                    "%s scenario test matrix: %s",
+                    scenario_name,
+                    ", ".join(scenarios.sequence(scenario_name)),
+                )
+
+    return scenarios
 
 
 def execute_subcommand(

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -124,33 +124,34 @@ def execute_cmdline_scenarios(
         SystemExit: If scenario exits prematurely.
     """
     glob_str = MOLECULE_GLOB
-    if scenario_names is None:
-        scenario_names = ["*"]
     if excludes is None:
         excludes = []
 
     configs: list[config.Config] = []
-    for scenario_name in scenario_names:
-        glob_str = glob_str.replace("*", scenario_name)
-        configs.extend(
-            config
-            for config in get_configs(args, command_args, ansible_args, glob_str)
-            if config.scenario.name not in excludes
-        )
+    if scenario_names is None:
+        configs = get_configs(args, command_args, ansible_args, glob_str)
+    else:
+        for scenario_name in scenario_names:
+            glob_str = glob_str.replace("*", scenario_name)
+            configs.extend(
+                config
+                for config in get_configs(args, command_args, ansible_args, glob_str)
+                if config.scenario.name not in excludes
+            )
 
     scenarios = molecule.scenarios.Scenarios(
         configs,
         scenario_names,
     )
 
-    # Should do something with this?
-    for scenario_name in scenario_names:
-        if scenario_name != "*" and scenarios:
-            LOG.info(
-                "%s scenario test matrix: %s",
-                scenario_name,
-                ", ".join(scenarios.sequence(scenario_name)),
-            )
+    if scenario_names is not None:
+        for scenario_name in scenario_names:
+            if scenario_name != "*" and scenarios:
+                LOG.info(
+                    "%s scenario test matrix: %s",
+                    scenario_name,
+                    ", ".join(scenarios.sequence(scenario_name)),
+                )
 
     for scenario in scenarios:
         if scenario.config.config["prerun"]:

--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -57,8 +57,21 @@ class Check(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Check all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 @click.option(
     "--parallel/--no-parallel",
@@ -67,7 +80,9 @@ class Check(base.Base):
 )
 def check(  # pragma: no cover
     ctx: click.Context,
-    scenario_name: str,
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
     *,
     parallel: bool,
 ) -> None:
@@ -76,13 +91,18 @@ def check(  # pragma: no cover
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
         parallel: Whether the scenario(s) should be run in parallel.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"parallel": parallel, "subcommand": subcommand}
 
+    if __all:
+        scenario_name = None
+
     if parallel:
         util.validate_parallel_cmd_args(command_args)
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -85,4 +85,4 @@ def check(  # pragma: no cover
     if parallel:
         util.validate_parallel_cmd_args(command_args)
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -59,12 +59,27 @@ class Cleanup(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Cleanup all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 def cleanup(
     ctx: click.Context,
-    scenario_name: str = "default",
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
 ) -> None:  # pragma: no cover
     """Use the provisioner to cleanup any changes.
 
@@ -73,9 +88,14 @@ def cleanup(
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -78,4 +78,4 @@ def cleanup(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -75,4 +75,4 @@ def converge(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args, ansible_args)

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -55,13 +55,28 @@ class Converge(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Converge all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def converge(
     ctx: click.Context,
-    scenario_name: str,
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
     ansible_args: tuple[str],
 ) -> None:  # pragma: no cover
     """Use the provisioner to configure instances (dependency, create, prepare converge).
@@ -69,10 +84,15 @@ def converge(
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
         ansible_args: Arguments to forward to Ansible.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args, ansible_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args, exclude)

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -65,8 +65,9 @@ class Create(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
 @click.option(
     "--driver-name",
@@ -74,20 +75,39 @@ class Create(base.Base):
     type=click.Choice([str(s) for s in drivers()]),
     help=f"Name of driver to use. ({DEFAULT_DRIVER})",
 )
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Start all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
+)
 def create(
     ctx: click.Context,
-    scenario_name: str,
+    scenario_name: list[str] | None,
+    exclude: list[str],
     driver_name: str,
+    __all: bool,  # noqa: FBT001
 ) -> None:  # pragma: no cover
     """Use the provisioner to start the instances.
 
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
         driver_name: Name of the Molecule driver to use.
+        __all: Whether molecule should target scenario_name or all scenarios.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand, "driver_name": driver_name}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -90,4 +90,4 @@ def create(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand, "driver_name": driver_name}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -54,21 +54,41 @@ class Dependency(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Target all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 def dependency(
     ctx: click.Context,
-    scenario_name: str,
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
 ) -> None:  # pragma: no cover
     """Manage the role's dependencies.
 
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -71,4 +71,4 @@ def dependency(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -122,4 +122,5 @@ def destroy(
     if parallel:
         util.validate_parallel_cmd_args(command_args)
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    scenarios = None if scenario_name is None else [scenario_name]
+    base.execute_cmdline_scenarios(scenarios, args, command_args)

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -65,8 +65,9 @@ class Destroy(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
 @click.option(
     "--driver-name",
@@ -79,6 +80,12 @@ class Destroy(base.Base):
     "__all",
     default=MOLECULE_PARALLEL,
     help="Destroy all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 @click.option(
     "--parallel/--no-parallel",

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -94,7 +94,8 @@ class Destroy(base.Base):
 )
 def destroy(
     ctx: click.Context,
-    scenario_name: str | None,
+    scenario_name: list[str] | None,
+    exclude: list[str],
     driver_name: str,
     __all: bool,  # noqa: FBT001
     parallel: bool,  # noqa: FBT001
@@ -104,6 +105,7 @@ def destroy(
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
         driver_name: Molecule driver to use.
         __all: Whether molecule should target scenario_name or all scenarios.
         parallel: Whether the scenario(s) should be run in parallel mode.
@@ -122,5 +124,4 @@ def destroy(
     if parallel:
         util.validate_parallel_cmd_args(command_args)
 
-    scenarios = None if scenario_name is None else [scenario_name]
-    base.execute_cmdline_scenarios(scenarios, args, command_args)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -121,13 +121,28 @@ class Idempotence(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Target all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def idempotence(
     ctx: click.Context,
-    scenario_name: str,
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
     ansible_args: tuple[str, ...],
 ) -> None:  # pragma: no cover
     """Use the provisioner to configure the instances.
@@ -137,10 +152,15 @@ def idempotence(
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
         ansible_args: Arguments to forward to Ansible.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args, ansible_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args, exclude)

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -143,4 +143,4 @@ def idempotence(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args, ansible_args)

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -91,7 +91,7 @@ def list_(
     statuses = []
     s = scenarios.Scenarios(
         base.get_configs(args, command_args, glob_str=MOLECULE_GLOB),
-        [scenario_name],
+        None if scenario_name is None else [scenario_name],
     )
     for scenario in s:
         statuses.extend(base.execute_subcommand(scenario.config, subcommand))

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -91,7 +91,7 @@ def list_(
     statuses = []
     s = scenarios.Scenarios(
         base.get_configs(args, command_args, glob_str=MOLECULE_GLOB),
-        scenario_name,
+        [scenario_name],
     )
     for scenario in s:
         statuses.extend(base.execute_subcommand(scenario.config, subcommand))

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -146,6 +146,6 @@ def login(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand, "host": host}
 
-    s = scenarios.Scenarios(base.get_configs(args, command_args), scenario_name)
+    s = scenarios.Scenarios(base.get_configs(args, command_args), [scenario_name])
     for scenario in s.all:
         base.execute_subcommand(scenario.config, subcommand)

--- a/src/molecule/command/matrix.py
+++ b/src/molecule/command/matrix.py
@@ -94,5 +94,5 @@ def matrix(
     args: MoleculeArgs = ctx.obj.get("args")
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    s = scenarios.Scenarios(base.get_configs(args, command_args), scenario_name)
+    s = scenarios.Scenarios(base.get_configs(args, command_args), [scenario_name])
     s.print_matrix()

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -154,4 +154,4 @@ def prepare(
         "force": force,
     }
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/command/reset.py
+++ b/src/molecule/command/reset.py
@@ -59,6 +59,6 @@ def reset(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)
     for driver in drivers().values():
         driver.reset()

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -62,21 +62,41 @@ class SideEffect(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Target all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 def side_effect(
     ctx: click.Context,
-    scenario_name: str,
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
 ) -> None:  # pragma: no cover
     """Use the provisioner to perform side-effects to the instances.
 
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
     """
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -79,4 +79,4 @@ def side_effect(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -71,4 +71,4 @@ def syntax(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -54,21 +54,41 @@ class Syntax(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Syntax check all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 def syntax(
     ctx: click.Context,
-    scenario_name: str,
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
 ) -> None:  # pragma: no cover
     """Use the provisioner to syntax check the role.
 
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -60,8 +60,9 @@ class Test(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
 )
 @click.option(
     "--platform-name",
@@ -82,6 +83,12 @@ class Test(base.Base):
     help="Test all scenarios. Default is False.",
 )
 @click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
+)
+@click.option(
     "--destroy",
     type=click.Choice(["always", "never"]),
     default="always",
@@ -95,7 +102,8 @@ class Test(base.Base):
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def test(  # noqa: PLR0913
     ctx: click.Context,
-    scenario_name: str | None,
+    scenario_name: list[str],
+    exclude: list[str],
     driver_name: str,
     __all: bool,  # noqa: FBT001
     destroy: Literal["always", "never"],
@@ -108,6 +116,7 @@ def test(  # noqa: PLR0913
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
         driver_name: Name of the driver to use.
         __all: Whether molecule should target scenario_name or all scenarios.
         destroy: The destroy strategy to use.
@@ -131,4 +140,4 @@ def test(  # noqa: PLR0913
     if parallel:
         util.validate_parallel_cmd_args(command_args)
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args)
+    base.execute_cmdline_scenarios(scenario_name, exclude, args, command_args, ansible_args)

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -102,7 +102,7 @@ class Test(base.Base):
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def test(  # noqa: PLR0913
     ctx: click.Context,
-    scenario_name: list[str],
+    scenario_name: list[str] | None,
     exclude: list[str],
     driver_name: str,
     __all: bool,  # noqa: FBT001
@@ -140,4 +140,4 @@ def test(  # noqa: PLR0913
     if parallel:
         util.validate_parallel_cmd_args(command_args)
 
-    base.execute_cmdline_scenarios(scenario_name, exclude, args, command_args, ansible_args)
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args, exclude)

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -53,21 +53,41 @@ class Verify(base.Base):
 @click.option(
     "--scenario-name",
     "-s",
-    default=base.MOLECULE_DEFAULT_SCENARIO_NAME,
-    help=f"Name of the scenario to target. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+    multiple=True,
+    default=[base.MOLECULE_DEFAULT_SCENARIO_NAME],
+    help=f"Name of the scenario to target. May be specified multiple times. ({base.MOLECULE_DEFAULT_SCENARIO_NAME})",
+)
+@click.option(
+    "--all/--no-all",
+    "__all",
+    default=False,
+    help="Verify all scenarios. Default is False.",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Name of the scenario to exclude from running. May be specified multiple times.",
 )
 def verify(
     ctx: click.Context,
-    scenario_name: str = "default",
+    scenario_name: list[str] | None,
+    exclude: list[str],
+    __all: bool,  # noqa: FBT001
 ) -> None:  # pragma: no cover
     """Run automated tests against instances.
 
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
+        exclude: Name of the scenarios to avoid targeting.
+        __all: Whether molecule should target scenario_name or all scenarios.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios([scenario_name], args, command_args)
+    if __all:
+        scenario_name = None
+
+    base.execute_cmdline_scenarios(scenario_name, args, command_args, excludes=exclude)

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -70,4 +70,4 @@ def verify(
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}
 
-    base.execute_cmdline_scenarios(scenario_name, args, command_args)
+    base.execute_cmdline_scenarios([scenario_name], args, command_args)

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -123,7 +123,7 @@ class Scenarios:
     def _verify(self) -> None:
         """Verify the specified scenario was found."""
         scenario_names = [c.scenario.name for c in self._configs]
-        if missing_names := set(self._scenario_names).difference(scenario_names):
+        if missing_names := sorted(set(self._scenario_names).difference(scenario_names)):
             scenario = "Scenario"
             if len(missing_names) > 1:
                 scenario += "s"

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -124,7 +124,11 @@ class Scenarios:
         """Verify the specified scenario was found."""
         scenario_names = [c.scenario.name for c in self._configs]
         if missing_names := set(self._scenario_names).difference(scenario_names):
-            msg = f"Scenario(s) '{missing_names}' not found.  Exiting."
+            scenario = "Scenario"
+            if len(missing_names) > 1:
+                scenario += "s"
+            missing = ", ".join(missing_names)
+            msg = f"{scenario} '{missing}' not found.  Exiting."
             util.sysexit_with_message(msg)
 
     def _filter_for_scenario(self) -> list[Scenario]:

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -41,16 +41,16 @@ class Scenarios:
     def __init__(
         self,
         configs: list[Config],
-        scenario_name: str | None = None,
+        scenario_names: list[str] | None = None,
     ) -> None:
         """Initialize a new scenarios class and returns None.
 
         Args:
             configs: Molecule config instances.
-            scenario_name: The name of the scenario.
+            scenario_names: The names of the scenarios.
         """
         self._configs = configs
-        self._scenario_name = scenario_name
+        self._scenario_names = [] if scenario_names is None else scenario_names
         self._scenarios = self.all
 
     def __iter__(self) -> Scenarios:
@@ -81,7 +81,7 @@ class Scenarios:
         Returns:
             All Scenario objects.
         """
-        if self._scenario_name:
+        if self._scenario_names:
             scenarios = self._filter_for_scenario()
             self._verify()
 
@@ -123,8 +123,8 @@ class Scenarios:
     def _verify(self) -> None:
         """Verify the specified scenario was found."""
         scenario_names = [c.scenario.name for c in self._configs]
-        if self._scenario_name not in scenario_names:
-            msg = f"Scenario '{self._scenario_name}' not found.  Exiting."
+        if missing_names := set(self._scenario_names).difference(scenario_names):
+            msg = f"Scenario(s) '{missing_names}' not found.  Exiting."
             util.sysexit_with_message(msg)
 
     def _filter_for_scenario(self) -> list[Scenario]:
@@ -133,7 +133,7 @@ class Scenarios:
         Returns:
             list
         """
-        return [c.scenario for c in self._configs if c.scenario.name == self._scenario_name]
+        return [c.scenario for c in self._configs if c.scenario.name in self._scenario_names]
 
     def _get_matrix(self) -> dict[str, dict[str, list[str]]]:
         """Build a matrix of scenarios and step sequences.

--- a/tests/unit/command/test_base.py
+++ b/tests/unit/command/test_base.py
@@ -252,7 +252,7 @@ def test_execute_cmdline_scenarios_prune(
         patched_execute_subcommand: Mocked execute_subcommand function.
         patched_prune: Mocked prune function.
     """
-    scenario_name = "default"
+    scenario_name = ["default"]
     args: MoleculeArgs = {}
     command_args: CommandArgs = {"destroy": "always", "subcommand": "test"}
 
@@ -273,7 +273,7 @@ def test_execute_cmdline_scenarios_no_prune(
         patched_prune: Mocked prune function.
         patched_execute_subcommand: Mocked execute_subcommand function.
     """
-    scenario_name = "default"
+    scenario_name = ["default"]
     args: MoleculeArgs = {}
     command_args: CommandArgs = {"destroy": "never", "subcommand": "test"}
 
@@ -301,7 +301,7 @@ def test_execute_cmdline_scenarios_exit_destroy(
         patched_execute_subcommand: Mocked execute_subcommand function.
         patched_sysexit: Mocked util.sysexit function.
     """
-    scenario_name = "default"
+    scenario_name = ["default"]
     args: MoleculeArgs = {}
     command_args: CommandArgs = {"destroy": "always", "subcommand": "test"}
     patched_execute_scenario.side_effect = SystemExit()
@@ -335,7 +335,7 @@ def test_execute_cmdline_scenarios_exit_nodestroy(
         patched_prune: Mocked prune function.
         patched_sysexit: Mocked util.sysexit function.
     """
-    scenario_name = "default"
+    scenario_name = ["default"]
     args: MoleculeArgs = {}
     command_args: CommandArgs = {"destroy": "never", "subcommand": "test"}
 

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -49,7 +49,7 @@ def test_configs_private_member(  # noqa: D103
 def test_scenario_name_private_member(  # noqa: D103
     _instance: scenarios.Scenarios,  # noqa: PT019
 ) -> None:
-    assert _instance._scenario_name is None
+    assert _instance._scenario_names is None
 
 
 def test_scenarios_private_member(  # noqa: D103
@@ -80,7 +80,7 @@ def test_all_property(_instance: scenarios.Scenarios) -> None:  # noqa: PT019, D
 def test_all_filters_on_scenario_name_property(  # noqa: D103
     _instance: scenarios.Scenarios,  # noqa: PT019
 ) -> None:
-    _instance._scenario_name = "default"
+    _instance._scenario_names = ["default"]
 
     assert len(_instance.all) == 1
 
@@ -126,7 +126,7 @@ foo:
 def test_verify_does_not_raise_when_found(  # noqa: D103
     _instance: scenarios.Scenarios,  # noqa: PT019
 ) -> None:
-    _instance._scenario_name = "default"
+    _instance._scenario_names = ["default"]
 
     _instance._verify()
 
@@ -135,7 +135,7 @@ def test_verify_raises_when_scenario_not_found(  # noqa: D103
     _instance: scenarios.Scenarios,  # noqa: PT019
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    _instance._scenario_name = "invalid"
+    _instance._scenario_names = ["invalid"]
     with pytest.raises(SystemExit) as e:
         _instance._verify()
 
@@ -148,12 +148,12 @@ def test_verify_raises_when_scenario_not_found(  # noqa: D103
 def test_filter_for_scenario(  # noqa: D103
     _instance: scenarios.Scenarios,  # noqa: PT019
 ) -> None:
-    _instance._scenario_name = "default"
+    _instance._scenario_names = ["default"]
     result = _instance._filter_for_scenario()
     assert len(result) == 1
     assert result[0].name == "default"
 
-    _instance._scenario_name = "invalid"
+    _instance._scenario_names = ["invalid"]
     result = _instance._filter_for_scenario()
     assert result == []
 

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -145,6 +145,20 @@ def test_verify_raises_when_scenario_not_found(  # noqa: D103
     assert msg in caplog.text
 
 
+def test_verify_raises_when_multiple_scenarios_not_found(  # noqa: D103
+    _instance: scenarios.Scenarios,  # noqa: PT019
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _instance._scenario_names = ["invalid", "also invalid"]
+    with pytest.raises(SystemExit) as e:
+        _instance._verify()
+
+    assert e.value.code == 1
+
+    msg = "Scenarios 'also invalid, invalid' not found.  Exiting."
+    assert msg in caplog.text
+
+
 def test_filter_for_scenario(  # noqa: D103
     _instance: scenarios.Scenarios,  # noqa: PT019
 ) -> None:

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -49,7 +49,7 @@ def test_configs_private_member(  # noqa: D103
 def test_scenario_name_private_member(  # noqa: D103
     _instance: scenarios.Scenarios,  # noqa: PT019
 ) -> None:
-    assert _instance._scenario_names is None
+    assert _instance._scenario_names == []
 
 
 def test_scenarios_private_member(  # noqa: D103


### PR DESCRIPTION
`molecule test` and `molecule destroy` now support specifying `--scenario-name` multiple times to run multiple scenarios, and also `--exclude` to exclude scenarios.

Support has also been added (along with `--all`) to `molecule check`, `molecule cleanup`, `molecule converge`, `molecule dependency`, `molecule idempotence`, `molecule prepare`, `molecule side-effect`, `molecule syntax`, and `molecule verify`.