### PR TITLE
Update recommended container

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,12 +103,11 @@ has some benefits:
 
 ## Container
 
-`Molecule` is built into a container image by the [Ansible Creator Execution
-Environment](https://github.com/ansible/creator-ee) project, `creator-ee`.
+`Molecule` is built into a [container image for Ansible Development Tools 
+(ADT)](https://ansible.readthedocs.io/projects/dev-tools/container/)
 
 Any questions or bugs related to the use of Molecule from within a container
-should be addressed by the Ansible Creator Execution Environment
-project.
+should be addressed by the ADT project.
 
 ## Source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,7 +103,7 @@ has some benefits:
 
 ## Container
 
-`Molecule` is built into a [container image for Ansible Development Tools 
+`Molecule` is built into a [container image for Ansible Development Tools
 (ADT)](https://ansible.readthedocs.io/projects/dev-tools/container/)
 
 Any questions or bugs related to the use of Molecule from within a container


### PR DESCRIPTION
https://github.com/ansible/creator-ee is no longer maintained and links to https://ansible.readthedocs.io/projects/dev-tools/container/ so I assume it is the recommended replacement.