### PR TITLE
feat: Add MOLECULE_SHARED_INVENTORY_DIR environment variable and playbook variable

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -26,6 +26,7 @@ dind
 docsite
 dotglob
 emptydisk
+endfor
 endgroup
 endraw
 enoent

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,12 @@ MOLECULE_INVENTORY_FILE
 : Path to generated inventory file, usually
 `~/.cache/molecule/<role-name>/<scenario-name>/inventory/ansible_inventory.yml`
 
+MOLECULE_SHARED_INVENTORY_DIR
+
+: Path to shared inventory directory when `--shared-inventory` is enabled, otherwise empty string.
+Allows playbooks to access the shared inventory location across scenarios.
+This is also available as the `molecule_shared_inventory_dir` variable in playbooks.
+
 MOLECULE_EPHEMERAL_DIRECTORY
 
 : Path to generated directory, usually

--- a/docs/guides/sharing.md
+++ b/docs/guides/sharing.md
@@ -68,7 +68,7 @@ The `molecule_shared_inventory_dir` variable is available in playbooks to access
       {% raw %}{% for platform in molecule_yml.platforms %}
       {{ platform.name }}{% for key, value in platform.get('host_vars', {}).items() %} {{ key }}={{ value }}{% endfor %}
       {% endfor %}{% endraw %}
-      
+
       [molecule:vars]
       ansible_user=root
       ansible_connection=docker

--- a/docs/guides/sharing.md
+++ b/docs/guides/sharing.md
@@ -58,21 +58,21 @@ The `molecule_shared_inventory_dir` variable is available in playbooks to access
 ```yaml
 - name: Build shared inventory with INI template
   ansible.builtin.copy:
-    content: "{{ inventory_ini }}"
-    dest: "{{ molecule_shared_inventory_dir }}/shared_inventory.ini"
+    content: "{% raw %}{{ inventory_ini }}{% endraw %}"
+    dest: "{% raw %}{{ molecule_shared_inventory_dir }}{% endraw %}/shared_inventory.ini"
     mode: "0600"
   when: molecule_shared_inventory_dir != ""
   vars:
     inventory_ini: |
       [molecule]
-      {% for platform in molecule_yml.platforms %}
+      {% raw %}{% for platform in molecule_yml.platforms %}
       {{ platform.name }}{% for key, value in platform.get('host_vars', {}).items() %} {{ key }}={{ value }}{% endfor %}
-      {% endfor %}
-
+      {% endfor %}{% endraw %}
+      
       [molecule:vars]
       ansible_user=root
       ansible_connection=docker
-     delegate_to: localhost
+   delegate_to: localhost
 
 - name: Force inventory refresh
   ansible.builtin.meta: refresh_inventory

--- a/docs/guides/sharing.md
+++ b/docs/guides/sharing.md
@@ -47,3 +47,36 @@ provisioner:
     converge: ../resources/playbooks/converge.yml
     prepare: ../resources/playbooks/prepare.yml
 ```
