### PR TITLE
feat: Add experimental --command-borders flag for visual command output separation

### DIFF
--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -77,26 +77,6 @@ tests/fixtures/integration/test_command/scenarios/verifier/molecule/testinfra-pr
     DOC107: Function `test_ansible_hostname`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
     DOC103: Function `test_ansible_hostname`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [host: ].
 --------------------
-tests/integration/test_command.py
-    DOC601: Class `ParamDefault`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC603: Class `ParamDefault`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [argnames: tuple[str, str], argvalues: tuple[tuple[str, str]], ids: str, indirect: tuple[str, str]]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC101: Function `test_command`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_command`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
-    DOC101: Function `test_command_idempotence`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_command_idempotence`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
-    DOC101: Function `test_command_list_with_format_plain`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_command_list_with_format_plain`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
-    DOC101: Function `test_with_missing_platform_name`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_with_missing_platform_name`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
-    DOC101: Function `test_role_name_check_one`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_role_name_check_one`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
-    DOC101: Function `test_podman`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_podman`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
-    DOC101: Function `test_docker`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_docker`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
-    DOC101: Function `test_smoke`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test_smoke`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app: App].
---------------------
 tests/unit/command/init/test_scenario.py
     DOC201: Function `fixture_command_args` does not have a return section in docstring
     DOC201: Function `fixture_instance` does not have a return section in docstring

--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -18,17 +18,24 @@ already accustomed to Ansible's interface.
 
 from __future__ import annotations
 
+import io
 import os
 import re
+import shlex
+import shutil
 import sys
 
 from typing import TYPE_CHECKING
 
-from molecule.constants import MARKUP_MAP, SCENARIO_RECAP_STATE_ORDER
+from typing_extensions import Self
+
+from molecule.constants import DEFAULT_BORDER_WIDTH, MARKUP_MAP, SCENARIO_RECAP_STATE_ORDER
 from molecule.constants import ANSICodes as A
 
 
 if TYPE_CHECKING:
+    from typing import TextIO
+
     from molecule.reporting import ScenariosResults
 
 
@@ -82,6 +89,57 @@ def should_do_markup() -> bool:
     return sys.stdout.isatty()
 
 
+def split_command_to_strings(cmd: str | list[str]) -> list[str]:
+    """Split command into properly formatted strings for display.
+
+    Args:
+        cmd: Command as string or list
+
+    Returns:
+        List of command argument strings
+    """
+    if isinstance(cmd, str):
+        return shlex.split(cmd)
+    return [str(arg) for arg in cmd]
+
+
+def get_line_style(line: str) -> str:
+    """Extract ANSI escape sequences from beginning of line for style preservation.
+
+    Args:
+        line: Input line that may contain ANSI codes
+
+    Returns:
+        ANSI escape sequence from start of line without reset codes, or empty string if none
+    """
+    # Match ANSI escape sequences at the start of the line
+    # Patterns: \x1b[...m or \033[...m
+    match = re.match(r"^(\x1b\[[0-9;]*m|\033\[[0-9;]*m)", line)
+    if match:
+        escape_seq = match.group(1)
+
+        # Skip pure reset sequences (just \x1b[0m)
+        if escape_seq in ["\x1b[0m", "\033[0m"]:
+            return ""
+
+        # Extract color from reset+color sequences (e.g., \x1b[0;32m -> \x1b[32m)
+        # This prevents reset codes from canceling our DIM formatting
+        if ";3" in escape_seq and escape_seq.startswith(("\x1b[0;", "\033[0;")):
+            # Extract just the color part (30-37 for standard colors)
+            color_match = re.search(r"(3[0-7])m", escape_seq)
+            if color_match:
+                color_code = color_match.group(1)
+                prefix = "\x1b[" if escape_seq.startswith("\x1b") else "\033["
+                return f"{prefix}{color_code}m"
+
+        # Skip other reset sequences (ending with 0m but not just 0m)
+        if escape_seq.endswith("0m") and len(escape_seq) > 5:
+            return ""
+
+        return escape_seq
+    return ""
+
+
 class AnsiOutput:
     """ANSI output formatter with Rich-style markup support.
 
@@ -111,7 +169,7 @@ class AnsiOutput:
         Returns:
             Text with all markup tags removed.
         """
