### PR TITLE
Add Ansible-style Scenario Recap to Report Output

### DIFF
--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -22,8 +22,14 @@ import os
 import re
 import sys
 
-from molecule.constants import MARKUP_MAP
+from typing import TYPE_CHECKING
+
+from molecule.constants import MARKUP_MAP, SCENARIO_RECAP_STATE_ORDER
 from molecule.constants import ANSICodes as A
+
+
+if TYPE_CHECKING:
+    from molecule.reporting import ScenariosResults
 
 
 def to_bool(a: object) -> bool:
@@ -189,7 +195,7 @@ class AnsiOutput:
 
         Args:
             message: The plain text completion message (e.g., "Completed: Successful")
-            color: The ANSI color code (e.g., A.GREEN, A.RED)
+            color: The ANSI color code (e.g., ANSICodes.GREEN, ANSICodes.RED)
 
         Returns:
             Formatted message with or without ANSI codes based on markup_enabled setting.
@@ -253,3 +259,82 @@ class AnsiOutput:
                 result += f" ({note})"
 
         return result
+
+    def format_scenario_recap(self, results: ScenariosResults) -> str:
+        """Format scenario recap similar to Ansible play recap.
+
+        Args:
+            results: The scenario results to format.
+
+        Returns:
+            Formatted recap string with ANSI colors if enabled.
+        """
+        # Import here to avoid circular imports
+        from molecule.reporting import CompletionState  # noqa: PLC0415
+
+        if not results:
+            return ""
+
+        lines = []
+
+        # Header with bold and underline styling, padded to 79 characters
+        header_text = "SCENARIO RECAP"
+        header_padded = f"{header_text:<79}"
+        header = self.process_markup(f"[bold][underline]{header_padded}[/]")
+        lines.append(header)
+
+        # Process each scenario
+        for scenario_result in results:
+            scenario_name = scenario_result.name
+
+            # Count completion states across all actions
+            state_counts = dict.fromkeys(SCENARIO_RECAP_STATE_ORDER, 0)
+            total_actions = 0
+
+            for action_result in scenario_result.actions:
+                total_actions += 1  # One action regardless of how many states it has
+
+                if action_result.states:
+                    # Count all individual states for this action
+                    for state in action_result.states:
+                        if state.state in state_counts:
+                            state_counts[state.state] += 1
+
+            # Create plain text version for length calculations
+            scenario_plain = scenario_name
+
+            # Pad scenario name to 26 characters (like Ansible's host field)
+            scenario_padded_plain = f"{scenario_plain:<26}"
+
+            # Apply colors to the padded plain text
+            scenario_colored = self.process_markup(f"[scenario]{scenario_padded_plain}[/]")
+
+            # Format counts with fixed field widths to ensure alignment
+            # Only apply colors if count > 0 (matching Ansible behavior)
+            actions_part = (
+                self.process_markup(f"[action]actions={total_actions}[/]")
+                if total_actions > 0
+                else f"actions={total_actions}"
+            )
+
+            # Generate state parts dynamically using CompletionState colors
+            state_parts = []
+            for state_name in SCENARIO_RECAP_STATE_ORDER:
+                count = state_counts[state_name]
+
+                # Get the color tag from the CompletionState
+                state_obj = getattr(CompletionState, state_name)
+                color_tag = state_obj.color.tag
+
+                if count > 0:
+                    state_part = self.process_markup(f"[{color_tag}]{state_name}={count}[/]")
+                else:
+                    state_part = f"{state_name}={count}"
+
+                state_parts.append(state_part)
+
+            # Build line with consistent spacing to match expected format
+            line = f"{scenario_colored}: {actions_part}  " + "  ".join(state_parts)
+            lines.append(line)
+
+        return "\n".join(lines)

--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -285,6 +285,9 @@ class AnsiOutput:
 
         # Process each scenario
         for scenario_result in results:
+            if not scenario_result.actions:
+                continue
+
             scenario_name = scenario_result.name
 
             # Count completion states across all actions
@@ -292,13 +295,12 @@ class AnsiOutput:
             total_actions = 0
 
             for action_result in scenario_result.actions:
