### PR TITLE
Strip argument documentation from command help text.

### DIFF
--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -73,6 +73,7 @@ def check(  # noqa: PLR0913
 ) -> None:  # pragma: no cover
     """Use the provisioner to perform a Dry-Run (destroy, dependency, create, prepare, converge).
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -81,7 +82,7 @@ def check(  # noqa: PLR0913
         parallel: Whether the scenario(s) should be run in parallel.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -72,6 +72,7 @@ def cleanup(
 
     Any changes made to external systems during the stages of testing.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -79,7 +80,7 @@ def cleanup(
         __all: Whether molecule should target scenario_name or all scenarios.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -68,6 +68,7 @@ def converge(  # noqa: PLR0913
 ) -> None:  # pragma: no cover
     """Use the provisioner to configure instances (dependency, create, prepare converge).
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -76,7 +77,7 @@ def converge(  # noqa: PLR0913
         ansible_args: Arguments to forward to Ansible.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -83,6 +83,7 @@ def create(  # noqa: PLR0913
 ) -> None:  # pragma: no cover
     """Use the provisioner to start the instances.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -91,7 +92,7 @@ def create(  # noqa: PLR0913
         __all: Whether molecule should target scenario_name or all scenarios.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -65,6 +65,7 @@ def dependency(
 ) -> None:  # pragma: no cover
     """Manage the role's dependencies.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -72,7 +73,7 @@ def dependency(
         __all: Whether molecule should target scenario_name or all scenarios.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -87,6 +87,7 @@ def destroy(  # noqa: PLR0913
 ) -> None:  # pragma: no cover
     """Use the provisioner to destroy the instances.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -96,7 +97,7 @@ def destroy(  # noqa: PLR0913
         parallel: Whether the scenario(s) should be run in parallel mode.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/drivers.py
+++ b/src/molecule/command/drivers.py
@@ -48,10 +48,11 @@ def drivers(
 ) -> None:  # pragma: no cover
     """List drivers.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         format: Output format to use.
-    """
+    """  # noqa: D301
     drivers = []  # pylint: disable=redefined-outer-name
     for driver in api.drivers().values():
         description = str(driver)

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -138,6 +138,7 @@ def idempotence(  # noqa: PLR0913
 
     After parse the output to determine idempotence.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -146,7 +147,7 @@ def idempotence(  # noqa: PLR0913
         ansible_args: Arguments to forward to Ansible.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -195,13 +195,14 @@ def scenario(
 
     If name is not specified the 'default' value will be used.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         dependency_name: Name of dependency to initialize.
         driver_name: Name of driver to use.
         provisioner_name: Name of provisioner to use.
         scenario_name: Name of scenario to initialize.
-    """
+    """  # noqa: D301
     command_args: CommandArgs = {
         "dependency_name": dependency_name,
         "driver_name": driver_name,

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -80,11 +80,12 @@ def list_(
 ) -> None:  # pragma: no cover
     """List status of instances.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
         format: Output format type.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand, "format": format}

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -136,11 +136,12 @@ def login(
 ) -> None:  # pragma: no cover
     """Log in to one instance.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         host: Host to access.
         scenario_name: Name of the scenario to target.
-    """
+    """  # noqa: D301
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand, "host": host}

--- a/src/molecule/command/matrix.py
+++ b/src/molecule/command/matrix.py
@@ -87,11 +87,12 @@ def matrix(
 ) -> None:  # pragma: no cover
     """List matrix of steps used to test instances.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
         subcommand: Subcommand to target.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     command_args: CommandArgs = {"subcommand": subcommand}
 

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -142,6 +142,7 @@ def prepare(  # noqa: PLR0913
 ) -> None:  # pragma: no cover
     """Use the provisioner to prepare the instances into a particular starting state.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -151,7 +152,7 @@ def prepare(  # noqa: PLR0913
         force: Whether to use force mode.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/reset.py
+++ b/src/molecule/command/reset.py
@@ -52,10 +52,11 @@ def reset(
 ) -> None:  # pragma: no cover
     """Reset molecule temporary folders.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {"subcommand": subcommand}

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -73,6 +73,7 @@ def side_effect(
 ) -> None:  # pragma: no cover
     """Use the provisioner to perform side-effects to the instances.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -80,7 +81,7 @@ def side_effect(
         __all: Whether molecule should target scenario_name or all scenarios.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -65,6 +65,7 @@ def syntax(
 ) -> None:  # pragma: no cover
     """Use the provisioner to syntax check the role.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -72,7 +73,7 @@ def syntax(
         __all: Whether molecule should target scenario_name or all scenarios.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -99,6 +99,7 @@ def test(  # noqa: PLR0913
 ) -> None:  # pragma: no cover
     """Test (dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy).
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -111,7 +112,7 @@ def test(  # noqa: PLR0913
         platform_name: Name of the platform to use.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -64,6 +64,7 @@ def verify(
 ) -> None:  # pragma: no cover
     """Run automated tests against instances.
 
+    \f
     Args:
         ctx: Click context object holding commandline arguments.
         scenario_name: Name of the scenario to target.
@@ -71,7 +72,7 @@ def verify(
         __all: Whether molecule should target scenario_name or all scenarios.
         report: Whether to show an after-run summary report.
         shared_inventory: Whether the inventory should be shared between scenarios.
-    """
+    """  # noqa: D301
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {

--- a/src/molecule/shell.py
+++ b/src/molecule/shell.py
@@ -153,13 +153,14 @@ def main(
 
         eval "$(_MOLECULE_COMPLETE=SHELL_source molecule)"
 
+    \f
     Args:
         ctx: Click context object.
         debug: Debug option value.
         verbose: Verbose option value.
         base_config: Base config option value.
         env_file: Environment variable file option value.
-    """
+    """  # noqa: D301
     ctx.obj = {}
     ctx.obj["args"] = {}
     ctx.obj["args"]["debug"] = debug


### PR DESCRIPTION
Click stops processing docstrings when it encounters a formfeed (\f) character. We can use this to keep the method argument documentation out of the command help syntax.

See https://click.palletsprojects.com/en/stable/documentation/#truncating-help-texts