-        return re.sub(r"\[/?[^\]]*\]", "", text)
+        return re.sub(r"\[/?[^\]]*\]", "", str(text))
 
     def process_markup(self, text: str) -> str:
         """Convert Rich-style markup tags to ANSI escape codes.
@@ -340,3 +398,321 @@ class AnsiOutput:
             lines.append(line)
 
         return "\n".join(lines)
+
+
+class BorderedStream:
+    """Stream wrapper that adds border characters to each line."""
+
+    def __init__(self, ansi: AnsiOutput, target_stream: TextIO) -> None:
+        """Initialize stream wrapper.
+
+        Args:
+            ansi: AnsiOutput instance for markup processing
+            target_stream: Actual stream to write to
+        """
+        self.ansi = ansi
+        self.target_stream = target_stream
+        self.buffer = io.StringIO()
+        self.partial_line = ""  # Track partial lines for proper concatenation
+
+    def write(self, text: str) -> int:
+        """Write text with border prefix.
+
+        Args:
+            text: Text to write
+
+        Returns:
+            Number of characters written
+        """
+        if not text:
+            return 0
+
+        # Add to buffer first for getvalue()
+        self.buffer.write(text)
+
+        # Concatenate new text with existing partial line FIRST, then split
+        remaining = self.partial_line + text
+        lines = remaining.split("\n")
+
+        # Process all complete lines
+        for line in lines[:-1]:
+            # Calculate effective width accounting for border prefix
+            terminal_width = shutil.get_terminal_size().columns
+            border_prefix_width = len("  │ ")  # 4 characters: "  │ "
+            continuation_indent_width = 2  # 2 additional spaces for continuation lines
+
+            # Width available for first line
+            first_line_width = terminal_width - border_prefix_width
+            # Width available for continuation lines (less space due to indentation)
+            continuation_width = terminal_width - border_prefix_width - continuation_indent_width
+
+            if len(line) <= first_line_width:
+                # Line fits, output directly
+                line_style = get_line_style(line)
+                styled_prefix = f"{A.DIM}{line_style}{A.BOX_VERTICAL}{A.RESET} "
+                self.target_stream.write(f"  {styled_prefix}{line}\n")
+            else:
+                # Extract original line style to preserve color across wrapped lines
+                original_style = get_line_style(line)
+
+                # Strip ANSI codes for accurate width calculation
+                clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
+
+                # Manual wrapping to handle different widths for first vs continuation lines
+                wrapped_lines = []
+                remaining_text = clean_line
+                is_first = True
+
+                while remaining_text:
+                    # Use appropriate width for this line
+                    current_width = first_line_width if is_first else continuation_width
+
+                    if len(remaining_text) <= current_width:
+                        # Remaining text fits in current line
+                        wrapped_lines.append(remaining_text)
+                        break
+                    # Find best break point within width limit
+                    break_point = remaining_text.rfind(" ", 0, current_width)
+                    if break_point == -1:
+                        # No space found, break at width limit
+                        break_point = current_width
+
+                    # Add this segment
+                    wrapped_lines.append(remaining_text[:break_point])
+                    remaining_text = remaining_text[break_point:].lstrip()
+                    is_first = False
+
+                # Output each wrapped line with proper styling and indentation
+                for i, wrapped_line in enumerate(wrapped_lines):
+                    _wrapped_line = wrapped_line
+                    # Add 2 spaces indentation to continuation lines (all except first)
+                    if i > 0:
+                        _wrapped_line = "  " + _wrapped_line
+
+                    # Apply original line style and color to maintain consistency
+                    styled_prefix = f"{A.DIM}{original_style}{A.BOX_VERTICAL}{A.RESET} "
+                    # Re-apply original color to the content
+                    if original_style:
+                        colored_content = f"{original_style}{_wrapped_line}{A.RESET}"
+                    else:
+                        colored_content = _wrapped_line
+                    self.target_stream.write(f"  {styled_prefix}{colored_content}\n")
+
+        # Store the remaining partial line
+        self.partial_line = lines[-1]
+
+        return len(text)
+
+    def flush(self) -> None:
+        """Flush the stream."""
+        # Write any remaining partial line
+        if self.partial_line:
+            line_style = get_line_style(self.partial_line)
+            styled_prefix = f"{A.DIM}{line_style}{A.BOX_VERTICAL}{A.RESET} "
+            self.target_stream.write(f"  {styled_prefix}{self.partial_line}\n")
+            self.partial_line = ""
+
+        # Clear the buffer after flushing
+        self.buffer = io.StringIO()
+        self.target_stream.flush()
+
+    def getvalue(self) -> str:
+        """Get buffered content."""
+        return self.buffer.getvalue()
+
+
+class CommandBorders:
+    """Manages command execution with visual borders."""
+
+    def __init__(
+        self,
+        cmd: str | list[str],
+        original_stderr: TextIO,
+        width: int = DEFAULT_BORDER_WIDTH,
+    ) -> None:
+        """Initialize command borders.
+
+        Args:
+            cmd: Command to display
+            original_stderr: Original stderr stream
+            width: Border width
+        """
+        if not should_do_markup():
+            return
+
+        self.ansi = AnsiOutput()
+        self.width = width
+        self.runtime_stdout = sys.stdout
+        self.runtime_stderr = sys.stderr
+        self.original_stderr = original_stderr  # Store for header/footer printing
+        self.stdout_capture = BorderedStream(self.ansi, original_stderr)  # Send stdout to stderr
+        self.stderr_capture = BorderedStream(self.ansi, original_stderr)  # Keep stderr to stderr
+        self._print_header_and_command(cmd)
+        sys.stdout = self.stdout_capture
+        sys.stderr = self.stderr_capture
+
+    def _print_header_and_command(self, cmd: str | list[str]) -> None:
+        """Print header with command details.
+
+        Args:
+            cmd: Command to display
+        """
+        # Print header to stderr (bypassing rich) using ANSI line drawing
+        header = self._create_header_line("")
+        self.original_stderr.write(f"  {A.DIM}{header}{A.RESET}\n")
+
+        # Format and display command
+        command_lines = self._format_command_lines(cmd)
+        for line in command_lines:
+            self.original_stderr.write(
+                f"  {A.DIM}{A.BOX_VERTICAL} {line}{A.RESET}\n",
+            )
+
+        # Add blank line with pipe
+        self.original_stderr.write(f"  {A.DIM}{A.BOX_VERTICAL}{A.RESET} \n")
+
+    def _format_command_lines(  # noqa: C901, PLR0912
+        self,
+        cmd: str | list[str],
+        max_width: int | None = None,
+    ) -> list[str]:
+        """Format command for display with proper line breaks.
+
+        Args:
+            cmd: Command string or list of command parts
+            max_width: Optional maximum width for lines. If None, uses terminal width.
+
+        Returns:
+            List of formatted command lines
+        """
+        indent = "  "
+        parts = split_command_to_strings(cmd)
+        if not parts:
+            return [""]
+
+        decor = len("  | ")
+
+        max_width = (
+            shutil.get_terminal_size().columns - decor if max_width is None else max_width - decor
+        )
+
+        lines, i = [], 0
+
+        # First line: exec + first param/flag/value
+        first = parts[i]
+        i += 1
+        if i < len(parts):
+            if parts[i].startswith("-"):
+                first += " " + parts[i]
+                i += 1
+                if i < len(parts) and not parts[i].startswith("-"):
+                    first += " " + parts[i]
+                    i += 1
+            else:
+                first += " " + parts[i]
+                i += 1
+        lines.append(first)
+
+        # Remaining flags/values and positional args
+        while i < len(parts):
+            part = parts[i]
+            if part.startswith("-") and i + 1 < len(parts) and not parts[i + 1].startswith("-"):
+                lines.append(part + " " + parts[i + 1])
+                i += 2
+            elif not part.startswith("-"):
+                lines.append(part)
+                i += 1
+            else:
+                lines.append(part)
+                i += 1
+
+        # Now wrap all lines
+        wrapped = []
+        for i, line in enumerate(lines):
+            while len(line) > max_width:
+                k = line.rfind(" ", 0, max_width)
+                wrapped.append(line[: k if k != -1 else max_width])
+                line = line[(k + 1) if k != -1 else max_width :]  # noqa: PLW2901
+            if i > 0:
+                wrapped.append(indent + line)
+            else:
+                wrapped.append(line)
+        return wrapped
+
+    def _create_header_line(self, text: str) -> str:
+        """Create header line with text.
+
+        Args:
+            text: Text to include in header
+
+        Returns:
+            Formatted header line using ANSI drawing characters
+        """
+        if text:
+            # Calculate padding for centered text
+            content_len = len(text) + 2  # Add 2 for spaces around text
+            padding = (self.width - content_len - 1) // 2  # -1 for corner
+            remaining = self.width - content_len - padding - 1
+            return f"{A.BOX_TOP_LEFT}{A.BOX_HORIZONTAL * padding} {text} {A.BOX_HORIZONTAL * remaining}"
+        # Header without text
+        return f"{A.BOX_TOP_LEFT}{A.BOX_HORIZONTAL * (self.width - 1)}"
+
+    def _create_footer_line(self, return_code: int) -> str:
+        """Create footer line with return code.
+
+        Args:
+            return_code: Command return code
+
+        Returns:
+            Formatted footer line using ANSI drawing characters
+        """
+        footer_text = f" Return code: {return_code} "
+        padding = self.width - len(footer_text) - 2  # 2 = "└" + "─"
+        return f"{A.BOX_BOTTOM_LEFT}{A.BOX_HORIZONTAL}{footer_text}" + A.BOX_HORIZONTAL * padding
+
+    def _print_footer(self, return_code: int) -> None:
+        """Print footer with return code.
+
+        Args:
+            return_code: Command return code
+        """
+        # Use simple color format to match extracted colors from get_line_style
+        footer_color = A.GREEN if return_code == 0 else A.RED
+
+        # Footer line to stderr (bypassing rich) using ANSI line drawing
+        footer = self._create_footer_line(return_code)
+        self.original_stderr.write(f"  {A.DIM}{footer_color}{footer}{A.RESET}\n")
+
+    def finalize(self, return_code: int) -> None:
+        """Finalize borders and restore streams.
+
+        Args:
+            return_code: Command return code
+        """
+        if not should_do_markup():
+            return
+
+        # Flush any remaining content
+        self.stdout_capture.flush()
+        self.stderr_capture.flush()
+
+        # Restore original streams
+        sys.stdout = self.runtime_stdout
+        sys.stderr = self.runtime_stderr
+
+        # Print footer
+        self._print_footer(return_code)
+
+    def __enter__(self) -> Self:
+        """Context manager entry."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Context manager exit."""
+        return_code = 1 if exc_type else 0
+        self.finalize(return_code)

