### PR TITLE
Fix #4408 parallel execution: create parent directory

### DIFF
--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -147,7 +147,7 @@ class Scenario:
         else:
             path = Path(os.getenv("MOLECULE_EPHEMERAL_DIRECTORY", ""))
         path.mkdir(parents=True, exist_ok=True)
-        
+
         if self.config.is_parallel and not self._lock:
             lock_file = path / ".lock"
             with lock_file.open("w") as self._lock:  # type: ignore[assignment]

--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -146,7 +146,8 @@ class Scenario:
             path = self.config.runtime.cache_dir / "tmp" / project_scenario_directory
         else:
             path = Path(os.getenv("MOLECULE_EPHEMERAL_DIRECTORY", ""))
-
+        path.mkdir(parents=True, exist_ok=True)
+        
         if self.config.is_parallel and not self._lock:
             lock_file = path / ".lock"
             with lock_file.open("w") as self._lock:  # type: ignore[assignment]


### PR DESCRIPTION
Fixes https://github.com/ansible/molecule/issues/4408

ensure directory path for missing ephimeral directory exists.