### PR TITLE
End-of-run summary report

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -81,6 +81,7 @@ prerun
 printenv
 profisioner
 pycolors
+Qalthos
 quux
 reget
 reraised

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -142,39 +142,51 @@ def execute_cmdline_scenarios(
 
     scenarios = _generate_scenarios(scenario_names, configs)
 
-    for scenario in scenarios:
-        if scenario.config.config["prerun"]:
-            role_name_check = scenario.config.config["role_name_check"]
-            LOG.info("Performing prerun with role_name_check=%s...", role_name_check)
-            scenario.config.runtime.prepare_environment(
-                install_local=True,
-                role_name_check=role_name_check,
-            )
-
-        if command_args.get("subcommand") == "reset":
-            LOG.info("Removing %s", scenario.ephemeral_directory)
-            shutil.rmtree(scenario.ephemeral_directory)
-            return
-        try:
-            execute_scenario(scenario)
-        except SystemExit:
-            # if the command has a 'destroy' arg, like test does,
-            # handle that behavior here.
-            if command_args.get("destroy") == "always":
-                msg = (
-                    f"An error occurred during the {scenario.config.subcommand} sequence action: "
-                    f"'{scenario.config.action}'. Cleaning up."
+    try:
+        for scenario in scenarios:
+            if scenario.config.config["prerun"]:
+                role_name_check = scenario.config.config["role_name_check"]
+                LOG.info("Performing prerun with role_name_check=%s...", role_name_check)
+                scenario.config.runtime.prepare_environment(
+                    install_local=True,
+                    role_name_check=role_name_check,
                 )
-                LOG.warning(msg)
-                execute_subcommand(scenario.config, "cleanup")
-                execute_subcommand(scenario.config, "destroy")
-                # always prune ephemeral dir if destroying on failure
-                scenario.prune()
-                if scenario.config.is_parallel:
-                    scenario._remove_scenario_state_directory()  # noqa: SLF001
-                util.sysexit()
-            else:
-                raise
+
+            if command_args.get("subcommand") == "reset":
+                LOG.info("Removing %s", scenario.ephemeral_directory)
+                shutil.rmtree(scenario.ephemeral_directory)
+                return
+            try:
+                execute_scenario(scenario)
+            except SystemExit:
+                # if the command has a 'destroy' arg, like test does,
+                # handle that behavior here.
+                if command_args.get("destroy") == "always":
+                    msg = (
+                        f"An error occurred during the {scenario.config.subcommand} sequence action: "
+                        f"'{scenario.config.action}'. Cleaning up."
+                    )
+                    LOG.warning(msg)
+                    execute_subcommand(scenario.config, "cleanup")
+                    execute_subcommand(scenario.config, "destroy")
+                    # always prune ephemeral dir if destroying on failure
+                    scenario.prune()
+                    if scenario.config.is_parallel:
+                        scenario._remove_scenario_state_directory()  # noqa: SLF001
+                    util.sysexit()
+                else:
+                    raise
+            finally:
+                # Store results regardless
+                scenarios.results.append({"name": scenario.name, "results": scenario.results})
+    # TODO: This should really be replaced with actual control flow, and not abusing SystemExit like this,
+    #       but this is what is here now.
+    except SystemExit:
+        raise
+    finally:
+        import yaml
+
+        print(yaml.safe_dump(scenarios.results))
 
 
 def _generate_scenarios(

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -150,9 +150,10 @@ def execute_cmdline_scenarios(
     except SystemExit:  # noqa: TRY203
         raise
     finally:
-        import yaml
+        if command_args.get("report"):
+            import yaml
 
-        print(yaml.safe_dump(scenarios.results))  # noqa: T201
+            print(yaml.safe_dump(scenarios.results))  # noqa: T201
 
 
 def _generate_scenarios(
@@ -433,8 +434,13 @@ def click_command_options(func: Callable[..., None]) -> Callable[..., None]:
         func: Function to be decorated.
 
     Returns:
-        Function with click options for scenario_name, exclude, and all added.
+        Function with click options for scenario_name, exclude, all, and report added.
     """
+    func = click.option(
+        "--report/--no-report",
+        default=False,
+        help="EXPERIMENTAL: Enable or disable end-of-run summary report. Default is disabled.",
+    )(func)
     func = click.option(
         "--exclude",
         "-e",

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from typing import NoReturn
 
     from molecule.scenario import Scenario
-    from molecule.types import CommandArgs, MoleculeArgs
+    from molecule.types import CommandArgs, MoleculeArgs, ScenariosResults
 
     ClickCommand = Callable[[Callable[..., None]], click.Command]
     ClickGroup = Callable[[Callable[..., None]], click.Group]
@@ -151,9 +151,7 @@ def execute_cmdline_scenarios(
         raise
     finally:
         if command_args.get("report"):
-            import yaml
-
-            print(yaml.safe_dump(scenarios.results))  # noqa: T201
+            print(generate_report(scenarios.results))  # noqa: T201
 
 
 def _generate_scenarios(
@@ -475,3 +473,17 @@ def result_callback(
     # We want to be used we run out custom exit code, regardless if run was
     # a success or failure.
     util.sysexit(0)
+
+
+def generate_report(results: list[ScenariosResults]) -> str:
+    """Print end-of-run report.
+
+    Args:
+        results: Dictionary containing results from each scenario.
+
+    Returns:
+        The formatted end-of-run report.
+    """
+    import yaml
+
+    return yaml.safe_dump(results)

--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -62,10 +62,12 @@ class Check(base.Base):
 )
 def check(  # pragma: no cover
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
     __all: bool,  # noqa: FBT001
     *,
+    report: bool,
     parallel: bool,
 ) -> None:
     """Use the provisioner to perform a Dry-Run (destroy, dependency, create, prepare, converge).
@@ -75,11 +77,12 @@ def check(  # pragma: no cover
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
         parallel: Whether the scenario(s) should be run in parallel.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"parallel": parallel, "subcommand": subcommand}
+    command_args: CommandArgs = {"parallel": parallel, "subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -59,9 +59,12 @@ class Cleanup(base.Base):
 @base.click_command_options
 def cleanup(
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
-    __all: bool,  # noqa: FBT001
+    *,
+    __all: bool,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Use the provisioner to cleanup any changes.
 
@@ -72,10 +75,11 @@ def cleanup(
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand}
+    command_args: CommandArgs = {"subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -56,9 +56,12 @@ class Converge(base.Base):
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def converge(
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
     __all: bool,  # noqa: FBT001
+    *,
+    report: bool,
     ansible_args: tuple[str],
 ) -> None:  # pragma: no cover
     """Use the provisioner to configure instances (dependency, create, prepare converge).
@@ -68,11 +71,12 @@ def converge(
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
         ansible_args: Arguments to forward to Ansible.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand}
+    command_args: CommandArgs = {"subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -71,10 +71,13 @@ class Create(base.Base):
 )
 def create(
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
     driver_name: str,
     __all: bool,  # noqa: FBT001
+    *,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Use the provisioner to start the instances.
 
@@ -84,10 +87,15 @@ def create(
         exclude: Name of the scenarios to avoid targeting.
         driver_name: Name of the Molecule driver to use.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand, "driver_name": driver_name}
+    command_args: CommandArgs = {
+        "subcommand": subcommand,
+        "driver_name": driver_name,
+        "report": report,
+    }
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -54,9 +54,12 @@ class Dependency(base.Base):
 @base.click_command_options
 def dependency(
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
-    __all: bool,  # noqa: FBT001
+    *,
+    __all: bool,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Manage the role's dependencies.
 
@@ -65,10 +68,11 @@ def dependency(
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand}
+    command_args: CommandArgs = {"subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -74,13 +74,16 @@ class Destroy(base.Base):
     default=MOLECULE_PARALLEL,
     help="Enable or disable parallel mode. Default is disabled.",
 )
-def destroy(
+def destroy(  # noqa: PLR0913
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
     driver_name: str,
     __all: bool,  # noqa: FBT001
-    parallel: bool,  # noqa: FBT001
+    *,
+    parallel: bool,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Use the provisioner to destroy the instances.
 
@@ -91,6 +94,7 @@ def destroy(
         driver_name: Molecule driver to use.
         __all: Whether molecule should target scenario_name or all scenarios.
         parallel: Whether the scenario(s) should be run in parallel mode.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
@@ -98,6 +102,7 @@ def destroy(
         "parallel": parallel,
         "subcommand": subcommand,
         "driver_name": driver_name,
+        "report": report,
     }
 
     if __all:

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -125,6 +125,7 @@ def idempotence(
     scenario_name: list[str] | None,
     exclude: list[str],
     __all: bool,  # noqa: FBT001
+    report: bool,  # noqa: FBT001
     ansible_args: tuple[str, ...],
 ) -> None:  # pragma: no cover
     """Use the provisioner to configure the instances.
@@ -136,11 +137,12 @@ def idempotence(
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
         ansible_args: Arguments to forward to Ansible.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand}
+    command_args: CommandArgs = {"subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -127,13 +127,16 @@ class Prepare(base.Base):
     default=False,
     help="Enable or disable force mode. Default is disabled.",
 )
-def prepare(
+def prepare(  # noqa: PLR0913
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
     driver_name: str,
     __all: bool,  # noqa: FBT001
-    force: bool,  # noqa: FBT001
+    *,
+    force: bool,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Use the provisioner to prepare the instances into a particular starting state.
 
@@ -144,6 +147,7 @@ def prepare(
         driver_name: Name of the Molecule driver to use.
         __all: Whether molecule should target scenario_name or all scenarios.
         force: Whether to use force mode.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
@@ -151,6 +155,7 @@ def prepare(
         "subcommand": subcommand,
         "driver_name": driver_name,
         "force": force,
+        "report": report,
     }
 
     if __all:

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -62,9 +62,12 @@ class SideEffect(base.Base):
 @base.click_command_options
 def side_effect(
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
-    __all: bool,  # noqa: FBT001
+    *,
+    __all: bool,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Use the provisioner to perform side-effects to the instances.
 
@@ -73,10 +76,11 @@ def side_effect(
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
     """
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand}
+    command_args: CommandArgs = {"subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -54,9 +54,12 @@ class Syntax(base.Base):
 @base.click_command_options
 def syntax(
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
-    __all: bool,  # noqa: FBT001
+    *,
+    __all: bool,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Use the provisioner to syntax check the role.
 
@@ -65,10 +68,11 @@ def syntax(
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand}
+    command_args: CommandArgs = {"subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -84,14 +84,17 @@ class Test(base.Base):
 @click.argument("ansible_args", nargs=-1, type=click.UNPROCESSED)
 def test(  # noqa: PLR0913
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
     driver_name: str,
     __all: bool,  # noqa: FBT001
+    *,
     destroy: Literal["always", "never"],
-    parallel: bool,  # noqa: FBT001
+    parallel: bool,
     ansible_args: tuple[str, ...],
     platform_name: str,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy).
 
@@ -105,6 +108,7 @@ def test(  # noqa: PLR0913
         parallel: Whether the scenario(s) should be run in parallel mode.
         ansible_args: Arguments to forward to Ansible.
         platform_name: Name of the platform to use.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
@@ -114,6 +118,7 @@ def test(  # noqa: PLR0913
         "subcommand": subcommand,
         "driver_name": driver_name,
         "platform_name": platform_name,
+        "report": report,
     }
 
     if __all:

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -53,9 +53,12 @@ class Verify(base.Base):
 @base.click_command_options
 def verify(
     ctx: click.Context,
+    /,
     scenario_name: list[str] | None,
     exclude: list[str],
-    __all: bool,  # noqa: FBT001
+    *,
+    __all: bool,
+    report: bool,
 ) -> None:  # pragma: no cover
     """Run automated tests against instances.
 
@@ -64,10 +67,11 @@ def verify(
         scenario_name: Name of the scenario to target.
         exclude: Name of the scenarios to avoid targeting.
         __all: Whether molecule should target scenario_name or all scenarios.
+        report: Whether to show an after-run summary report.
     """
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
-    command_args: CommandArgs = {"subcommand": subcommand}
+    command_args: CommandArgs = {"subcommand": subcommand, "report": report}
 
     if __all:
         scenario_name = None

--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -38,6 +38,7 @@ from molecule.text import checksum
 
 if TYPE_CHECKING:
     from molecule.config import Config
+    from molecule.types import ScenarioResult
 
 
 LOG = logging.getLogger(__name__)
@@ -54,6 +55,7 @@ class Scenario:
         """
         self._lock = None
         self.config = config
+        self.results: list[ScenarioResult] = []
         self._setup()
 
     def __repr__(self) -> str:

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -30,6 +30,7 @@ from molecule import util
 if TYPE_CHECKING:
     from molecule.config import Config
     from molecule.scenario import Scenario
+    from molecule.types import ScenarioResult
 
 
 LOG = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ class Scenarios:
         self._configs = configs
         self._scenario_names = [] if scenario_names is None else scenario_names
         self._scenarios = self.all
+        self.results: list[dict[str, str | list[ScenarioResult]]] = []
 
     def __iter__(self) -> Scenarios:
         """Make object iterable.

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -30,7 +30,7 @@ from molecule import util
 if TYPE_CHECKING:
     from molecule.config import Config
     from molecule.scenario import Scenario
-    from molecule.types import ScenarioResult
+    from molecule.types import ScenariosResults
 
 
 LOG = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class Scenarios:
         self._configs = configs
         self._scenario_names = [] if scenario_names is None else scenario_names
         self._scenarios = self.all
-        self.results: list[dict[str, str | list[ScenarioResult]]] = []
+        self.results: list[ScenariosResults] = []
 
     def __iter__(self) -> Scenarios:
         """Make object iterable.

--- a/src/molecule/types.py
+++ b/src/molecule/types.py
@@ -277,3 +277,15 @@ class CommandArgs(TypedDict, total=False):
     platform_name: str
     scenario_name: str
     subcommand: str
+
+
+class ScenarioResult(TypedDict):
+    """Dictionary containing the result of a Scenario run.
+
+    Attributes:
+        subcommand: The action that ran.
+        state: The outcome of the action ("PASSED", "FAILED", or "SKIPPED).
+    """
+
+    subcommand: str | None
+    state: Literal["PASSED", "FAILED", "SKIPPED"]

--- a/src/molecule/types.py
+++ b/src/molecule/types.py
@@ -280,7 +280,7 @@ class CommandArgs(TypedDict, total=False):
 
 
 class ScenarioResult(TypedDict):
-    """Dictionary containing the result of a Scenario run.
+    """Dictionary containing the result of a Scenario action.
 
     Attributes:
         subcommand: The action that ran.
@@ -289,3 +289,15 @@ class ScenarioResult(TypedDict):
 
     subcommand: str | None
     state: Literal["PASSED", "FAILED", "SKIPPED"]
+
+
+class ScenariosResults(TypedDict):
+    """Dictionary containing the results of multiple Scenario runs.
+
+    Attributes:
+        name: The name of the scenario.
+        results: A list of ScenarioResult objects.
+    """
+
+    name: str
+    results: list[ScenarioResult]

--- a/src/molecule/types.py
+++ b/src/molecule/types.py
@@ -264,6 +264,7 @@ class CommandArgs(TypedDict, total=False):
         host: Host to access.
         parallel: Whether to enable parallel mode.
         platform_name: Name of the platform to target.
+        report: Whether to show an after-run summary report.
         scenario_name: Name of the scenario to target.
         subcommand: Name of subcommand being run.
     """
@@ -275,6 +276,7 @@ class CommandArgs(TypedDict, total=False):
     host: str
     parallel: bool
     platform_name: str
+    report: bool
     scenario_name: str
     subcommand: str
 

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -38,6 +38,7 @@ from tests.conftest import mac_on_gh  # pylint:disable=C0411
 
 if TYPE_CHECKING:
     from molecule.app import App
+    from molecule.types import ScenariosResults
 
 
 def run(cmd: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[Any]:
@@ -186,6 +187,51 @@ def test_command(
         assert "converge.yml" in result.stdout
     else:
         assert "PLAY RECAP" in result.stdout
+
+
+def test_command_report(
+    test_ephemeral_dir_env: dict[str, str],
+) -> None:
+    """Test the output of the --report flag.
+
+    Args:
+        test_ephemeral_dir_env: The ephemeral directory env.
+    """
+    cmd = ["molecule", "test", "--report"]
+    result = run(cmd=cmd, env=test_ephemeral_dir_env)
+    assert result.returncode == 0
+
+    scenario_result: ScenariosResults = {
+        "name": "default",
+        "results": [
+            {
+                "state": "PASSED",
+                "subcommand": "destroy",
+            },
+            {
+                "state": "PASSED",
+                "subcommand": "syntax",
+            },
+            {
+                "state": "PASSED",
+                "subcommand": "create",
+            },
+            {
+                "state": "PASSED",
+                "subcommand": "converge",
+            },
+            {
+                "state": "PASSED",
+                "subcommand": "idempotence",
+            },
+            {
+                "state": "PASSED",
+                "subcommand": "destroy",
+            },
+        ],
+    }
+    report = base.generate_report([scenario_result])
+    assert result.stdout.strip().endswith(report.strip())
 
 
 @pytest.mark.extensive


### PR DESCRIPTION
Partially addresses #4004

~~This should probably be hidden behind a flag if this gets merged as is~~

current output:

```
$ molecule test --all --report
INFO     Performing prerun with role_name_check=0...
[...]
INFO     Pruning extra files from scenario ephemeral directory
- name: default
  results:
  - state: PASSED
    subcommand: prepare
- name: integration_failure
  results:
  - state: PASSED
    subcommand: converge
- name: integration_key_checking
  results:
  - state: PASSED
    subcommand: converge
- name: integration_success
  results:
  - state: PASSED
    subcommand: prepare
  - state: FAILED
    subcommand: converge
  - state: PASSED
    subcommand: cleanup
  - state: PASSED
    subcommand: destroy
```