### PR TITLE
Add always-on one-line execution summary with improved formatting

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -55,6 +55,7 @@ jsonfile
 keepends
 keypair
 kubevirt
+levelname
 libcloud
 libera
 libpod

--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -34,6 +34,8 @@ from molecule.constants import ANSICodes as A
 if TYPE_CHECKING:
     from typing import TextIO
 
+    from typing_extensions import Self
+
     from molecule.reporting.definitions import ScenariosResults
 
 

--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -34,9 +34,13 @@ from molecule.constants import ANSICodes as A
 if TYPE_CHECKING:
     from typing import TextIO
 
+<<<<<<< HEAD
     from typing_extensions import Self
 
     from molecule.reporting import ScenariosResults
+=======
+    from molecule.reporting.definitions import ScenariosResults
+>>>>>>> f7432737 (Add always-on one-line execution summary with improved formatting)
 
 
 def to_bool(a: object) -> bool:
@@ -330,7 +334,7 @@ class AnsiOutput:
             Formatted recap string with ANSI colors if enabled.
         """
         # Import here to avoid circular imports
-        from molecule.reporting import CompletionState  # noqa: PLC0415
+        from molecule.reporting.definitions import CompletionState  # noqa: PLC0415
 
         if not results:
             return ""

--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -34,13 +34,7 @@ from molecule.constants import ANSICodes as A
 if TYPE_CHECKING:
     from typing import TextIO
 
-<<<<<<< HEAD
-    from typing_extensions import Self
-
-    from molecule.reporting import ScenariosResults
-=======
     from molecule.reporting.definitions import ScenariosResults
->>>>>>> f7432737 (Add always-on one-line execution summary with improved formatting)
 
 
 def to_bool(a: object) -> bool:

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -40,7 +40,8 @@ from wcmatch import glob
 from molecule import config, logger, text, util
 from molecule.constants import MOLECULE_DEFAULT_SCENARIO_NAME
 from molecule.exceptions import ImmediateExit, MoleculeError, ScenarioFailureError
-from molecule.reporting import ScenarioResults, report
+from molecule.reporting.definitions import ScenarioResults
+from molecule.reporting.rendering import report
 from molecule.scenarios import Scenarios
 
 
@@ -175,8 +176,7 @@ def execute_cmdline_scenarios(
         msg = "Scenario execution failed"
         raise ImmediateExit(msg, code=exc.code) from exc
     finally:
-        if command_args.get("report"):
-            report(scenarios.results)
+        report(scenarios.results, report_flag=command_args.get("report", False))
 
 
 def _generate_scenarios(

--- a/src/molecule/command/cleanup.py
+++ b/src/molecule/command/cleanup.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/command/create.py
+++ b/src/molecule/command/create.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/command/prepare.py
+++ b/src/molecule/command/prepare.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/command/side_effect.py
+++ b/src/molecule/command/side_effect.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from molecule.click_cfg import click_command_ex, common_options
 from molecule.command import base
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/dependency/ansible_galaxy/base.py
+++ b/src/molecule/dependency/ansible_galaxy/base.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 
 from molecule import util
 from molecule.dependency import base
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/dependency/shell.py
+++ b/src/molecule/dependency/shell.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from molecule.dependency import base
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/logger.py
+++ b/src/molecule/logger.py
@@ -33,7 +33,7 @@ from ansible_compat.ports import cache
 from molecule.ansi_output import AnsiOutput
 from molecule.console import console, original_stderr
 from molecule.constants import ANSICodes as A
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 from molecule.text import underscore
 
 

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -35,7 +35,7 @@ from molecule import logger, util
 from molecule.constants import RC_SETUP_ERROR
 from molecule.exceptions import ImmediateExit, MoleculeError
 from molecule.provisioner import ansible_playbook, ansible_playbooks, base
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/provisioner/ansible_playbook.py
+++ b/src/molecule/provisioner/ansible_playbook.py
@@ -32,7 +32,7 @@ from rich.markup import escape
 from molecule import logger, util
 from molecule.api import MoleculeRuntimeWarning
 from molecule.exceptions import ScenarioFailureError
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/reporting/__init__.py
+++ b/src/molecule/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting module."""