--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -129,11 +129,13 @@ def get_line_style(line: str) -> str:
             color_match = re.search(r"(3[0-7])m", escape_seq)
             if color_match:
                 color_code = color_match.group(1)
-                prefix = "\x1b[" if escape_seq.startswith("\x1b") else "\033["
-                return f"{prefix}{color_code}m"
+                # Use \x1b prefix consistently (most common format)
+                return f"\x1b[{color_code}m"
 
         # Skip other reset sequences (ending with 0m but not just 0m)
-        if escape_seq.endswith("0m") and len(escape_seq) > 5:
+        # Length 5 is minimum for reset+color (\x1b[0m = 5 chars)
+        min_reset_color_length = 5
+        if escape_seq.endswith("0m") and len(escape_seq) > min_reset_color_length:
             return ""
 
         return escape_seq

--- a/src/molecule/click_cfg.py
+++ b/src/molecule/click_cfg.py
@@ -39,6 +39,7 @@ COMMON_OPTIONS = [
     "scenario_name_with_default",
     "shared_inventory",
     "shared_state",
+    "command_borders",
 ]
 
 
@@ -371,6 +372,17 @@ class CliOptions:
         return CliOption(
             name="shared-state",
             help="Enable or disable sharing (some) state between scenarios.",
+            is_flag=True,
+            default=False,
+            experimental=True,
+        )
+
+    @property
+    def command_borders(self) -> CliOption:
+        """Command borders option."""
+        return CliOption(
+            name="command-borders",
+            help="Enable or disable borders around command output.",
             is_flag=True,
             default=False,
             experimental=True,

--- a/src/molecule/command/check.py
+++ b/src/molecule/command/check.py
@@ -59,6 +59,7 @@ def check(ctx: click.Context) -> None:  # pragma: no cover
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     parallel = ctx.params["parallel"]
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "parallel": parallel,
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -66,6 +66,7 @@ def cleanup(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],
         "shared_state": ctx.params["shared_state"],

--- a/src/molecule/command/converge.py
+++ b/src/molecule/command/converge.py
@@ -63,6 +63,7 @@ def converge(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],
         "shared_state": ctx.params["shared_state"],

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -68,6 +68,7 @@ def create(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "driver_name": ctx.params["driver_name"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],

--- a/src/molecule/command/dependency.py
+++ b/src/molecule/command/dependency.py
@@ -57,6 +57,7 @@ def dependency(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],
         "shared_state": ctx.params["shared_state"],

--- a/src/molecule/command/destroy.py
+++ b/src/molecule/command/destroy.py
@@ -63,6 +63,7 @@ def destroy(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "driver_name": ctx.params["driver_name"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],

--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -127,6 +127,7 @@ def idempotence(ctx: click.Context) -> None:  # pragma: no cover
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],
         "shared_state": ctx.params["shared_state"],

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -135,7 +135,12 @@ class Scenario(base.Base):
         # it to use colors.
         env["ANSIBLE_FORCE_COLOR"] = "1"
         env["ANSIBLE_PYTHON_INTERPRETER"] = sys.executable
-        self._config.app.run_command(cmd, env=env, check=True)
+        self._config.app.run_command(
+            cmd,
+            env=env,
+            check=True,
+            command_borders=self._config.command_borders,
+        )
 
         msg = f"Initialized scenario in {scenario_directory} successfully."
         self._log.info(msg)

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -127,6 +127,7 @@ def login(ctx: click.Context) -> None:  # pragma: no cover
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "host": ctx.params["host"],
         "subcommand": subcommand,
     }

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -122,6 +122,7 @@ def prepare(ctx: click.Context) -> None:  # pragma: no cover
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "force": ctx.params["force"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -69,6 +69,7 @@ def side_effect(ctx: click.Context) -> None:  # pragma: no cover
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],
         "shared_state": ctx.params["shared_state"],

--- a/src/molecule/command/syntax.py
+++ b/src/molecule/command/syntax.py
@@ -57,6 +57,7 @@ def syntax(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],
         "shared_state": ctx.params["shared_state"],

--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -61,6 +61,7 @@ def test(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "destroy": ctx.params["destroy"],
         "driver_name": ctx.params["driver_name"],
         "platform_name": ctx.params["platform_name"],

--- a/src/molecule/command/verify.py
+++ b/src/molecule/command/verify.py
@@ -56,6 +56,7 @@ def verify(ctx: click.Context) -> None:  # pragma: no cover
     args: MoleculeArgs = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "report": ctx.params["report"],
         "shared_inventory": ctx.params["shared_inventory"],
         "shared_state": ctx.params["shared_state"],

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -174,6 +174,11 @@ class Config:
         return self.command_args.get("shared_state", False)
 
     @property
+    def command_borders(self) -> bool:
+        """Return if command borders are enabled."""
+        return self.command_args.get("command_borders", False)
+
+    @property
     def platform_name(self) -> str | None:
         """Configured platform.
 

--- a/src/molecule/constants.py
+++ b/src/molecule/constants.py
@@ -48,6 +48,17 @@ class ANSICodes(StrEnum):
         DIM: Dim text.
         ITALIC: Italic text.
         UNDERLINE: Underline text.
+        NOT_DIM: Turn off bold and dim without affecting colors.
+        BOX_TOP_LEFT: Top-left corner box drawing character.
+        BOX_TOP_RIGHT: Top-right corner box drawing character.
+        BOX_BOTTOM_LEFT: Bottom-left corner box drawing character.
+        BOX_BOTTOM_RIGHT: Bottom-right corner box drawing character.
+        BOX_HORIZONTAL: Horizontal line box drawing character.
+        BOX_VERTICAL: Vertical line box drawing character.
+        BOX_TOP_MIDDLE: Top middle junction box drawing character.
+        BOX_BOTTOM_MIDDLE: Bottom middle junction box drawing character.
+        BOX_LEFT_MIDDLE: Left middle junction box drawing character.
+        BOX_RIGHT_MIDDLE: Right middle junction box drawing character.
         RIGHT_ARROW: Right arrow.
     """
 
@@ -79,6 +90,21 @@ class ANSICodes(StrEnum):
     DIM = "\033[2m"
     ITALIC = "\033[3m"
     UNDERLINE = "\033[4m"
+
+    # Text Style Resets (specific, not full reset)
+    NOT_DIM = "\033[22m"  # Turns off bold and dim without affecting colors
+
+    # Box Drawing Constants
+    BOX_TOP_LEFT = "\u250c"
+    BOX_TOP_RIGHT = "\u2510"
+    BOX_BOTTOM_LEFT = "\u2514"
+    BOX_BOTTOM_RIGHT = "\u2518"
+    BOX_HORIZONTAL = "\u2500"
+    BOX_VERTICAL = "\u2502"
+    BOX_TOP_MIDDLE = "\u252c"
+    BOX_BOTTOM_MIDDLE = "\u2534"
+    BOX_LEFT_MIDDLE = "\u251c"
+    BOX_RIGHT_MIDDLE = "\u2524"
 
     # Molecule-specific symbols
     RIGHT_ARROW = "➜"
@@ -122,3 +148,6 @@ MARKUP_MAP: dict[str, str] = {
     "scenario": ANSICodes.GREEN,
     "action": ANSICodes.YELLOW,
 }
+
+# Border width constant
+DEFAULT_BORDER_WIDTH = 83

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -73,7 +73,12 @@ class Base(abc.ABC):
     def execute_with_retries(self) -> None:
         """Run dependency downloads with retry and timed back-off."""
         try:
-            self._config.app.run_command(self._sh_command, debug=self._config.debug, check=True)
+            self._config.app.run_command(
+                self._sh_command,
+                debug=self._config.debug,
+                check=True,
+                command_borders=self._config.command_borders,
+            )
             msg = "Dependency completed successfully."
             self._log.info(msg)
             return  # noqa: TRY300
@@ -90,7 +95,12 @@ class Base(abc.ABC):
             self.SLEEP += self.BACKOFF
 
             try:
-                self._config.app.run_command(self._sh_command, debug=self._config.debug, check=True)
+                self._config.app.run_command(
+                    self._sh_command,
+                    debug=self._config.debug,
+                    check=True,
+                    command_borders=self._config.command_borders,
+                )
                 msg = "Dependency completed successfully."
                 self._log.info(msg)
                 return  # noqa: TRY300

--- a/src/molecule/provisioner/ansible_playbook.py
+++ b/src/molecule/provisioner/ansible_playbook.py
@@ -126,7 +126,7 @@ class AnsiblePlaybook:
                         text=True,
                         check=True,
                     )
-                    self._log.info("%s version: %s", backend, result.stdout.strip())
+                    self._log.debug("%s version: %s", backend, result.stdout.strip())
                 except subprocess.CalledProcessError as exc:
                     msg = f"{backend} is not available. Please ensure that it is installed."
                     raise RuntimeError(msg) from exc
@@ -187,10 +187,11 @@ class AnsiblePlaybook:
                 env=self._env,
                 debug=self._config.debug,
                 cwd=cwd,
+                command_borders=self._config.command_borders,
             )
 
         if result.returncode != 0:
-            err = f"Ansible return code was {result.returncode}, command was: [dim]{escape(shlex.join(result.args))}[/]"
+            err = f"Ansible return code was {result.returncode}, command was: {escape(shlex.join(result.args))}"
             self._config.scenario.results.add_completion(CompletionState.failed(note=err))
 
             raise ScenarioFailureError(

--- a/src/molecule/types.py
+++ b/src/molecule/types.py
@@ -280,6 +280,7 @@ class CommandArgs(TypedDict, total=False):
         shared_inventory: Whether inventory should be shared between scenarios.
         shared_state: Whether (some) state should be shared between scenarios.
         subcommand: Name of subcommand being run.
+        command_borders: Whether to enable borders around command output.
     """
 
     destroy: Literal["always", "never"]
@@ -294,3 +295,4 @@ class CommandArgs(TypedDict, total=False):
     shared_inventory: bool
     shared_state: bool
     subcommand: str
+    command_borders: bool

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -238,6 +238,7 @@ class Testinfra(Verifier):
             env=self.env,
             debug=self._config.debug,
             cwd=Path(self._config.scenario.directory),
+            command_borders=self._config.command_borders,
         )
         if result.returncode == 0:
             msg = "Verifier completed successfully."

--- a/tests/fixtures/integration/test_command/comprehensive_output.txt
+++ b/tests/fixtures/integration/test_command/comprehensive_output.txt
@@ -1,0 +1,194 @@
+INFO     test-scenario ➜ discovery: scenario test matrix: dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy
+INFO     smoke ➜ discovery: scenario test matrix: dependency, cleanup, destroy, syntax, create, prepare, converge, idempotence, side_effect, verify, cleanup, destroy
+INFO     default ➜ create: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest
+  │   REDACTED
+  │
+  │
+  │ PLAY [Create] ******************************************************************
+  │
+  │ TASK [Populate instance config dict] *******************************************
+  │ skipping: [localhost]
+  │
+  │ TASK [Convert instance config dict to a list] **********************************
+  │ skipping: [localhost]
+  │
+  │ TASK [Dump instance config] ****************************************************
+  │ skipping: [localhost]
+  │
+  │ PLAY RECAP *********************************************************************
+  │ localhost                  : ok=0    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0
+  │
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     default ➜ create: Completed: Successful
+INFO     test-scenario ➜ prerun: Performing prerun with role_name_check=0...
+INFO     test-scenario ➜ dependency: Starting
+INFO     test-scenario ➜ cleanup: Starting
+INFO     test-scenario ➜ syntax: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest
+  │   --syntax-check REDACTED
+  │
+  │
+  │ playbook: REDACTED
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     test-scenario ➜ syntax: Completed: Successful
+INFO     test-scenario ➜ prepare: Starting
+INFO     test-scenario ➜ converge: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest
+  │   REDACTED
+  │
+  │
+  │ PLAY [Converge] ****************************************************************
+  │
+  │ TASK [Replace this task with one that validates your content] ******************
+  │ ok: [localhost] => {
+  │     "msg": "This is the effective test"
+  │ }
+  │
+  │ PLAY RECAP *********************************************************************
+  │ localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+  │
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     test-scenario ➜ converge: Completed: Successful
+INFO     test-scenario ➜ idempotence: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest,molecule-idempotence-notest
+  │   REDACTED
+  │
+  │
+  │ PLAY [Converge] ****************************************************************
+  │
+  │ TASK [Replace this task with one that validates your content] ******************
+  │ ok: [localhost] => {
+  │     "msg": "This is the effective test"
+  │ }
+  │
+  │ PLAY RECAP *********************************************************************
+  │ localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+  │
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     test-scenario ➜ idempotence: Completed: Successful
+INFO     test-scenario ➜ side_effect: Starting
+INFO     test-scenario ➜ verify: Starting
+INFO     test-scenario ➜ cleanup: Starting
+INFO     smoke ➜ prerun: Performing prerun with role_name_check=0...
+INFO     smoke ➜ dependency: Starting
+INFO     smoke ➜ cleanup: Starting
+INFO     smoke ➜ syntax: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest
+  │   --syntax-check REDACTED
+  │
+  │
+  │ playbook: REDACTED
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     smoke ➜ syntax: Completed: Successful
+INFO     smoke ➜ prepare: Starting
+INFO     smoke ➜ converge: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest
+  │   REDACTED
+  │
+  │
+  │ PLAY [Converge] ****************************************************************
+  │
+  │ TASK [Gathering Facts] *********************************************************
+  │ ok: [localhost]
+  │
+  │ TASK [Assert CWD is the same as playbook_dir] **********************************
+  │ ok: [localhost] => {
+  │     "changed": false,
+  │     "msg": "All assertions passed"
+  │ }
+  │
+  │ PLAY RECAP *********************************************************************
+  │ localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+  │
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     smoke ➜ converge: Completed: Successful
+INFO     smoke ➜ idempotence: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest,molecule-idempotence-notest
+  │   REDACTED
+  │
+  │
+  │ PLAY [Converge] ****************************************************************
+  │
+  │ TASK [Gathering Facts] *********************************************************
+  │ ok: [localhost]
+  │
+  │ TASK [Assert CWD is the same as playbook_dir] **********************************
+  │ ok: [localhost] => {
+  │     "changed": false,
+  │     "msg": "All assertions passed"
+  │ }
+  │
+  │ PLAY RECAP *********************************************************************
+  │ localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+  │
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     smoke ➜ idempotence: Completed: Successful
+INFO     smoke ➜ side_effect: Starting
+INFO     smoke ➜ verify: Starting
+INFO     smoke ➜ cleanup: Starting
+INFO     default ➜ destroy: Starting
+  ┌──────────────────────────────────────────────────────────────────────────────────
+  │ ansible-playbook --inventory REDACTED
+  │   --skip-tags molecule-notest,notest
+  │   REDACTED
+  │
+  │
+  │ PLAY [Destroy] *****************************************************************
+  │
+  │ TASK [Populate instance config] ************************************************
+  │ ok: [localhost]
+  │
+  │ TASK [Dump instance config] ****************************************************
+  │ skipping: [localhost]
+  │
+  │ PLAY RECAP *********************************************************************
+  │ localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+  │
+  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+INFO     default ➜ destroy: Completed: Successful
+
+DETAILS
+default ➜ create: Completed: Successful
+
+test-scenario ➜ dependency: Completed: 2 missing (Remove from test_sequence to suppress)
+test-scenario ➜ cleanup: Completed: Missing playbook (Remove from test_sequence to suppress)
+test-scenario ➜ syntax: Completed: Successful
+test-scenario ➜ prepare: Completed: Missing playbook (Remove from test_sequence to suppress)
+test-scenario ➜ converge: Completed: Successful
+test-scenario ➜ idempotence: Completed: Successful
+test-scenario ➜ side_effect: Completed: Missing playbook (Remove from test_sequence to suppress)
+test-scenario ➜ verify: Completed: Missing playbook (Remove from test_sequence to suppress)
+test-scenario ➜ cleanup: Completed: Missing playbook (Remove from test_sequence to suppress)
+
+smoke ➜ dependency: Completed: 2 missing (Remove from test_sequence to suppress)
+smoke ➜ cleanup: Completed: Missing playbook (Remove from test_sequence to suppress)
+smoke ➜ syntax: Completed: Successful
+smoke ➜ prepare: Completed: Missing playbook (Remove from test_sequence to suppress)
+smoke ➜ converge: Completed: Successful
+smoke ➜ idempotence: Completed: Successful
+smoke ➜ side_effect: Completed: Missing playbook (Remove from test_sequence to suppress)
+smoke ➜ verify: Completed: Missing playbook (Remove from test_sequence to suppress)
+smoke ➜ cleanup: Completed: Missing playbook (Remove from test_sequence to suppress)
+
+default ➜ destroy: Completed: Successful
+
+SCENARIO RECAP
+default                   : actions=1  successful=1  disabled=0  skipped=0  missing=0  failed=0
+test-scenario             : actions=9  successful=3  disabled=0  skipped=0  missing=7  failed=0
+smoke                     : actions=9  successful=3  disabled=0  skipped=0  missing=7  failed=0
+default                   : actions=1  successful=1  disabled=0  skipped=0  missing=0  failed=0

--- a/tests/fixtures/integration/test_command/comprehensive_output.txt
+++ b/tests/fixtures/integration/test_command/comprehensive_output.txt
@@ -21,7 +21,7 @@ INFO     default ➜ create: Starting
   │ PLAY RECAP *********************************************************************
   │ localhost                  : ok=0    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0
   │
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     default ➜ create: Completed: Successful
 INFO     test-scenario ➜ prerun: Performing prerun with role_name_check=0...
 INFO     test-scenario ➜ dependency: Starting
@@ -34,7 +34,7 @@ INFO     test-scenario ➜ syntax: Starting
   │
   │
   │ playbook: REDACTED
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     test-scenario ➜ syntax: Completed: Successful
 INFO     test-scenario ➜ prepare: Starting
 INFO     test-scenario ➜ converge: Starting
@@ -54,7 +54,7 @@ INFO     test-scenario ➜ converge: Starting
   │ PLAY RECAP *********************************************************************
   │ localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
   │
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     test-scenario ➜ converge: Completed: Successful
 INFO     test-scenario ➜ idempotence: Starting
   ┌──────────────────────────────────────────────────────────────────────────────────
@@ -73,7 +73,7 @@ INFO     test-scenario ➜ idempotence: Starting
   │ PLAY RECAP *********************************************************************
   │ localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
   │
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     test-scenario ➜ idempotence: Completed: Successful
 INFO     test-scenario ➜ side_effect: Starting
 INFO     test-scenario ➜ verify: Starting
@@ -89,7 +89,7 @@ INFO     smoke ➜ syntax: Starting
   │
   │
   │ playbook: REDACTED
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     smoke ➜ syntax: Completed: Successful
 INFO     smoke ➜ prepare: Starting
 INFO     smoke ➜ converge: Starting
@@ -113,7 +113,7 @@ INFO     smoke ➜ converge: Starting
   │ PLAY RECAP *********************************************************************
   │ localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
   │
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     smoke ➜ converge: Completed: Successful
 INFO     smoke ➜ idempotence: Starting
   ┌──────────────────────────────────────────────────────────────────────────────────
@@ -136,7 +136,7 @@ INFO     smoke ➜ idempotence: Starting
   │ PLAY RECAP *********************************************************************
   │ localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
   │
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     smoke ➜ idempotence: Completed: Successful
 INFO     smoke ➜ side_effect: Starting
 INFO     smoke ➜ verify: Starting
@@ -159,7 +159,7 @@ INFO     default ➜ destroy: Starting
   │ PLAY RECAP *********************************************************************
   │ localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
   │
-  │─ Return code: 0 ─────────────────────────────────────────────────────────────────
+  └─ Return code: 0 ─────────────────────────────────────────────────────────────────
 INFO     default ➜ destroy: Completed: Successful
 
 DETAILS

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -562,8 +562,9 @@ def test_full_output(
     monkeypatch.setenv("TERM", "xterm-256color")
     monkeypatch.setenv("ANSIBLE_FORCE_COLOR", "1")
     monkeypatch.setenv("ANSIBLE_STDOUT_CALLBACK", "default")
-    monkeypatch.setenv("ANSIBLE_DISABLE_WARNINGS", "True")
     monkeypatch.setenv("ANSIBLE_DEPRECATION_WARNINGS", "false")
+    monkeypatch.setenv("ANSIBLE_COMMAND_WARNINGS", "false")
+    monkeypatch.setenv("ANSIBLE_ACTION_WARNINGS", "false")
 
     # Run comprehensive molecule test with command borders and shared state
     # First reset all scenarios to ensure clean state and avoid warning messages about modified scenario config files

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -562,6 +562,7 @@ def test_full_output(
     monkeypatch.setenv("TERM", "xterm-256color")
     monkeypatch.setenv("ANSIBLE_FORCE_COLOR", "1")
     monkeypatch.setenv("ANSIBLE_STDOUT_CALLBACK", "default")
+    monkeypatch.setenv("ANSIBLE_DISABLE_WARNINGS", "True")
 
     # Run comprehensive molecule test with command borders and shared state
     # First reset all scenarios to ensure clean state and avoid warning messages about modified scenario config files

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -563,6 +563,7 @@ def test_full_output(
     monkeypatch.setenv("ANSIBLE_FORCE_COLOR", "1")
     monkeypatch.setenv("ANSIBLE_STDOUT_CALLBACK", "default")
     monkeypatch.setenv("ANSIBLE_DISABLE_WARNINGS", "True")
+    monkeypatch.setenv("ANSIBLE_DEPRECATION_WARNINGS", "false")
 
     # Run comprehensive molecule test with command borders and shared state
     # First reset all scenarios to ensure clean state and avoid warning messages about modified scenario config files

--- a/tests/unit/dependency/ansible_galaxy/test_collections.py
+++ b/tests/unit/dependency/ansible_galaxy/test_collections.py
@@ -168,6 +168,7 @@ def test_collections_execute(  # type: ignore[no-untyped-def]  # noqa: ANN201, D
         "patched-command",
         debug=False,
         check=True,
+        command_borders=False,
     )
 
     msg = "Dependency completed successfully."

--- a/tests/unit/dependency/ansible_galaxy/test_roles.py
+++ b/tests/unit/dependency/ansible_galaxy/test_roles.py
@@ -167,6 +167,7 @@ def test_execute(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
         "patched-command",
         debug=False,
         check=True,
+        command_borders=False,
     )
 
     msg = "Dependency completed successfully."

--- a/tests/unit/dependency/test_shell.py
+++ b/tests/unit/dependency/test_shell.py
@@ -128,6 +128,7 @@ def test_shell_execute(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
             "patched-command",
             debug=False,
             check=True,
+            command_borders=False,
         )
 
         # Check for scenario-aware log records instead of text

--- a/tests/unit/test_ansi_output_borders.py
+++ b/tests/unit/test_ansi_output_borders.py
@@ -1,0 +1,576 @@
+"""Tests for the command borders functionality in ansi_output module."""
+
+from __future__ import annotations
+
+import io
+import re
+import sys
+
+import pytest
+
+from molecule.ansi_output import (
+    AnsiOutput,
+    BorderedStream,
+    CommandBorders,
+    get_line_style,
+    split_command_to_strings,
+)
+from molecule.constants import ANSICodes as A
+
+
+def test_split_command_to_strings_simple_command() -> None:
+    """Test split_command_to_strings with a simple command."""
+    command = "ansible-playbook playbook.yml"
+    result = split_command_to_strings(command)
+    expected = ["ansible-playbook", "playbook.yml"]
+    assert result == expected
+
+
+def test_split_command_to_strings_option_value_merging() -> None:
+    """Test split_command_to_strings with option-value pairs (standard shlex behavior)."""
+    command = "ansible-playbook -i inventory.yml --extra-vars var=value playbook.yml"
+    result = split_command_to_strings(command)
+    expected = [
+        "ansible-playbook",
+        "-i",
+        "inventory.yml",
+        "--extra-vars",
+        "var=value",
+        "playbook.yml",
+    ]
+    assert result == expected
+
+
+def test_split_command_to_strings_empty_command() -> None:
+    """Test split_command_to_strings with empty command."""
+    command = ""
+    result = split_command_to_strings(command)
+    expected: list[str] = []
+    assert result == expected
+
+
+def test_split_command_to_strings_with_equals() -> None:
+    """Test split_command_to_strings handles existing equals signs."""
+    command = "ansible-playbook --extra-vars=existing=value playbook.yml"
+    result = split_command_to_strings(command)
+    expected = ["ansible-playbook", "--extra-vars=existing=value", "playbook.yml"]
+    assert result == expected
+
+
+def test_split_command_to_strings_long_options() -> None:
+    """Test split_command_to_strings with long options (standard shlex behavior)."""
+    command = "ansible-playbook --check --diff --verbose playbook.yml"
+    result = split_command_to_strings(command)
+    expected = ["ansible-playbook", "--check", "--diff", "--verbose", "playbook.yml"]
+    assert result == expected
+
+
+def test_split_command_to_strings_short_options() -> None:
+    """Test split_command_to_strings with short options (standard shlex behavior)."""
+    command = "ansible-playbook -v -C playbook.yml"
+    result = split_command_to_strings(command)
+    expected = ["ansible-playbook", "-v", "-C", "playbook.yml"]
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("input_line", "expected"),
+    (
+        ("", ""),
+        ("plain text", ""),
+        ("\x1b[1mBold text\x1b[0m", "\x1b[1m"),
+        ("\x1b[31mRed text\x1b[0m", "\x1b[31m"),
+        ("\x1b[32;1mGreen bold\x1b[0m", "\x1b[32;1m"),
+        ("\033[33mYellow\033[0m", "\033[33m"),
+        ("\x1b[0mReset only", ""),  # Reset sequences are ignored
+    ),
+    ids=[
+        "empty_string",
+        "plain_text_no_ansi",
+        "bold_formatting",
+        "red_color",
+        "green_bold_combination",
+        "yellow_octal_escape",
+        "reset_sequence_only",
+    ],
+)
+def test_get_line_style(input_line: str, expected: str) -> None:
+    """Test get_line_style extracts ANSI escape sequences properly."""
+    result = get_line_style(input_line)
+    assert result == expected
+
+
+def test_get_line_style_returns_first_style() -> None:
+    """Test get_line_style returns only the first non-reset style."""
+    line = "\x1b[1mBold\x1b[0m text \x1b[32mGreen\x1b[0m"
+    result = get_line_style(line)
+    # Should return the first non-reset style
+    assert result == "\x1b[1m"
+
+
+def test_bordered_stream_init() -> None:
+    """Test BorderedStream initialization."""
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+    stream = BorderedStream(ansi, original_stream)
+
+    assert stream.ansi is ansi
+    assert stream.target_stream is original_stream
+    assert stream.buffer.getvalue() == ""
+
+
+def test_bordered_stream_write_with_ansi_output() -> None:
+    """Test BorderedStream.write with AnsiOutput integration."""
+    # Test constants
+    hello_world_length = 12  # Length of "Hello world\n"
+
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+    stream = BorderedStream(ansi, original_stream)
+
+    result = stream.write("Hello world\n")
+
+    assert result == hello_world_length  # Length of input
+    output = original_stream.getvalue()
+    assert A.BOX_VERTICAL in output
+
+
+def test_bordered_stream_write_partial_line() -> None:
+    """Test BorderedStream write with partial line (no newline)."""
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+
+    stream = BorderedStream(ansi, original_stream)
+    stream.write("Partial")
+
+    # Should buffer partial line
+    assert stream.buffer.getvalue() == "Partial"
+    assert original_stream.getvalue() == ""
+
+
+def test_bordered_stream_write_multiple_lines() -> None:
+    """Test BorderedStream write with multiple lines."""
+    # Test constants
+    expected_border_lines = 3  # Number of lines with borders
+
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+
+    stream = BorderedStream(ansi, original_stream)
+    stream.write("Line 1\nLine 2\nLine 3\n")
+
+    output = original_stream.getvalue()
+    lines = output.split("\n")
+
+    # Should have 3 lines with borders
+    border_lines = [line for line in lines if A.BOX_VERTICAL in line]
+    assert len(border_lines) == expected_border_lines
+
+    # Each line should contain the expected text
+    assert "Line 1" in output
+    assert "Line 2" in output
+    assert "Line 3" in output
+
+
+def test_bordered_stream_flush() -> None:
+    """Test BorderedStream flush method."""
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+
+    stream = BorderedStream(ansi, original_stream)
+    stream.write("Test")
+    stream.flush()
+
+    # Should flush partial line
+    output = original_stream.getvalue()
+    assert A.BOX_VERTICAL in output
+    assert "Test" in output
+    assert stream.buffer.getvalue() == ""
+
+
+def test_bordered_stream_getvalue() -> None:
+    """Test BorderedStream getvalue method."""
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+
+    stream = BorderedStream(ansi, original_stream)
+    stream.write("Test line\n")
+
+    # getvalue returns the buffer content, not the original stream
+    result = stream.getvalue()
+    assert "Test line\n" in result
+
+
+def test_command_borders_basic_functionality(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test CommandBorders basic functionality."""
+    # Override the autouse _no_color fixture
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+
+    original_stderr = io.StringIO()
+    borders = CommandBorders("echo hello", original_stderr)
+
+    # Test that streams are captured
+    assert borders.stdout_capture is not None
+    assert borders.stderr_capture is not None
+
+    # Test finalization - it now returns None
+    borders.finalize(0)
+
+    # Check that footer was written
+    output = original_stderr.getvalue()
+    assert "Return code: 0" in output
+
+
+def test_command_borders_enabled_when_markup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test CommandBorders redirects streams when markup is enabled."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+
+    stderr_mock = io.StringIO()
+
+    # Mock sys.stderr to capture header output
+    monkeypatch.setattr(sys, "stderr", stderr_mock)
+
+    _borders = CommandBorders("echo test", stderr_mock)
+
+    # Should have changed stdout/stderr to BorderedStream instances
+    assert sys.stdout is not original_stdout
+    assert sys.stderr is not original_stderr
+    assert isinstance(sys.stdout, BorderedStream)
+    assert isinstance(sys.stderr, BorderedStream)
+
+    # Should have printed header during construction
+    output = stderr_mock.getvalue()
+    assert A.BOX_TOP_LEFT in output
+    # Command gets split across lines, so check for both parts
+    assert "echo" in output
+    assert "test" in output
+
+    # Restore streams
+    monkeypatch.setattr(sys, "stdout", original_stdout)
+    monkeypatch.setattr(sys, "stderr", original_stderr)
+
+
+def test_command_borders_finalize_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test CommandBorders finalize with successful return code."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    stderr_mock = io.StringIO()
+
+    # Mock sys.stderr to capture output
+    monkeypatch.setattr(sys, "stderr", stderr_mock)
+
+    borders = CommandBorders("echo test", stderr_mock)
+
+    # Clear the header output to focus on footer
+    stderr_mock.seek(0)
+    stderr_mock.truncate(0)
+
+    borders.finalize(0)
+
+    # Should restore streams - but finalize restores to what was saved at construction time
+    # Since we set stderr_mock before construction, it will restore to stderr_mock
+    assert sys.stdout is original_stdout
+    # Manually restore stderr for this test
+    monkeypatch.setattr(sys, "stderr", original_stderr)
+
+    # Should have printed footer with success
+    footer_output = stderr_mock.getvalue()
+    assert A.BOX_BOTTOM_LEFT in footer_output
+    assert "Return code: 0" in footer_output  # More specific check
+
+
+def test_command_borders_finalize_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test CommandBorders finalize with failure return code."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    stderr_mock = io.StringIO()
+
+    # Temporarily replace stderr for the constructor
+    monkeypatch.setattr(sys, "stderr", stderr_mock)
+
+    borders = CommandBorders("echo test", stderr_mock)
+
+    # Clear the header output to focus on footer
+    stderr_mock.seek(0)
+    stderr_mock.truncate(0)
+
+    borders.finalize(1)
+
+    # Should restore streams - but finalize restores to what was saved at construction time
+    # Since we set stderr_mock before construction, it will restore to stderr_mock
+    assert sys.stdout is original_stdout
+    # Manually restore stderr for this test
+    monkeypatch.setattr(sys, "stderr", original_stderr)
+
+    # Should have printed footer with failure
+    footer_output = stderr_mock.getvalue()
+    assert A.BOX_BOTTOM_LEFT in footer_output
+    assert "Return code: 1" in footer_output  # More specific check
+
+
+def test_command_borders_custom_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test CommandBorders with custom width."""
+    # Test constants
+    custom_width = 50  # Custom border width for testing
+
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    original_stderr = sys.stderr
+    stderr_mock = io.StringIO()
+
+    # Mock sys.stderr to capture output
+    monkeypatch.setattr(sys, "stderr", stderr_mock)
+
+    borders = CommandBorders("echo test", stderr_mock, width=custom_width)
+    assert borders.width == custom_width
+
+    # Check that header uses custom width
+    header_output = stderr_mock.getvalue()
+    # Count horizontal characters in the border
+    horizontal_count = header_output.count(A.BOX_HORIZONTAL)
+    # Should be using custom width (minus corners and spaces)
+    assert horizontal_count > 0
+
+    # Restore stderr
+    monkeypatch.setattr(sys, "stderr", original_stderr)
+
+
+def test_command_borders_format_command_lines_simple(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test CommandBorders formats simple commands properly."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    stderr_mock = io.StringIO()
+    borders = CommandBorders("echo test", stderr_mock)
+
+    # Test with simple string command
+    lines = borders._format_command_lines("echo test", max_width=100)
+    assert lines == ["echo test"]
+
+    # Test with simple list command
+    lines = borders._format_command_lines(["echo", "test"], max_width=100)
+    assert lines == ["echo test"]
+
+
+def test_command_borders_format_command_lines_flag_value_grouping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test CommandBorders groups flags with their values intelligently."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    stderr_mock = io.StringIO()
+    borders = CommandBorders("test", stderr_mock)
+
+    # Test flag-value grouping
+    cmd = [
+        "ansible-playbook",
+        "--inventory",
+        "/path/to/inventory",
+        "--skip-tags",
+        "notest",
+        "playbook.yml",
+    ]
+    lines = borders._format_command_lines(cmd, max_width=100)
+
+    # Should group executable with first flag-value pair
+    assert lines[0] == "ansible-playbook --inventory /path/to/inventory"
+    # Subsequent flag-value pairs should be grouped and indented
+    assert "  --skip-tags notest" in lines
+    # Positional args should be separate and indented
+    assert "  playbook.yml" in lines
+
+
+def test_command_borders_format_command_lines_line_wrapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test CommandBorders handles line wrapping correctly."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    stderr_mock = io.StringIO()
+    borders = CommandBorders("test", stderr_mock)
+
+    # Long command that should wrap
+    very_long_path = "/very/long/path/to/some/file/that/exceeds/the/terminal/width.yml"
+    cmd = ["ansible-playbook", "--inventory", very_long_path]
+    lines = borders._format_command_lines(cmd, max_width=50)
+
+    # Should have multiple lines due to wrapping
+    assert len(lines) > 1
+    # First line should contain the executable
+    assert "ansible-playbook" in lines[0]
+    # Subsequent lines should be indented (or be wrapped parts of the first line)
+    assert any(line.startswith(("  ", "/")) for line in lines[1:])
+
+
+def test_command_borders_format_command_lines_multiple_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test CommandBorders handles multiple flags and values correctly."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    stderr_mock = io.StringIO()
+    borders = CommandBorders("test", stderr_mock)
+
+    cmd = [
+        "ansible-playbook",
+        "--inventory",
+        "inventory.yml",
+        "--extra-vars",
+        "key=value",
+        "--tags",
+        "tag1,tag2",
+        "--limit",
+        "host1",
+        "playbook.yml",
+    ]
+    lines = borders._format_command_lines(cmd, max_width=200)
+
+    # Should group flags with their values
+    combined = " ".join(lines)
+    assert "--inventory inventory.yml" in combined
+    assert "--extra-vars key=value" in combined
+    assert "--tags tag1,tag2" in combined
+    assert "--limit host1" in combined
+    assert "playbook.yml" in combined
+
+
+def test_command_borders_format_command_lines_standalone_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test CommandBorders handles standalone flags (no values) correctly."""
+    monkeypatch.setattr("molecule.ansi_output.should_do_markup", lambda: True)
+
+    stderr_mock = io.StringIO()
+    borders = CommandBorders("test", stderr_mock)
+
+    cmd = ["ansible-playbook", "--check", "--diff", "--verbose", "playbook.yml"]
+    lines = borders._format_command_lines(cmd, max_width=200)
+
+    # Standalone flags should be on separate lines
+    combined = " ".join(lines)
+    assert "ansible-playbook" in combined
+    assert "--check" in combined
+    assert "--diff" in combined
+    assert "--verbose" in combined
+    assert "playbook.yml" in combined
+
+
+def test_bordered_stream_handles_ansi_sequences() -> None:
+    """Test BorderedStream properly handles ANSI escape sequences."""
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+
+    stream = BorderedStream(ansi, original_stream)
+    stream.write("\x1b[31mRed text\x1b[0m\n")
+
+    output = original_stream.getvalue()
+    assert A.BOX_VERTICAL in output
+    assert "\x1b[31m" in output  # ANSI codes should be preserved
+    assert "Red text" in output
+
+
+def test_bordered_stream_continuation_styling() -> None:
+    """Test BorderedStream applies continuation styling correctly."""
+    # Test constants
+    expected_border_lines = 2  # Number of lines with borders
+
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+
+    stream = BorderedStream(ansi, original_stream)
+
+    # Write a styled line, then a continuation
+    stream.write("\x1b[32mGreen line\x1b[0m\n")
+    stream.write("Continuation\n")
+
+    output = original_stream.getvalue()
+    lines = output.split("\n")
+
+    # Both lines should have borders
+    border_lines = [line for line in lines if A.BOX_VERTICAL in line]
+    assert len(border_lines) == expected_border_lines
+
+    # First line has explicit styling
+    assert "\x1b[32m" in border_lines[0]
+    assert "Green line" in border_lines[0]
+
+    # Second line should have continuation
+    assert "Continuation" in border_lines[1]
+
+
+def test_split_command_to_strings_handles_complex_args() -> None:
+    """Test split_command_to_strings with complex arguments (standard shlex behavior)."""
+    command = "ansible-playbook -e key=value --tags tag1,tag2 --limit host1:host2 playbook.yml"
+    result = split_command_to_strings(command)
+
+    assert "ansible-playbook" in result
+    assert "-e" in result
+    assert "key=value" in result
+    assert "--tags" in result
+    assert "tag1,tag2" in result
+    assert "--limit" in result
+    assert "host1:host2" in result
+    assert "playbook.yml" in result
+
+
+def test_bordered_stream_wraps_long_lines() -> None:
+    """Test BorderedStream wraps long lines using textwrap with proper indentation and color preservation."""
+    ansi = AnsiOutput()
+    original_stream = io.StringIO()
+
+    stream = BorderedStream(ansi, original_stream)
+
+    # Create a very long line with ANSI color that will exceed terminal width
+    long_line = "\x1b[32mThis is a very long green line that contains a lot of text and should be wrapped by textwrap when it exceeds the terminal width minus the border characters overhead\x1b[0m"
+    stream.write(f"{long_line}\n")
+
+    output = original_stream.getvalue()
+    lines = output.split("\n")
+
+    # Should have multiple lines due to wrapping
+    border_lines = [line for line in lines if A.BOX_VERTICAL in line]
+    assert len(border_lines) > 1
+
+    # All border lines should contain the box vertical character
+    for line in border_lines:
+        assert A.BOX_VERTICAL in line
+
+    # Check that continuation lines are indented (have 2 extra spaces after the border)
+    continuation_lines = border_lines[1:]  # All lines except the first
+    for line in continuation_lines:
+        # After removing ANSI codes and finding the content after "│ ", it should start with 2 spaces
+        clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
+        if "│" in clean_line:
+            content = clean_line.split("│ ", 1)[-1]
+            assert content.startswith("  "), (
+                f"Continuation line should start with 2 spaces: '{content}'"
+            )
+
+    # Check that original color is preserved in all wrapped lines
+    for line in border_lines:
+        assert "\x1b[32m" in line, "Original green color should be preserved in all wrapped lines"
+
+    # Reconstruct the original text from bordered output (removing indentation)
+    reconstructed_parts = []
+    for i, line in enumerate(border_lines):
+        # First remove ANSI escape codes, then split on the vertical bar
+        clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
+        if "│" in clean_line:
+            text_part = clean_line.split("│ ", 1)[-1]
+            # Remove the 2-space indentation from continuation lines
+            if i > 0 and text_part.startswith("  "):
+                text_part = text_part[2:]
+            reconstructed_parts.append(text_part)
+
+    # When joined with spaces, should contain the original text content
+    reconstructed = " ".join(reconstructed_parts)
+    assert "This is a very long green line" in reconstructed
+    assert "should be wrapped by textwrap" in reconstructed
+    assert "terminal width minus the border characters overhead" in reconstructed

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ pass_env =
     DOCKER_*
     GITHUB_*
     HOME
+    MOLECULE_UPDATE_FIXTURES
     PYTEST_*
     SSH_AUTH_SOCK
     TERM


### PR DESCRIPTION
<img width="2101" height="801" alt="image" src="https://github.com/user-attachments/assets/9fe68f1f-297e-408f-a097-23190f9c6cbf" />


## Summary

Adds an experimental `--command-borders` CLI flag that visually separates external command output from Molecule's own output using Unicode box-drawing characters and ANSI escape codes.

## Motivation

When running complex scenarios, distinguishing between Molecule's orchestration output and the actual command output (ansible-playbook, dependency installs, etc.) can be challenging. This enhancement provides clear visual boundaries around external command execution without affecting Molecule's core logic or behavior.

## Implementation

### Core Changes
- **`src/molecule/ansi_output.py`**: New `CommandBorders`, `BorderedStream` classes with intelligent command-line formatting
- **`src/molecule/app.py`**: Integration point for bordered command execution
- **`src/molecule/constants.py`**: Unicode box-drawing character constants

### CLI Integration  
- **`src/molecule/click_cfg.py`**: New `--command-borders` flag definition
- **`src/molecule/types.py`**: Type definitions for the new flag
- **`src/molecule/config.py`**: Configuration storage

### Command Propagation
- **`src/molecule/command/*.py`**: Flag propagation through all commands
- **Dependencies/Provisioners/Verifiers**: Setting propagation to external command execution

### Testing
- **`tests/unit/test_ansi_output_borders.py`**: Comprehensive unit tests (33 test cases)
- **`tests/unit/test_ansi_output.py`**: Extended coverage for new functionality  
- **`tests/integration/test_command.py`**: End-to-end validation with fixture comparison

## Characteristics

- **Experimental**: Opt-in functionality behind explicit flag
- **Non-invasive**: Zero impact on existing behavior when disabled
- **Presentation-only**: No changes to Molecule's execution logic or state management
- **Smart formatting**: Intelligent flag-value grouping and dynamic terminal width detection
- **Comprehensive**: Works across all Molecule commands that execute external processes

## Visual Example

```
INFO     default ➜ create: Starting
  ┌──────────────────────────────────────────────────────────────────────────────────
  │ ansible-playbook --inventory /path/to/inventory
  │   --skip-tags molecule-notest,notest  
  │   /path/to/create.yml
  │ 
  │ PLAY [Create] ******************************************************************
  │ 
  │ TASK [Populate instance config] ***********************************************
  │ ok: [localhost]
  │ 
  │ PLAY RECAP *********************************************************************
  │ localhost                  : ok=1    changed=0    unreachable=0    failed=0
  │ 
  └─ Return code: 0 ────────────────────────────────────────────────────────────────
INFO     default ➜ create: Completed: Successful
```

Note:  a better balance between stdout and stderr will follow, it was too much given the scope of this PR https://github.com/ansible/molecule/issues/4497