+
+## Shared Inventory
+
+When using the `--shared-inventory` option, Molecule can share inventory data between scenarios.
+This is useful when testing multiple scenarios that need to interact with the same set of instances.
+
+The `molecule_shared_inventory_dir` variable is available in playbooks to access the shared inventory location:
+
+```yaml
+- name: Build shared inventory with INI template
+  ansible.builtin.copy:
+    content: "{{ inventory_ini }}"
+    dest: "{{ molecule_shared_inventory_dir }}/shared_inventory.ini"
+    mode: "0600"
+  when: molecule_shared_inventory_dir != ""
+  vars:
+    inventory_ini: |
+      [molecule]
+      {% for platform in molecule_yml.platforms %}
+      {{ platform.name }}{% for key, value in platform.get('host_vars', {}).items() %} {{ key }}={{ value }}{% endfor %}
+      {% endfor %}
+
+      [molecule:vars]
+      ansible_user=root
+      ansible_connection=docker
+     delegate_to: localhost
+
+- name: Force inventory refresh
+  ansible.builtin.meta: refresh_inventory
+```
+
+The variable contains the path to the shared inventory directory when `--shared-inventory` is enabled,
+or an empty string when running in normal mode or with `--parallel`.

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -352,12 +352,18 @@ class Config:
         Returns:
             Total set of computed environment variables.
         """
+        shared_inventory_dir = (
+            self.scenario.inventory_directory
+            if self.shared_inventory and not self.is_parallel
+            else ""
+        )
         return {
             "MOLECULE_DEBUG": str(self.debug),
             "MOLECULE_FILE": self.config_file,
             "MOLECULE_ENV_FILE": str(self.env_file),
             "MOLECULE_STATE_FILE": self.state.state_file,
             "MOLECULE_INVENTORY_FILE": self.provisioner.inventory_file,  # type: ignore[union-attr]
+            "MOLECULE_SHARED_INVENTORY_DIR": shared_inventory_dir,
             "MOLECULE_EPHEMERAL_DIRECTORY": self.scenario.ephemeral_directory,
             "MOLECULE_SCENARIO_DIRECTORY": self.scenario.directory,
             "MOLECULE_PROJECT_DIRECTORY": self.project_directory,

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -573,7 +573,7 @@ class Ansible(base.Base):
         return self._config.config["provisioner"]["inventory"]["links"]
 
     @property
-    def inventory(self) -> dict[str, str]:
+    def inventory(self) -> dict[str, Any]:
         """Create an inventory structure and returns a dict.
 
         ``` yaml
@@ -605,6 +605,7 @@ class Ansible(base.Base):
                     "molecule_file": "{{ lookup('env', 'MOLECULE_FILE') }}",
                     "molecule_ephemeral_directory": "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
                     "molecule_scenario_directory": "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                    "molecule_shared_inventory_dir": "{{ lookup('env', 'MOLECULE_SHARED_INVENTORY_DIR') }}",
                     "molecule_yml": "{{ lookup('file', molecule_file) | from_yaml }}",
                     "molecule_instance_config": "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}",
                     "molecule_no_log": "{{ lookup('env', 'MOLECULE_NO_LOG') or not "

--- a/tests/fixtures/integration/test_command/scenarios/shared_inventory/molecule/default/converge.yml
+++ b/tests/fixtures/integration/test_command/scenarios/shared_inventory/molecule/default/converge.yml
@@ -1,0 +1,40 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Test molecule_shared_inventory_dir variable is available
+      ansible.builtin.debug:
+        msg: "molecule_shared_inventory_dir: {{ molecule_shared_inventory_dir }}"
+
+    - name: Verify molecule_shared_inventory_dir is a string
+      ansible.builtin.assert:
+        that:
+          - molecule_shared_inventory_dir is defined
+          - molecule_shared_inventory_dir is string
+        fail_msg: "molecule_shared_inventory_dir should be defined and be a string"
+        success_msg: "molecule_shared_inventory_dir is properly defined"
+
+    - name: Create shared inventory file (if available)
+      ansible.builtin.copy:
+        content: "{{ inventory_ini }}"
+        dest: "{{ molecule_shared_inventory_dir }}/shared_inventory.ini"
+        mode: "0600"
+      when: molecule_shared_inventory_dir != ""
+      vars:
+        inventory_ini: |
+          [molecule]
+          {% for platform in molecule_yml.platforms %}
+          {{ platform.name }} ansible_connection=delegated
+          {% endfor %}
+
+          [molecule:vars]
+          ansible_user=root
+      delegate_to: localhost
+
+    - name: Test that shared inventory directory is empty in normal mode
+      ansible.builtin.assert:
+        that:
+          - molecule_shared_inventory_dir == ""
+        fail_msg: "molecule_shared_inventory_dir should be empty in normal mode"
+        success_msg: "molecule_shared_inventory_dir is correctly empty in normal mode"

--- a/tests/fixtures/integration/test_command/scenarios/shared_inventory/molecule/default/molecule.yml
+++ b/tests/fixtures/integration/test_command/scenarios/shared_inventory/molecule/default/molecule.yml
@@ -1,0 +1,14 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: default
+platforms:
+  - name: instance
+    image: ${TEST_BASE_IMAGE}
+    command: /sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -733,3 +733,28 @@ smoke                     : actions=12  successful=3  disabled=0  skipped=0  mis
             f"Expected ({len(normalized_expected)} chars):\n{normalized_expected!r}\n\n"
             f"Actual ({len(normalized_details)} chars):\n{normalized_details!r}",
         )
+
+
+@pytest.mark.parametrize(
+    ("scenario_to_test", "scenario_name"),
+    (("shared_inventory", "default"),),
+)
+@pytest.mark.usefixtures("with_scenario")
+def test_command_shared_inventory(
+    test_ephemeral_dir_env: dict[str, str],
+    scenario_name: str,
+) -> None:
+    """Test shared inventory scenario functionality.
+
+    Args:
+        test_ephemeral_dir_env: The ephemeral directory env.
+        scenario_name: The scenario name.
+    """
+    # Test converge to verify our molecule_shared_inventory_dir variable works
+    cmd = ["molecule", "converge", "--scenario-name", scenario_name]
+    result = run(cmd=cmd, env=test_ephemeral_dir_env)
+    assert result.returncode == 0
+    assert "PLAY RECAP" in result.stdout
+
+    # Verify that our variable assertions passed
+    assert "molecule_shared_inventory_dir is properly defined" in result.stdout

--- a/tests/unit/provisioner/test_ansible.py
+++ b/tests/unit/provisioner/test_ansible.py
@@ -794,3 +794,21 @@ def test_absolute_path_for_raises_with_missing_key(instance):  # type: ignore[no
 
     with pytest.raises(KeyError):
         instance._absolute_path_for(env, "invalid")
+
+
+def test_inventory_contains_molecule_shared_inventory_dir_variable(instance: Ansible) -> None:
+    """Test that molecule_shared_inventory_dir is included in inventory vars.
+
+    Args:
+        instance: Ansible provisioner instance fixture.
+    """
+    inventory = instance.inventory
+
+    # Check that all groups have the molecule_shared_inventory_dir variable
+    assert "all" in inventory
+    assert "vars" in inventory["all"]
+    assert "molecule_shared_inventory_dir" in inventory["all"]["vars"]
+    assert (
+        inventory["all"]["vars"]["molecule_shared_inventory_dir"]
+        == "{{ lookup('env', 'MOLECULE_SHARED_INVENTORY_DIR') }}"
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -197,6 +197,7 @@ def test_env(config_instance: config.Config) -> None:  # noqa: D103
         "MOLECULE_FILE": config_instance.config_file,
         "MOLECULE_ENV_FILE": util.abs_path(env_file),
         "MOLECULE_INVENTORY_FILE": config_instance.provisioner.inventory_file,  # type: ignore[union-attr]
+        "MOLECULE_SHARED_INVENTORY_DIR": "",
         "MOLECULE_EPHEMERAL_DIRECTORY": config_instance.scenario.ephemeral_directory,
         "MOLECULE_SCENARIO_DIRECTORY": config_instance.scenario.directory,
         "MOLECULE_PROJECT_DIRECTORY": config_instance.project_directory,
@@ -468,6 +469,47 @@ def test_set_env_from_file_returns_original_env_when_env_file_not_found(  # noqa
     env = config.set_env_from_file({}, "file-not-found")
 
     assert env == {}
+
+
+def test_env_molecule_shared_inventory_dir_when_shared_inventory_disabled(
+    config_instance: config.Config,
+) -> None:
+    """Test MOLECULE_SHARED_INVENTORY_DIR is empty when shared_inventory=False.
+
+    Args:
+        config_instance: Molecule config instance fixture.
+    """
+    config_instance.command_args["shared_inventory"] = False
+    env = config_instance.env
+    assert env["MOLECULE_SHARED_INVENTORY_DIR"] == ""
+
+
+def test_env_molecule_shared_inventory_dir_when_shared_inventory_enabled(
+    config_instance: config.Config,
+) -> None:
+    """Test MOLECULE_SHARED_INVENTORY_DIR points to shared directory when shared_inventory=True.
+
+    Args:
+        config_instance: Molecule config instance fixture.
+    """
+    config_instance.command_args["shared_inventory"] = True
+    env = config_instance.env
+    assert env["MOLECULE_SHARED_INVENTORY_DIR"] == config_instance.scenario.inventory_directory
+
+
+def test_env_molecule_shared_inventory_dir_when_parallel_mode(
+    config_instance: config.Config,
+) -> None:
+    """Test MOLECULE_SHARED_INVENTORY_DIR is empty in parallel mode (shared inventory disabled).
+
+    Args:
+        config_instance: Molecule config instance fixture.
+    """
+    config_instance.command_args["shared_inventory"] = True
+    config_instance.command_args["parallel"] = True
+    env = config_instance.env
+    # In parallel mode, shared_inventory should be treated as disabled
+    assert env["MOLECULE_SHARED_INVENTORY_DIR"] == ""
 
 
 def test_write_config(config_instance: config.Config) -> None:  # noqa: D103


### PR DESCRIPTION
# Add MOLECULE_SHARED_INVENTORY_DIR environment variable and playbook variable

## Summary

Introduces `MOLECULE_SHARED_INVENTORY_DIR` as both an environment variable and playbook variable to enable access to shared inventory directories when using the `--shared-inventory` option. This enhancement allows scenarios to programmatically create and consume shared inventory files across multiple test runs.

## Use Case

When testing complex multi-scenario setups, users often need to share inventory data between scenarios. The existing `--shared-inventory` option provides shared storage but lacks programmatic access from playbooks. This implementation enables:

- Dynamic inventory file creation in shared locations
- Cross-scenario inventory data consumption  
- Custom inventory management workflows
- Enhanced testing of multi-service deployments

## Implementation Details

### Core Changes

**Environment Variable (`src/molecule/config.py`)**
- Added `MOLECULE_SHARED_INVENTORY_DIR` to environment variables
- Returns shared inventory path when `--shared-inventory` enabled and not in parallel mode
- Returns empty string in normal mode or parallel mode (where shared inventory is disabled)

**Playbook Variable (`src/molecule/provisioner/ansible.py`)**
- Added `molecule_shared_inventory_dir` to molecule variables available in all playbooks
- Uses environment lookup: `{{ lookup('env', 'MOLECULE_SHARED_INVENTORY_DIR') }}`
- Fixed inventory property type annotation from `dict[str, str]` to `dict[str, Any]`

### Testing

**Unit Tests**
- `tests/unit/test_config.py`: Environment variable behavior across all modes
- `tests/unit/provisioner/test_ansible.py`: Playbook variable inclusion verification

**Integration Tests**
- `tests/fixtures/integration/.../shared_inventory/`: Complete test scenario with realistic inventory templating
- `tests/integration/test_command.py`: Dedicated test for shared inventory functionality

### Documentation

**Configuration Reference (`docs/configuration.md`)**
- Documented new environment variable with usage context
- Referenced corresponding playbook variable availability

**Usage Guide (`docs/guides/sharing.md`)**
- Added practical examples showing inventory file creation and consumption
- Demonstrated real-world use cases with Jinja2 templating

## Behavior

| Mode | `shared_inventory` | `parallel` | Variable Value |
|------|-------------------|------------|----------------|
| Normal | `false` | `false` | `""` (empty) |
| Shared | `true` | `false` | `/path/to/shared/inventory` |
| Parallel | `true` | `true` | `""` (shared disabled) |

## Example Usage

```yaml
- name: Create shared inventory
  ansible.builtin.copy:
    content: "{{ inventory_ini }}"
    dest: "{{ molecule_shared_inventory_dir }}/shared_inventory.ini"
    mode: "0600"
  when: molecule_shared_inventory_dir != ""
  vars:
    inventory_ini: |
      [molecule]
      {% for platform in molecule_yml.platforms %}
      {{ platform.name }}{% for key, value in platform.get('host_vars', {}).items() %} {{ key }}={{ value }}{% endfor %}
      {% endfor %}
  delegate_to: localhost
```

## Compatibility

- Fully backward compatible
- No changes to existing behavior
- New variables are additive only
- Follows established molecule variable patterns 