--- a/src/molecule/reporting/rendering.py
+++ b/src/molecule/reporting/rendering.py
@@ -1,0 +1,64 @@
+"""Rendering and output functionality for reporting."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from molecule.ansi_output import AnsiOutput
+from molecule.console import original_stderr
+from molecule.logger import get_logger
+
+
+if TYPE_CHECKING:
+    from .definitions import ScenariosResults
+
+
+def report(results: ScenariosResults, *, report_flag: bool) -> None:
+    """Report the results of the scenario.
+
+    Args:
+        results: The results of the scenario.
+        report_flag: Value of the --report flag from user (True = show details, False = summary only).
+    """
+    if not results:
+        return
+
+    # ALWAYS show one-line summary with appropriate log level
+    overall_state, summary_line = results.get_overall_summary()
+
+    # Log at the appropriate level based on highest priority completion state
+    log = get_logger(__name__)
+    getattr(log, overall_state.log_level)(summary_line)
+
+    # Show detailed sections ONLY if --report flag was provided by user
+    if report_flag:
+        ao = AnsiOutput()
+
+        # Details section header (bold and underlined), padded to 79 characters
+        details_text = "DETAILS"
+        details_padded = f"{details_text:<79}"
+        details_header = f"\n[bold][underline]{details_padded}[/]"
+        original_stderr.write(ao.process_markup(details_header))
+        original_stderr.write("\n")
+
+        # Details section content - show completion status for each action
+        for scenario_result in results:
+            if not scenario_result.actions:
+                continue
+            for action_result in scenario_result.actions:
+                line = ao.format_full_completion_line(
+                    scenario_name=scenario_result.name,
+                    action_name=action_result.action or "unknown",
+                    completion_message=action_result.summary.message,
+                    color=action_result.summary.color,
+                    note=action_result.summary.note,
+                )
+                original_stderr.write(ao.process_markup(line))
+                original_stderr.write("\n")
+            original_stderr.write("\n")
+
+        # Scenario recap section - dynamically generated from CompletionState
+        recap = ao.format_scenario_recap(results)
+        if recap:
+            original_stderr.write(recap)
+            original_stderr.write("\n\n")

--- a/src/molecule/scenario.py
+++ b/src/molecule/scenario.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 from molecule import logger, scenarios, util
 from molecule.constants import RC_TIMEOUT
 from molecule.exceptions import MoleculeError
-from molecule.reporting import ScenarioResults
+from molecule.reporting.definitions import ScenarioResults
 from molecule.text import checksum
 
 

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 
 from molecule import util
 from molecule.exceptions import MoleculeError
-from molecule.reporting import ScenariosResults
+from molecule.reporting.definitions import ScenariosResults
 
 
 if TYPE_CHECKING:

--- a/src/molecule/verifier/ansible.py
+++ b/src/molecule/verifier/ansible.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, cast
 
 from molecule import logger, util
 from molecule.api import Verifier
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, cast
 from molecule import logger, util
 from molecule.api import Verifier
 from molecule.exceptions import ImmediateExit
-from molecule.reporting import CompletionState
+from molecule.reporting.definitions import CompletionState
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
### Overview
Molecule now displays a concise execution summary for every run, providing immediate visibility into scenario outcomes with proper log levels and color coding.

### New Behavior
**Before**: Summary only shown when `--report` flag was used
```bash
# No summary without --report flag
```

**After**: Always displays execution summary with appropriate log level
```bash
INFO     Molecule executed 1 scenario (1 successful)
WARNING  Molecule executed 1 scenario (1 missing files)  
ERROR    Molecule executed 3 scenarios (1 failed, 1 missing files, and 1 successful)
```

### Key Features
- **Always visible**: Summary appears regardless of `--report` flag usage
- **Proper log levels**: ERROR for failures, WARNING for missing files, INFO for success
- **Color-coded details**: Individual state counts use appropriate colors while maintaining clean formatting
- **Improved messaging**: Uses "executed" terminology and clarifies "missing files" vs ambiguous "missing"
- **Oxford comma formatting**: Grammatically correct lists for multiple states
- **Priority ordering**: Most critical issues (failures) appear first in multi-state summaries

### Implementation Details
The `--report` flag now controls detailed output sections only, while the one-line summary is always shown. This required restructuring the reporting module to eliminate circular imports and separate data definitions from rendering logic.

**Module Structure Changes:**
- Split `reporting.py` into `reporting/definitions.py` (data structures) and `reporting/rendering.py` (I/O)
- Updated imports across codebase to use specific modules
- Eliminated circular import warnings

### Backward Compatibility
All existing functionality preserved. The `--report` flag continues to control detailed output sections as before, with the addition of the always-visible summary line.