-                total_actions += 1  # One action regardless of how many states it has
-
                 if action_result.states:
                     # Count all individual states for this action
                     for state in action_result.states:
                         if state.state in state_counts:
                             state_counts[state.state] += 1
+                total_actions += 1  # One action regardless of how many states it has
 
             # Create plain text version for length calculations
             scenario_plain = scenario_name

--- a/src/molecule/constants.py
+++ b/src/molecule/constants.py
@@ -93,6 +93,23 @@ class ANSICodes(StrEnum):
         return self.name.lower()
 
 
+# Scenario recap display order (reverse rank order - lowest to highest priority)
+SCENARIO_RECAP_STATE_ORDER = ("successful", "disabled", "skipped", "missing", "failed")
+
+# Completion state priority order (highest to lowest priority) - used for ActionResult.summary
+COMPLETION_STATE_PRIORITY_ORDER = ("failed", "missing", "skipped", "disabled", "successful")
+
+# Mapping of completion state names to their color tags for scenario recap
+COMPLETION_STATE_COLORS = {
+    "successful": ANSICodes.GREEN,
+    "disabled": ANSICodes.CYAN,
+    "skipped": ANSICodes.CYAN,
+    "missing": ANSICodes.MAGENTA,
+    "failed": ANSICodes.RED,
+    "partial": ANSICodes.GREEN,
+}
+
+
 # Rich markup to ANSI mapping
 MARKUP_MAP: dict[str, str] = {
     "logging.level.debug": ANSICodes.DIM,


### PR DESCRIPTION
### Summary
Introduces a new "Scenario recap" section to Molecule's report output that matches Ansible's play recap format. This enhancement provides users with a consolidated view of scenario execution results, displaying action counts and completion state statistics per scenario with conditional ANSI coloring.

### Motivation
- Improve user experience by providing familiar Ansible-style output formatting
- Offer quick visual summary of test execution across multiple scenarios
- Maintain consistency with Ansible tooling that users already know

### Changes by File

#### `src/molecule/reporting.py`
- Add scenario recap section to main `report()` function  
- Update headers to "DETAILS" and "SCENARIO RECAP" with 79-character padding
- Integrate `format_scenario_recap()` call in report flow
- Use `original_stderr` for proper stream handling

#### `src/molecule/ansi_output.py`
- Add `format_scenario_recap()` method to `AnsiOutput` class
- Implement Ansible-style formatting with 26-character scenario name padding
- Apply conditional ANSI coloring (only when count > 0)
- Generate state counts dynamically from `SCENARIO_RECAP_STATE_ORDER` constant
- Support actions count display (`actions=X`) before completion states

#### `src/molecule/constants.py`
- Add `SCENARIO_RECAP_STATE_ORDER` tuple for display order
- Add `COMPLETION_STATE_PRIORITY_ORDER` tuple for state ranking
- Add `COMPLETION_STATE_COLORS` mapping for consistent color application

#### `tests/unit/test_reporting.py`
- Add comprehensive test coverage for `format_scenario_recap()` method
- Test empty results, single/multiple scenarios, mixed states, and alignment
- Verify conditional coloring behavior and proper state counting
- Update existing report tests for new header format

#### `tests/integration/test_command.py`
- Add `normalize_report_whitespace()` helper for robust test comparisons
- Update test expectations for new "DETAILS" and "SCENARIO RECAP" headers
- Improve error output with unified diff and character count reporting
- Handle 79-character header padding in assertions

### Output Example
```
DETAILS                                                                        
default ➜ create: Completed: Successful
test-scenario ➜ dependency: Completed: 2 missing (Remove from test_sequence to suppress)
test-scenario ➜ converge: Completed: Successful

SCENARIO RECAP                                                                 
default                   : actions=1  successful=1  disabled=0  skipped=0  missing=0  failed=0
test-scenario             : actions=9  successful=3  disabled=0  skipped=0  missing=7  failed=0
```

### Testing
- All unit tests pass with comprehensive coverage of new functionality
- Integration tests pass in tox environment  
- Maintains backward compatibility with existing report output
- No breaking changes to public APIs