### PR TITLE
Consolidate command class loggers into base.Base property

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -49,8 +49,6 @@ if TYPE_CHECKING:
     from molecule.scenario import Scenario
     from molecule.types import CommandArgs, MoleculeArgs, ScenariosResults
 
-LOG = logging.getLogger(__name__)
-
 
 class Base(abc.ABC):
     """An abstract base class used to define the command interface."""

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -172,7 +172,8 @@ def _generate_scenarios(
     if scenario_names is not None:
         for scenario_name in scenario_names:
             if scenario_name != "*" and scenarios:
-                scenario_log = logger.get_scenario_logger(__name__, scenario_name)
+                # Use generic "discovery" step since this is scenario discovery phase
+                scenario_log = logger.get_scenario_logger(__name__, scenario_name, "discovery")
                 scenario_log.info(
                     "scenario test matrix: %s",
                     ", ".join(scenarios.sequence(scenario_name)),
@@ -204,7 +205,11 @@ def _run_scenarios(
     for scenario in scenarios.all:
         if scenario.config.config["prerun"]:
             role_name_check = scenario.config.config["role_name_check"]
-            scenario_log = logger.get_scenario_logger(__name__, scenario.config.scenario.name)
+            scenario_log = logger.get_scenario_logger(
+                __name__,
+                scenario.config.scenario.name,
+                "prerun",
+            )
             scenario_log.info("Performing prerun with role_name_check=%s...", role_name_check)
             scenario.config.runtime.prepare_environment(
                 install_local=True,
@@ -212,7 +217,11 @@ def _run_scenarios(
             )
 
         if command_args.get("subcommand") == "reset":
-            scenario_log = logger.get_scenario_logger(__name__, scenario.config.scenario.name)
+            scenario_log = logger.get_scenario_logger(
+                __name__,
+                scenario.config.scenario.name,
+                "reset",
+            )
             scenario_log.info("Removing %s", scenario.ephemeral_directory)
             shutil.rmtree(scenario.ephemeral_directory)
             return
@@ -227,7 +236,12 @@ def _run_scenarios(
                     f"An error occurred during the {scenario.config.subcommand} sequence action: "
                     f"'{scenario.config.action}'. Cleaning up."
                 )
-                scenario_log = logger.get_scenario_logger(__name__, scenario.config.scenario.name)
+                step_name = getattr(scenario.config, "action", "cleanup")
+                scenario_log = logger.get_scenario_logger(
+                    __name__,
+                    scenario.config.scenario.name,
+                    step_name,
+                )
                 scenario_log.warning(msg)
                 execute_subcommand(scenario.config, "cleanup")
                 destroy_results = execute_subcommand_default(default_config, "destroy")
@@ -275,7 +289,7 @@ def execute_subcommand_default(
         default.results = []
         return results
     # Use the default scenario name for this warning since it's about the default scenario
-    scenario_log = logger.get_scenario_logger(__name__, default.name)
+    scenario_log = logger.get_scenario_logger(__name__, default.name, subcommand)
     scenario_log.warning(
         "%s not found in default scenario, falling back to current scenario",
         subcommand,

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -86,6 +86,17 @@ class Base(abc.ABC):
             self._config.provisioner.write_config()
             self._config.provisioner.manage_inventory()
 
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a scenario logger with automatic step name derivation.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+            The step name is automatically derived from the class name (e.g., 'Idempotence' -> 'idempotence').
+        """
+        step_name = self.__class__.__name__.lower()
+        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
+
 
 def execute_cmdline_scenarios(
     scenario_names: list[str] | None,

--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule import util
@@ -34,9 +32,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs, MoleculeArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Check(base.Base):

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -44,7 +44,7 @@ class Cleanup(base.Base):
             c: An instance of a Molecule config.
         """
         super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "cleanup")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to cleanup the instances.

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -36,15 +35,6 @@ if TYPE_CHECKING:
 
 class Cleanup(base.Base):
     """Cleanup Command Class."""
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize Cleanup command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "cleanup")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to cleanup the instances.

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 import click
@@ -38,9 +36,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs, MoleculeArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Converge(base.Base):

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -44,7 +44,17 @@ class Create(base.Base):
             c: An instance of a Molecule config.
         """
         super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "create")
+        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule create`.

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
+from molecule import logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -36,14 +36,6 @@ if TYPE_CHECKING:
 
 class Create(base.Base):
     """Create Command Class."""
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize Create command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
 
     @property
     def _log(self) -> logger.ScenarioLoggerAdapter:

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import logger
+from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -37,16 +37,14 @@ if TYPE_CHECKING:
 class Create(base.Base):
     """Create Command Class."""
 
-    @property
-    def _log(self) -> logger.ScenarioLoggerAdapter:
-        """Get a fresh scenario logger with current context.
+    def __init__(self, c: config.Config) -> None:
+        """Initialize Create command.
 
-        Returns:
-            A scenario logger adapter with current scenario and step context.
+        Args:
+            c: An instance of a Molecule config.
         """
-        # Get step context from the current action being executed
-        step_name = getattr(self._config, "action", "create")
-        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
+        super().__init__(c)
+        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule create`.

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -36,15 +35,6 @@ if TYPE_CHECKING:
 
 class Create(base.Base):
     """Create Command Class."""
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize Create command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule create`.

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
@@ -33,9 +31,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs, MoleculeArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Dependency(base.Base):

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -44,7 +44,17 @@ class Destroy(base.Base):
             c: An instance of a Molecule config.
         """
         super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "destroy")
+        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule destroy`.

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
+from molecule import logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -36,14 +36,6 @@ if TYPE_CHECKING:
 
 class Destroy(base.Base):
     """Destroy Command Class."""
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize Destroy command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
 
     @property
     def _log(self) -> logger.ScenarioLoggerAdapter:

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -36,15 +35,6 @@ if TYPE_CHECKING:
 
 class Destroy(base.Base):
     """Destroy Command Class."""
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize Destroy command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule destroy`.

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import logger
+from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -37,16 +37,14 @@ if TYPE_CHECKING:
 class Destroy(base.Base):
     """Destroy Command Class."""
 
-    @property
-    def _log(self) -> logger.ScenarioLoggerAdapter:
-        """Get a fresh scenario logger with current context.
+    def __init__(self, c: config.Config) -> None:
+        """Initialize Destroy command.
 
-        Returns:
-            A scenario logger adapter with current scenario and step context.
+        Args:
+            c: An instance of a Molecule config.
         """
-        # Get step context from the current action being executed
-        step_name = getattr(self._config, "action", "destroy")
-        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
+        super().__init__(c)
+        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule destroy`.

--- a/src/molecule/command/drivers.py
+++ b/src/molecule/command/drivers.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule import api
@@ -32,9 +30,6 @@ from molecule.console import console
 
 if TYPE_CHECKING:
     import click
-
-
-LOG = logging.getLogger(__name__)
 
 
 @click_command_ex()

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -25,7 +25,6 @@ import re
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 from molecule.exceptions import ScenarioFailureError
@@ -44,15 +43,6 @@ class Idempotence(base.Base):
     If no tasks will be marked as changed \
     the scenario will be considered idempotent.
     """
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize Idempotence command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "idempotence")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule idempotence`.

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -52,7 +52,7 @@ class Idempotence(base.Base):
             c: An instance of a Molecule config.
         """
         super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "idempotence")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule idempotence`.

--- a/src/molecule/command/init/base.py
+++ b/src/molecule/command/init/base.py
@@ -22,14 +22,10 @@
 from __future__ import annotations
 
 import abc
-import logging
 
 from pathlib import Path
 
 from molecule.exceptions import MoleculeError
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Base(abc.ABC):

--- a/src/molecule/command/init/init.py
+++ b/src/molecule/command/init/init.py
@@ -21,13 +21,8 @@
 
 from __future__ import annotations
 
-import logging
-
 from molecule.click_cfg import click_group_ex
 from molecule.command.init import scenario
-
-
-LOG = logging.getLogger(__name__)
 
 
 @click_group_ex()

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -22,7 +22,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import sys
 
@@ -63,9 +62,6 @@ if TYPE_CHECKING:
         provisioner_name: str
         scenario_name: str
         subcommand: str
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Scenario(base.Base):

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -98,7 +98,7 @@ class Scenario(base.Base):
         self._command_args = command_args
         # For init scenario, use the scenario name from command args
         scenario_name = command_args.get("scenario_name", "unknown")
-        self._log = logger.get_scenario_logger(__name__, scenario_name)
+        self._log = logger.get_scenario_logger(__name__, scenario_name, "init")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule init scenario`.

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from rich import box
@@ -41,9 +39,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class List(base.Base):

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -51,7 +51,7 @@ class Login(base.Base):
         """
         super().__init__(c)
         self._pt = None
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "login")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule login`.

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -27,7 +27,7 @@ import subprocess
 
 from typing import TYPE_CHECKING
 
-from molecule import logger, scenarios
+from molecule import scenarios
 from molecule.click_cfg import click_command_ex, options
 from molecule.command import base
 from molecule.exceptions import MoleculeError
@@ -51,7 +51,6 @@ class Login(base.Base):
         """
         super().__init__(c)
         self._pt = None
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "login")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to perform a `molecule login`.

--- a/src/molecule/command/matrix.py
+++ b/src/molecule/command/matrix.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule import scenarios
@@ -34,9 +32,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Matrix(base.Base):

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -94,7 +94,7 @@ class Prepare(base.Base):
             c: An instance of a Molecule config.
         """
         super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "prepare")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to prepare the instances.

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -86,15 +85,6 @@ class Prepare(base.Base):
         Load an env file to read variables from when rendering
         molecule.yml.
     """
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize Prepare command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "prepare")
 
     def execute(self, action_args: list[str] | None = None) -> None:  # noqa: ARG002
         """Execute the actions necessary to prepare the instances.

--- a/src/molecule/command/reset.py
+++ b/src/molecule/command/reset.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule.api import drivers
@@ -34,9 +32,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 @click_command_ex()

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from molecule import config, logger
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
 
@@ -39,15 +38,6 @@ class SideEffect(base.Base):
 
     See the provisioners documentation for further details.
     """
-
-    def __init__(self, c: config.Config) -> None:
-        """Initialize SideEffect command.
-
-        Args:
-            c: An instance of a Molecule config.
-        """
-        super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "side_effect")
 
     def execute(self, action_args: list[str] | None = None) -> None:
         """Execute the actions necessary to perform a `molecule side-effect`.

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -47,7 +47,7 @@ class SideEffect(base.Base):
             c: An instance of a Molecule config.
         """
         super().__init__(c)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name, "side_effect")
 
     def execute(self, action_args: list[str] | None = None) -> None:
         """Execute the actions necessary to perform a `molecule side-effect`.

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
@@ -33,9 +31,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs, MoleculeArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Syntax(base.Base):

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
@@ -33,9 +31,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs, MoleculeArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Test(base.Base):

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
@@ -33,9 +31,6 @@ if TYPE_CHECKING:
     import click
 
     from molecule.types import CommandArgs, MoleculeArgs
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Verify(base.Base):

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -32,7 +32,7 @@ from uuid import uuid4
 
 from ansible_compat.ports import cache, cached_property
 
-from molecule import api, interpolation, platforms, scenario, state, util
+from molecule import api, interpolation, logger, platforms, scenario, state, util
 from molecule.app import get_app
 from molecule.data import __file__ as data_module
 from molecule.dependency import ansible_galaxy, shell
@@ -416,7 +416,8 @@ class Config:
             if my_state.molecule_yml_date_modified is None:
                 my_state.change_state("molecule_yml_date_modified", modTime)
             elif my_state.molecule_yml_date_modified != modTime:
-                LOG.warning(
+                scenario_log = logger.get_scenario_logger(__name__, self.scenario.name, "config")
+                scenario_log.warning(
                     "The scenario config file ('%s') has been modified since the scenario was created. "
                     "If recent changes are important, reset the scenario with 'molecule destroy' to clean up created items or "
                     "'molecule reset' to clear current configuration.",

--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import abc
 import copy
-import logging
 import os
 
 from pathlib import Path
@@ -37,9 +36,6 @@ if TYPE_CHECKING:
     from collections.abc import MutableMapping
 
     from molecule.config import Config
-
-
-LOG = logging.getLogger(__name__)
 
 
 class AnsibleGalaxyBase(base.Base):

--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -29,7 +29,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from molecule import logger, util
+from molecule import util
 from molecule.dependency import base
 
 
@@ -61,7 +61,6 @@ class AnsibleGalaxyBase(base.Base):
         """
         super().__init__(config)
         self._sh_command = []
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
 
         self.command = "ansible-galaxy"
 

--- a/src/molecule/dependency/ansible_galaxy/collections.py
+++ b/src/molecule/dependency/ansible_galaxy/collections.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -13,9 +11,6 @@ from molecule.dependency.ansible_galaxy.base import AnsibleGalaxyBase
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Collections(AnsibleGalaxyBase):

--- a/src/molecule/dependency/ansible_galaxy/roles.py
+++ b/src/molecule/dependency/ansible_galaxy/roles.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -13,9 +11,6 @@ from molecule.dependency.ansible_galaxy.base import AnsibleGalaxyBase
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Roles(AnsibleGalaxyBase):

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -58,7 +58,17 @@ class Base(abc.ABC):
         """
         self._config = config
         self._sh_command: str | list[str] = []
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "dependency")
+        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
 
     def execute_with_retries(self) -> None:
         """Run dependency downloads with retry and timed back-off."""

--- a/src/molecule/dependency/shell.py
+++ b/src/molecule/dependency/shell.py
@@ -25,7 +25,6 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from molecule import logger
 from molecule.dependency import base
 
 
@@ -86,7 +85,6 @@ class Shell(base.Base):
         """
         super().__init__(config)
         self._sh_command = ""
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
 
     @property
     def command(self) -> str:

--- a/src/molecule/dependency/shell.py
+++ b/src/molecule/dependency/shell.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule.dependency import base
@@ -32,9 +30,6 @@ if TYPE_CHECKING:
     from collections.abc import MutableMapping
 
     from molecule.config import Config
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Shell(base.Base):

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -35,9 +33,6 @@ if TYPE_CHECKING:
     from typing import Any
 
     from molecule.config import Config
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Delegated(Driver):

--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -45,8 +45,6 @@ if TYPE_CHECKING:
     R = TypeVar("R")
 
 
-LOG = logging.getLogger(__name__)
-
 LOG_LEVEL_LUT = {
     0: logging.INFO,
     1: logging.DEBUG,

--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -247,22 +247,20 @@ class ScenarioLoggerAdapter(logging.LoggerAdapter):  # type: ignore[type-arg]
 def get_scenario_logger(
     name: str,
     scenario_name: str,
-    step_name: str | None = None,
+    step_name: str,
 ) -> ScenarioLoggerAdapter:
     """Return a scenario-aware logger that includes scenario name in all messages.
 
     Args:
         name: Name of the child logger.
         scenario_name: Name of the scenario for context.
-        step_name: Optional step name (e.g., 'converge', 'create', 'destroy').
+        step_name: Step name (e.g., 'converge', 'create', 'destroy').
 
     Returns:
         A ScenarioLoggerAdapter that includes scenario context in all messages.
     """
     logger = get_logger(name)
-    extra = {"scenario_name": scenario_name}
-    if step_name:
-        extra["step_name"] = step_name
+    extra = {"scenario_name": scenario_name, "step_name": step_name}
     return ScenarioLoggerAdapter(logger, extra)
 
 

--- a/src/molecule/platforms.py
+++ b/src/molecule/platforms.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from typing import TYPE_CHECKING
 
 from molecule import util
@@ -31,9 +29,6 @@ from molecule import util
 if TYPE_CHECKING:
     from molecule.config import Config
     from molecule.types import PlatformData
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Platforms:

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -414,7 +414,17 @@ class Ansible(base.Base):
             config: An instance of a Molecule config.
         """
         super().__init__(config)
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "provisioner")
+        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
 
     @property
     def default_config_options(self) -> dict[str, Any]:

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -39,7 +39,6 @@ from molecule.provisioner import ansible_playbook, ansible_playbooks, base
 if TYPE_CHECKING:
     from typing import Any
 
-    from molecule.config import Config
     from molecule.types import Options
 
     Vivify = collections.defaultdict[str, Any | "Vivify"]
@@ -406,14 +405,6 @@ class Ansible(base.Base):
             - --limit=host1,host2
     ```
     """
-
-    def __init__(self, config: Config) -> None:
-        """Initialize Ansible provisioner.
-
-        Args:
-            config: An instance of a Molecule config.
-        """
-        super().__init__(config)
 
     @property
     def _log(self) -> logger.ScenarioLoggerAdapter:

--- a/src/molecule/provisioner/ansible_playbook.py
+++ b/src/molecule/provisioner/ansible_playbook.py
@@ -70,7 +70,16 @@ class AnsiblePlaybook:
         elif self._config.provisioner:
             self._env = self._config.provisioner.env
 
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "provisioner")
+        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
 
     def bake(self) -> None:
         """Bake ``ansible-playbook`` or ``navigator run`` command so it's ready to execute.

--- a/src/molecule/provisioner/ansible_playbooks.py
+++ b/src/molecule/provisioner/ansible_playbooks.py
@@ -21,7 +21,6 @@
 
 from __future__ import annotations
 
-import logging
 import os
 
 from pathlib import Path
@@ -44,9 +43,6 @@ if TYPE_CHECKING:
         "side_effect",
         "verify",
     ]
-
-
-LOG = logging.getLogger(__name__)
 
 
 class AnsiblePlaybooks:

--- a/src/molecule/provisioner/ansible_playbooks.py
+++ b/src/molecule/provisioner/ansible_playbooks.py
@@ -59,7 +59,17 @@ class AnsiblePlaybooks:
             config: An instance of a Molecule config.
         """
         self._config = config
-        self._log = logger.get_scenario_logger(__name__, self._config.scenario.name)
+
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "provisioner")
+        return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
 
     @property
     def cleanup(self) -> str | None:

--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -67,7 +67,7 @@ class Scenario:
     def _remove_scenario_state_directory(self) -> None:
         """Remove scenario cached disk stored state."""
         directory = str(Path(self.ephemeral_directory).parent)
-        scenario_log = logger.get_scenario_logger(__name__, self.name)
+        scenario_log = logger.get_scenario_logger(__name__, self.name, "scenario")
         scenario_log.info("Removing %s", directory)
         shutil.rmtree(directory)
 
@@ -79,7 +79,7 @@ class Scenario:
         files declared as "safe_files" in the ``driver`` configuration
         declared in ``molecule.yml``.
         """
-        scenario_log = logger.get_scenario_logger(__name__, self.name)
+        scenario_log = logger.get_scenario_logger(__name__, self.name, "scenario")
         scenario_log.info("Pruning extra files from scenario ephemeral directory")
 
         safe_files = [
@@ -155,7 +155,7 @@ class Scenario:
                         break
                     except OSError:
                         delay = 30 * i
-                        scenario_log = logger.get_scenario_logger(__name__, self.name)
+                        scenario_log = logger.get_scenario_logger(__name__, self.name, "scenario")
                         scenario_log.warning(
                             "Retrying to acquire lock on %s, waiting for %s seconds",
                             path,
@@ -163,7 +163,7 @@ class Scenario:
                         )
                         sleep(delay)
                 else:
-                    scenario_log = logger.get_scenario_logger(__name__, self.name)
+                    scenario_log = logger.get_scenario_logger(__name__, self.name, "scenario")
                     scenario_log.warning("Timedout trying to acquire lock on %s", path)
                     raise MoleculeError(code=RC_TIMEOUT)
 

--- a/src/molecule/state.py
+++ b/src/molecule/state.py
@@ -21,8 +21,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict, TypeVar, cast
@@ -32,9 +30,6 @@ from molecule import util
 
 if TYPE_CHECKING:
     from molecule.config import Config
-
-
-LOG = logging.getLogger(__name__)
 VALID_KEYS = [
     "created",
     "converged",

--- a/src/molecule/verifier/ansible.py
+++ b/src/molecule/verifier/ansible.py
@@ -32,7 +32,6 @@ from molecule.api import Verifier
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
 
-    from molecule.config import Config
     from molecule.verifier.base import Schema
 
 
@@ -65,14 +64,6 @@ class Ansible(Verifier):
             FOO: bar
     ```
     """
-
-    def __init__(self, config: Config) -> None:
-        """Initialize Ansible verifier.
-
-        Args:
-            config: An instance of a Molecule config.
-        """
-        super().__init__(config)
 
     @property
     def _log(self) -> logger.ScenarioLoggerAdapter:

--- a/src/molecule/verifier/ansible.py
+++ b/src/molecule/verifier/ansible.py
@@ -73,8 +73,18 @@ class Ansible(Verifier):
             config: An instance of a Molecule config.
         """
         super().__init__(config)
+
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "verify")
         scenario_name = self._config.scenario.name if self._config else "unknown"
-        self._log = logger.get_scenario_logger(__name__, scenario_name)
+        return logger.get_scenario_logger(__name__, scenario_name, step_name)
 
     @property
     def name(self) -> str:

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -22,7 +22,6 @@
 from __future__ import annotations
 
 import glob
-import logging
 import os
 
 from pathlib import Path
@@ -37,9 +36,6 @@ if TYPE_CHECKING:
 
     from molecule.config import Config
     from molecule.verifier.base import Schema
-
-
-LOG = logging.getLogger(__name__)
 
 
 class Testinfra(Verifier):

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -109,8 +109,18 @@ class Testinfra(Verifier):
         super().__init__(config)
         self._testinfra_command: list[str] = []
         self._tests = []  # type: ignore[var-annotated]
+
+    @property
+    def _log(self) -> logger.ScenarioLoggerAdapter:
+        """Get a fresh scenario logger with current context.
+
+        Returns:
+            A scenario logger adapter with current scenario and step context.
+        """
+        # Get step context from the current action being executed
+        step_name = getattr(self._config, "action", "verify")
         scenario_name = self._config.scenario.name if self._config else "unknown"
-        self._log = logger.get_scenario_logger(__name__, scenario_name)
+        return logger.get_scenario_logger(__name__, scenario_name, step_name)
 
     @property
     def name(self) -> str:

--- a/tests/unit/command/test_cleanup.py
+++ b/tests/unit/command/test_cleanup.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
+import logging
 import os
 
 from typing import TYPE_CHECKING
@@ -70,9 +71,17 @@ def test_cleanup_execute(  # noqa: D103
     util.write_file(pb, "")
 
     cu = cleanup.Cleanup(config_instance)
-    cu.execute()
 
-    assert "cleanup" in caplog.text
+    with caplog.at_level(logging.INFO, logger="molecule.molecule.logger"):
+        cu.execute()
+
+    # Check that we have log records with scenario and step information
+    assert any(
+        hasattr(record, "molecule_scenario")
+        and hasattr(record, "molecule_step")
+        and record.molecule_step == "cleanup"
+        for record in caplog.records
+    )
 
     _patched_ansible_cleanup.assert_called_once_with()
 

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -150,15 +150,15 @@ def test_scenario_logger_with_step(caplog):  # type: ignore[no-untyped-def]  # n
     assert record.molecule_scenario == "test_scenario"
     assert record.molecule_step == "converge"
 
-    # Test logger without step
+    # Test logger with step parameter
     caplog.clear()
-    logger_without_step = get_scenario_logger("test", "test_scenario")
+    logger_without_step = get_scenario_logger("test", "test_scenario", "test")
 
     with caplog.at_level(logging.INFO):
         logger_without_step.info("Test message")
 
-    # Check that the log record has scenario but no step information
+    # Check that the log record has both scenario and step information
     record = caplog.records[0]
     assert hasattr(record, "molecule_scenario")
-    assert not hasattr(record, "molecule_step")
+    assert record.molecule_step == "test"
     assert record.molecule_scenario == "test_scenario"


### PR DESCRIPTION
Depends on PR #4485

Problem: Command classes had duplicate logger setup code across 7+ files.
Solution: Single @property _log in base.Base with automatic step derivation.

Key Changes:
- Added @property _log to base.Base with automatic step naming
- Removed individual logger setups from 7 command classes  
- Eliminated 50+ lines of duplicate code
- Updated tests for scenario logger pattern

Impact:
- Future command classes get logger automatically
- Consistent scenario->step format across all commands
- Perfect architectural separation of concerns

Testing: All command tests pass with proper context validation.