### PR TITLE
Workaround for dependabot improper python version

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,3 @@
+3.10
+
+# Needed by dependabot, see https://github.com/dependabot/dependabot-core/issues/1455

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_disable_tools = ["python"]


### PR DESCRIPTION
Due to https://github.com/dependabot/dependabot-core/issues/1455
we are forced to add a `.python-version` file so dependabot will not use unsupported older python when running.

Still, we need to reconfigure `mise` to tell it to ignore this file.

Related: https://github.com/ansible/ansible-compat/pull/479
Related: AAP-43336
