### PR TITLE
Add kubevirt driver support to molecule.json

### DIFF
--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -87,7 +87,7 @@
                 "gce",
                 "libvirt",
                 "lxd",
-		"kubevirt"
+                "kubevirt"
               ]
             },
             {

--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -86,7 +86,8 @@
                 "digitalocean",
                 "gce",
                 "libvirt",
-                "lxd"
+                "lxd",
+		"kubevirt"
               ]
             },
             {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `"kubevirt"` to the list of supported drivers in `molecule.json`, allowing Molecule to properly validate and accept `driver.name: kubevirt` in scenario configurations.

This is required for users who wish to use the `molecule-kubevirt` driver (e.g., for testing Ansible roles in KubeVirt-based clusters). Without this addition, Molecule throws an error when parsing `molecule.yml`.

**Background context**:
- Molecule 25.x+ dropped legacy driver autodetection and enforces declared drivers from `molecule.json`
- This patch is based on `molecule==25.1.0`
- Driver is defined externally in the `molecule-kubevirt` plugin repo (see related PR)

**Release note**:
```release-note
Add "kubevirt" to allowed drivers in molecule.json to support external molecule-kubevirt driver
