### PR TITLE
Replace ImmediateExit with sysexit_with_message for direct exits

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -44,7 +44,6 @@ from molecule.reporting.definitions import ScenarioResults
 from molecule.reporting.rendering import report
 from molecule.scenarios import Scenarios
 from molecule.utils import util
-from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -174,7 +173,7 @@ def execute_cmdline_scenarios(
 
     except ScenarioFailureError as exc:
         msg = "Scenario execution failed"
-        sysexit_with_message(msg, code=exc.code)
+        util.sysexit_with_message(msg, code=exc.code)
     finally:
         report(scenarios.results, report_flag=command_args.get("report", False))
 

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -154,7 +154,7 @@ def execute_cmdline_scenarios(
                 glob_str = effective_base_glob.replace("*", scenario_name)
                 configs.extend(get_configs(args, command_args, ansible_args, glob_str))
         except ScenarioFailureError as exc:
-            util.sysexit_with_message(str(exc), code=exc.code)
+            util.sysexit_from_exception(exc)
 
     default_glob = effective_base_glob.replace("*", MOLECULE_DEFAULT_SCENARIO_NAME)
     default_config = None
@@ -170,8 +170,7 @@ def execute_cmdline_scenarios(
         _run_scenarios(scenarios, command_args, default_config)
 
     except ScenarioFailureError as exc:
-        msg = "Scenario execution failed"
-        util.sysexit_with_message(msg, code=exc.code)
+        util.sysexit_from_exception(exc)
     finally:
         report(scenarios.results, report_flag=command_args.get("report", False))
 

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -157,7 +157,7 @@ def execute_cmdline_scenarios(
                 glob_str = effective_base_glob.replace("*", scenario_name)
                 configs.extend(get_configs(args, command_args, ansible_args, glob_str))
         except ScenarioFailureError as exc:
-            sysexit_with_message(str(exc), code=exc.code)
+            util.sysexit_with_message(str(exc), code=exc.code)
 
     default_glob = effective_base_glob.replace("*", MOLECULE_DEFAULT_SCENARIO_NAME)
     default_config = None

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -157,8 +157,7 @@ def execute_cmdline_scenarios(
                 glob_str = effective_base_glob.replace("*", scenario_name)
                 configs.extend(get_configs(args, command_args, ansible_args, glob_str))
         except ScenarioFailureError as exc:
-            msg = "Scenario configuration failed"
-            sysexit_with_message(msg, code=exc.code)
+            sysexit_with_message(str(exc), code=exc.code)
 
     default_glob = effective_base_glob.replace("*", MOLECULE_DEFAULT_SCENARIO_NAME)
     default_config = None

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -133,8 +133,6 @@ def execute_cmdline_scenarios(
         command_args: dict of command arguments, including the target
         ansible_args: Optional tuple of arguments to pass to the `ansible-playbook` command
         excludes: Name of scenarios to not run.
-
-    Exits with error code on scenario configuration failure.
     """
     if excludes is None:
         excludes = []

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -39,11 +39,12 @@ from wcmatch import glob
 
 from molecule import config, logger, text
 from molecule.constants import MOLECULE_DEFAULT_SCENARIO_NAME
-from molecule.exceptions import ImmediateExit, MoleculeError, ScenarioFailureError
+from molecule.exceptions import MoleculeError, ScenarioFailureError
 from molecule.reporting.definitions import ScenarioResults
 from molecule.reporting.rendering import report
 from molecule.scenarios import Scenarios
 from molecule.utils import util
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -135,7 +136,7 @@ def execute_cmdline_scenarios(
         excludes: Name of scenarios to not run.
 
     Raises:
-        ImmediateExit: When scenario configuration fails.
+        SystemExit: When scenario configuration fails.
     """
     if excludes is None:
         excludes = []
@@ -158,7 +159,7 @@ def execute_cmdline_scenarios(
                 configs.extend(get_configs(args, command_args, ansible_args, glob_str))
         except ScenarioFailureError as exc:
             msg = "Scenario configuration failed"
-            raise ImmediateExit(msg, code=exc.code) from exc
+            sysexit_with_message(msg, code=exc.code)
 
     default_glob = effective_base_glob.replace("*", MOLECULE_DEFAULT_SCENARIO_NAME)
     default_config = None
@@ -175,7 +176,7 @@ def execute_cmdline_scenarios(
 
     except ScenarioFailureError as exc:
         msg = "Scenario execution failed"
-        raise ImmediateExit(msg, code=exc.code) from exc
+        sysexit_with_message(msg, code=exc.code)
     finally:
         report(scenarios.results, report_flag=command_args.get("report", False))
 

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -135,8 +135,7 @@ def execute_cmdline_scenarios(
         ansible_args: Optional tuple of arguments to pass to the `ansible-playbook` command
         excludes: Name of scenarios to not run.
 
-    Raises:
-        SystemExit: When scenario configuration fails.
+    Exits with error code on scenario configuration failure.
     """
     if excludes is None:
         excludes = []

--- a/src/molecule/command/init/base.py
+++ b/src/molecule/command/init/base.py
@@ -25,7 +25,7 @@ import abc
 
 from pathlib import Path
 
-from molecule.exceptions import ImmediateExit
+from molecule.utils.util import sysexit_with_message
 
 
 class Base(abc.ABC):
@@ -42,4 +42,4 @@ class Base(abc.ABC):
     def _validate_template_dir(self, template_dir: str) -> None:
         if not Path(template_dir).is_dir():
             msg = f"The specified template directory ({template_dir!s}) does not exist"
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)

--- a/src/molecule/command/init/base.py
+++ b/src/molecule/command/init/base.py
@@ -25,7 +25,7 @@ import abc
 
 from pathlib import Path
 
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 
 
 class Base(abc.ABC):
@@ -42,4 +42,4 @@ class Base(abc.ABC):
     def _validate_template_dir(self, template_dir: str) -> None:
         if not Path(template_dir).is_dir():
             msg = f"The specified template directory ({template_dir!s}) does not exist"
-            raise MoleculeError(message=msg)
+            raise ImmediateExit(msg, code=1)

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -102,8 +102,6 @@ class Scenario(base.Base):
 
         Args:
             action_args: Arguments for this command. Unused.
-
-        Exits with error code 1 if the scenario cannot be created.
         """
         scenario_name = self._command_args["scenario_name"]
 

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -43,7 +43,7 @@ from molecule.constants import (
     MOLECULE_DEFAULT_SCENARIO_NAME,
     MOLECULE_ROOT,
 )
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 from molecule.utils import util
 
 
@@ -105,7 +105,7 @@ class Scenario(base.Base):
             action_args: Arguments for this command. Unused.
 
         Raises:
-            MoleculeError: when the scenario cannot be created.
+            ImmediateExit: when the scenario cannot be created.
         """
         scenario_name = self._command_args["scenario_name"]
 
@@ -128,7 +128,7 @@ class Scenario(base.Base):
 
         if scenario_directory.is_dir():
             msg = f"The directory {relative_path} exists. Cannot create new scenario."
-            raise MoleculeError(msg)
+            raise ImmediateExit(msg, code=1)
 
         # Ensure parent directory exists
         molecule_path.mkdir(parents=True, exist_ok=True)
@@ -172,7 +172,7 @@ def _role_exists(
     role_directory = Path.cwd().parent / value
     if not role_directory.exists():
         msg = f"The role '{value}' not found. Please choose the proper role name."
-        raise MoleculeError(msg)
+        raise ImmediateExit(msg, code=1)
     return value
 
 

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -104,8 +104,7 @@ class Scenario(base.Base):
         Args:
             action_args: Arguments for this command. Unused.
 
-        Raises:
-            SystemExit: when the scenario cannot be created.
+        Exits with error code 1 if the scenario cannot be created.
         """
         scenario_name = self._command_args["scenario_name"]
 

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -170,7 +170,7 @@ def _role_exists(
     role_directory = Path.cwd().parent / value
     if not role_directory.exists():
         msg = f"The role '{value}' not found. Please choose the proper role name."
-        sysexit_with_message(msg, code=1)
+        util.sysexit_with_message(msg, code=1)
     return value
 
 

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -43,8 +43,8 @@ from molecule.constants import (
     MOLECULE_DEFAULT_SCENARIO_NAME,
     MOLECULE_ROOT,
 )
-from molecule.exceptions import ImmediateExit
 from molecule.utils import util
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -105,7 +105,7 @@ class Scenario(base.Base):
             action_args: Arguments for this command. Unused.
 
         Raises:
-            ImmediateExit: when the scenario cannot be created.
+            SystemExit: when the scenario cannot be created.
         """
         scenario_name = self._command_args["scenario_name"]
 
@@ -128,7 +128,7 @@ class Scenario(base.Base):
 
         if scenario_directory.is_dir():
             msg = f"The directory {relative_path} exists. Cannot create new scenario."
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)
 
         # Ensure parent directory exists
         molecule_path.mkdir(parents=True, exist_ok=True)
@@ -172,7 +172,7 @@ def _role_exists(
     role_directory = Path.cwd().parent / value
     if not role_directory.exists():
         msg = f"The role '{value}' not found. Please choose the proper role name."
-        raise ImmediateExit(msg, code=1)
+        sysexit_with_message(msg, code=1)
     return value
 
 

--- a/src/molecule/command/init/scenario.py
+++ b/src/molecule/command/init/scenario.py
@@ -44,7 +44,6 @@ from molecule.constants import (
     MOLECULE_ROOT,
 )
 from molecule.utils import util
-from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -127,7 +126,7 @@ class Scenario(base.Base):
 
         if scenario_directory.is_dir():
             msg = f"The directory {relative_path} exists. Cannot create new scenario."
-            sysexit_with_message(msg, code=1)
+            util.sysexit_with_message(msg, code=1)
 
         # Ensure parent directory exists
         molecule_path.mkdir(parents=True, exist_ok=True)

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -34,7 +34,6 @@ from molecule.console import console
 from molecule.exceptions import ScenarioFailureError
 from molecule.status import Status
 from molecule.utils import util
-from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -69,8 +69,7 @@ def list_(ctx: click.Context) -> None:  # pragma: no cover
     Args:
         ctx: Click context object holding commandline arguments.
 
-    Raises:
-        SystemExit: If scenario configuration fails.
+    Exits with error code if scenario configuration fails.
     """
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -31,9 +31,10 @@ from molecule import scenarios, text
 from molecule.click_cfg import click_command_ex, options
 from molecule.command import base
 from molecule.console import console
-from molecule.exceptions import ImmediateExit, ScenarioFailureError
+from molecule.exceptions import ScenarioFailureError
 from molecule.status import Status
 from molecule.utils import util
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -69,7 +70,7 @@ def list_(ctx: click.Context) -> None:  # pragma: no cover
         ctx: Click context object holding commandline arguments.
 
     Raises:
-        ImmediateExit: If scenario configuration fails.
+        SystemExit: If scenario configuration fails.
     """
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
@@ -85,7 +86,7 @@ def list_(ctx: click.Context) -> None:  # pragma: no cover
     try:
         configs = base.get_configs(args, command_args)
     except ScenarioFailureError as exc:
-        raise ImmediateExit(str(exc), exc.code) from exc
+        sysexit_with_message(str(exc), code=exc.code)
 
     s = scenarios.Scenarios(
         configs,

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -67,8 +67,6 @@ def list_(ctx: click.Context) -> None:  # pragma: no cover
 
     Args:
         ctx: Click context object holding commandline arguments.
-
-    Exits with error code if scenario configuration fails.
     """
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -85,7 +85,7 @@ def list_(ctx: click.Context) -> None:  # pragma: no cover
     try:
         configs = base.get_configs(args, command_args)
     except ScenarioFailureError as exc:
-        sysexit_with_message(str(exc), code=exc.code)
+        sysexit_from_exception(exc)
 
     s = scenarios.Scenarios(
         configs,

--- a/src/molecule/command/list.py
+++ b/src/molecule/command/list.py
@@ -84,7 +84,7 @@ def list_(ctx: click.Context) -> None:  # pragma: no cover
     try:
         configs = base.get_configs(args, command_args)
     except ScenarioFailureError as exc:
-        sysexit_from_exception(exc)
+        util.sysexit_from_exception(exc)
 
     s = scenarios.Scenarios(
         configs,

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 from molecule import scenarios
 from molecule.click_cfg import click_command_ex, options
 from molecule.command import base
-from molecule.exceptions import ImmediateExit
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -78,11 +78,11 @@ class Login(base.Base):
                     "which with --host.\n\n"
                     f"Available hosts:\n{host_list}"
                 )
-                raise ImmediateExit(msg, code=1)
+                sysexit_with_message(msg, code=1)
         match = [x for x in hosts if x.startswith(hostname)]
         if len(match) == 0:
             msg = f"There are no hosts that match '{hostname}'.  You can only login to valid hosts."
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)
         if len(match) != 1:
             # If there are multiple matches, but one of them is an exact string
             # match, assume this is the one they're looking for and use it.
@@ -94,7 +94,7 @@ class Login(base.Base):
                     "can only login to one at a time.\n\n"
                     f"Available hosts:\n{host_list}"
                 )
-                raise ImmediateExit(msg, code=1)
+                sysexit_with_message(msg, code=1)
 
         return match[0]
 

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 from molecule import scenarios
 from molecule.click_cfg import click_command_ex, options
 from molecule.command import base
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 
 
 if TYPE_CHECKING:
@@ -78,11 +78,11 @@ class Login(base.Base):
                     "which with --host.\n\n"
                     f"Available hosts:\n{host_list}"
                 )
-                raise MoleculeError(msg)
+                raise ImmediateExit(msg, code=1)
         match = [x for x in hosts if x.startswith(hostname)]
         if len(match) == 0:
             msg = f"There are no hosts that match '{hostname}'.  You can only login to valid hosts."
-            raise MoleculeError(msg)
+            raise ImmediateExit(msg, code=1)
         if len(match) != 1:
             # If there are multiple matches, but one of them is an exact string
             # match, assume this is the one they're looking for and use it.
@@ -94,7 +94,7 @@ class Login(base.Base):
                     "can only login to one at a time.\n\n"
                     f"Available hosts:\n{host_list}"
                 )
-                raise MoleculeError(msg)
+                raise ImmediateExit(msg, code=1)
 
         return match[0]
 

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -38,12 +38,11 @@ from molecule.app import get_app
 from molecule.constants import DEFAULT_CONFIG, ENV_VAR_CONFIG_MAPPING
 from molecule.data import __file__ as data_module
 from molecule.dependency import ansible_galaxy, shell
-from molecule.exceptions import ImmediateExit
 from molecule.model import schema_v3
 from molecule.provisioner import ansible
 from molecule.utils import util
 from molecule.utils.boolean import to_bool
-from molecule.utils.util import boolean
+from molecule.utils.util import boolean, sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -346,8 +345,7 @@ class Config:
         Returns:
             The driver for this scenario.
 
-        Raises:
-            ImmediateExit: when the specified driver cannot be found.
+        Exits with error code 1 if the specified driver cannot be found.
         """
         driver_name = self._get_driver_name()
         driver = None
@@ -355,7 +353,7 @@ class Config:
         api_drivers = api.drivers(config=self)
         if driver_name not in api_drivers:
             msg = f"Failed to find driver {driver_name}. Please ensure that the driver is correctly installed."
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)
 
         driver = api_drivers[driver_name]
         driver.name = driver_name
@@ -501,14 +499,14 @@ class Config:
                 f"Instance(s) were created with the '{driver_name}' driver, but the "
                 f"subcommand is using '{driver_from_cli}' driver."
             )
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)
 
         if driver_from_state_file and driver_name not in api.drivers():
             msg = (
                 f"Driver '{driver_name}' from state-file "
                 f"'{self.state.state_file}' is not available."
             )
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)
 
         if driver_from_scenario != driver_name:
             msg = (
@@ -698,7 +696,7 @@ class Config:
             return i.interpolate(stream, keep_string)
         except interpolation.InvalidInterpolation as e:
             msg = f"parsing config file '{self.molecule_file}'.\n\n{e.place}\n{e.string}"
-            raise ImmediateExit(msg, code=1) from e
+            sysexit_with_message(msg, code=1)
         return ""
 
     def _get_defaults(self) -> ConfigData:
@@ -726,8 +724,7 @@ class Config:
     def _validate(self) -> None:
         """Validate molecule file.
 
-        Raises:
-            ImmediateExit: when config file fails to validate.
+        Exits with error code 1 if config file fails to validate.
         """
         # Use scenario logger with hardcoded values since scenario property isn't available yet
         scenario_name = self.config["scenario"]["name"]
@@ -739,7 +736,7 @@ class Config:
         errors = schema_v3.validate(self.config)
         if errors:
             msg = f"Failed to validate {self.molecule_file}\n\n{errors}"
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)
 
 
 def molecule_directory(path: str | Path) -> str:

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -38,7 +38,7 @@ from molecule.app import get_app
 from molecule.constants import DEFAULT_CONFIG, ENV_VAR_CONFIG_MAPPING
 from molecule.data import __file__ as data_module
 from molecule.dependency import ansible_galaxy, shell
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 from molecule.model import schema_v3
 from molecule.provisioner import ansible
 from molecule.utils import util
@@ -347,7 +347,7 @@ class Config:
             The driver for this scenario.
 
         Raises:
-            MoleculeError: when the specified driver cannot be found.
+            ImmediateExit: when the specified driver cannot be found.
         """
         driver_name = self._get_driver_name()
         driver = None
@@ -355,7 +355,7 @@ class Config:
         api_drivers = api.drivers(config=self)
         if driver_name not in api_drivers:
             msg = f"Failed to find driver {driver_name}. Please ensure that the driver is correctly installed."
-            raise MoleculeError(msg)
+            raise ImmediateExit(msg, code=1)
 
         driver = api_drivers[driver_name]
         driver.name = driver_name
@@ -501,14 +501,14 @@ class Config:
                 f"Instance(s) were created with the '{driver_name}' driver, but the "
                 f"subcommand is using '{driver_from_cli}' driver."
             )
-            raise MoleculeError(msg)
+            raise ImmediateExit(msg, code=1)
 
         if driver_from_state_file and driver_name not in api.drivers():
             msg = (
                 f"Driver '{driver_name}' from state-file "
                 f"'{self.state.state_file}' is not available."
             )
-            raise MoleculeError(msg)
+            raise ImmediateExit(msg, code=1)
 
         if driver_from_scenario != driver_name:
             msg = (
@@ -698,7 +698,7 @@ class Config:
             return i.interpolate(stream, keep_string)
         except interpolation.InvalidInterpolation as e:
             msg = f"parsing config file '{self.molecule_file}'.\n\n{e.place}\n{e.string}"
-            raise MoleculeError(msg) from e
+            raise ImmediateExit(msg, code=1) from e
         return ""
 
     def _get_defaults(self) -> ConfigData:
@@ -727,7 +727,7 @@ class Config:
         """Validate molecule file.
 
         Raises:
-            MoleculeError: when config file fails to validate.
+            ImmediateExit: when config file fails to validate.
         """
         # Use scenario logger with hardcoded values since scenario property isn't available yet
         scenario_name = self.config["scenario"]["name"]
@@ -739,7 +739,7 @@ class Config:
         errors = schema_v3.validate(self.config)
         if errors:
             msg = f"Failed to validate {self.molecule_file}\n\n{errors}"
-            raise MoleculeError(msg)
+            raise ImmediateExit(msg, code=1)
 
 
 def molecule_directory(path: str | Path) -> str:

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -344,8 +344,6 @@ class Config:
 
         Returns:
             The driver for this scenario.
-
-        Exits with error code 1 if the specified driver cannot be found.
         """
         driver_name = self._get_driver_name()
         driver = None
@@ -722,10 +720,7 @@ class Config:
         return defaults  # type: ignore[return-value]
 
     def _validate(self) -> None:
-        """Validate molecule file.
-
-        Exits with error code 1 if config file fails to validate.
-        """
+        """Validate molecule file."""
         # Use scenario logger with hardcoded values since scenario property isn't available yet
         scenario_name = self.config["scenario"]["name"]
         validation_log = logger.get_scenario_logger(__name__, scenario_name, "validate")

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -72,10 +72,7 @@ class Base(abc.ABC):
         return logger.get_scenario_logger(__name__, self._config.scenario.name, step_name)
 
     def execute_with_retries(self) -> None:
-        """Run dependency downloads with retry and timed back-off.
-
-        Exits with error code when dependency installation fails after retries.
-        """
+        """Run dependency downloads with retry and timed back-off."""
         try:
             self._config.app.run_command(
                 self._sh_command,

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING
 
 from molecule import logger
 from molecule.utils import util
-from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -112,8 +111,7 @@ class Base(abc.ABC):
             except CalledProcessError as _exception:
                 exception = _exception
 
-        self._log.error(str(exception))
-        sysexit_with_message(str(exception), code=exception.returncode)
+        util.sysexit_with_message(str(exception), code=exception.returncode)
 
     @abc.abstractmethod
     def execute(

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -29,8 +29,8 @@ from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from molecule import logger
-from molecule.exceptions import ImmediateExit
 from molecule.utils import util
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -76,7 +76,7 @@ class Base(abc.ABC):
         """Run dependency downloads with retry and timed back-off.
 
         Raises:
-            ImmediateExit: When dependency installation fails after retries.
+            SystemExit: When dependency installation fails after retries.
         """
         try:
             self._config.app.run_command(
@@ -114,7 +114,7 @@ class Base(abc.ABC):
                 exception = _exception
 
         self._log.error(str(exception))
-        raise ImmediateExit(str(exception), code=exception.returncode)
+        sysexit_with_message(str(exception), code=exception.returncode)
 
     @abc.abstractmethod
     def execute(

--- a/src/molecule/dependency/base.py
+++ b/src/molecule/dependency/base.py
@@ -75,8 +75,7 @@ class Base(abc.ABC):
     def execute_with_retries(self) -> None:
         """Run dependency downloads with retry and timed back-off.
 
-        Raises:
-            SystemExit: When dependency installation fails after retries.
+        Exits with error code when dependency installation fails after retries.
         """
         try:
             self._config.app.run_command(

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -556,8 +556,7 @@ class Ansible(base.Base):
         The inventory property always returns a minimal valid structure
         regardless of the platforms defined in the molecule.yml file.
 
-        Raises:
-            SystemExit: if a specific platform was requested but doesn't exist.
+        Exits with error code if a specific platform was requested but doesn't exist.
         """
         if self._config.platform_name is not None and not self._config.platforms.instances:
             msg = "Instances missing from the 'platform' section of molecule.yml."

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -33,10 +33,11 @@ from ansible_compat.ports import cached_property
 
 from molecule import logger
 from molecule.constants import DEFAULT_ANSIBLE_CFG_OPTIONS, RC_SETUP_ERROR
-from molecule.exceptions import ImmediateExit, MoleculeError
+from molecule.exceptions import MoleculeError
 from molecule.provisioner import ansible_playbook, ansible_playbooks, base
 from molecule.reporting.definitions import CompletionState
 from molecule.utils import util
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -556,11 +557,11 @@ class Ansible(base.Base):
         regardless of the platforms defined in the molecule.yml file.
 
         Raises:
-            ImmediateExit: if a specific platform was requested but doesn't exist.
+            SystemExit: if a specific platform was requested but doesn't exist.
         """
         if self._config.platform_name is not None and not self._config.platforms.instances:
             msg = "Instances missing from the 'platform' section of molecule.yml."
-            raise ImmediateExit(msg, code=RC_SETUP_ERROR)
+            sysexit_with_message(msg, code=RC_SETUP_ERROR)
 
     def _get_config_template(self) -> str:
         """Return a config template string.

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -37,7 +37,6 @@ from molecule.exceptions import MoleculeError
 from molecule.provisioner import ansible_playbook, ansible_playbooks, base
 from molecule.reporting.definitions import CompletionState
 from molecule.utils import util
-from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -560,7 +559,7 @@ class Ansible(base.Base):
         """
         if self._config.platform_name is not None and not self._config.platforms.instances:
             msg = "Instances missing from the 'platform' section of molecule.yml."
-            sysexit_with_message(msg, code=RC_SETUP_ERROR)
+            util.sysexit_with_message(msg, code=RC_SETUP_ERROR)
 
     def _get_config_template(self) -> str:
         """Return a config template string.

--- a/src/molecule/provisioner/ansible.py
+++ b/src/molecule/provisioner/ansible.py
@@ -554,8 +554,6 @@ class Ansible(base.Base):
         Check if a specific platform was requested but doesn't exist.
         The inventory property always returns a minimal valid structure
         regardless of the platforms defined in the molecule.yml file.
-
-        Exits with error code if a specific platform was requested but doesn't exist.
         """
         if self._config.platform_name is not None and not self._config.platforms.instances:
             msg = "Instances missing from the 'platform' section of molecule.yml."

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -25,9 +25,9 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from molecule.exceptions import ImmediateExit
 from molecule.reporting.definitions import ScenariosResults
 from molecule.utils import util
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -136,8 +136,7 @@ class Scenarios:
     def _verify(self) -> None:
         """Verify the specified scenario was found.
 
-        Raises:
-            ImmediateExit: when scenario is not found.
+        Exits with error code 1 if scenario is not found.
         """
         scenario_names = [c.scenario.name for c in self._configs]
         if missing_names := sorted(set(self._scenario_names).difference(scenario_names)):
@@ -146,7 +145,7 @@ class Scenarios:
                 scenario += "s"
             missing = ", ".join(missing_names)
             msg = f"{scenario} '{missing}' not found.  Exiting."
-            raise ImmediateExit(msg, code=1)
+            sysexit_with_message(msg, code=1)
 
     def _filter_for_scenario(self) -> list[Scenario]:
         """Find the scenario matching the provided scenario name and returns a list.

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING
 
 from molecule.reporting.definitions import ScenariosResults
 from molecule.utils import util
-from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -134,10 +133,7 @@ class Scenarios:
         )
 
     def _verify(self) -> None:
-        """Verify the specified scenario was found.
-
-        Exits with error code 1 if scenario is not found.
-        """
+        """Verify the specified scenario was found."""
         scenario_names = [c.scenario.name for c in self._configs]
         if missing_names := sorted(set(self._scenario_names).difference(scenario_names)):
             scenario = "Scenario"
@@ -145,7 +141,7 @@ class Scenarios:
                 scenario += "s"
             missing = ", ".join(missing_names)
             msg = f"{scenario} '{missing}' not found.  Exiting."
-            sysexit_with_message(msg, code=1)
+            util.sysexit_with_message(msg, code=1)
 
     def _filter_for_scenario(self) -> list[Scenario]:
         """Find the scenario matching the provided scenario name and returns a list.

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -25,7 +25,7 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 from molecule.reporting.definitions import ScenariosResults
 from molecule.utils import util
 
@@ -137,7 +137,7 @@ class Scenarios:
         """Verify the specified scenario was found.
 
         Raises:
-            MoleculeError: when scenario is not found.
+            ImmediateExit: when scenario is not found.
         """
         scenario_names = [c.scenario.name for c in self._configs]
         if missing_names := sorted(set(self._scenario_names).difference(scenario_names)):
@@ -146,7 +146,7 @@ class Scenarios:
                 scenario += "s"
             missing = ", ".join(missing_names)
             msg = f"{scenario} '{missing}' not found.  Exiting."
-            raise MoleculeError(msg)
+            raise ImmediateExit(msg, code=1)
 
     def _filter_for_scenario(self) -> list[Scenario]:
         """Find the scenario matching the provided scenario name and returns a list.

--- a/src/molecule/utils/util.py
+++ b/src/molecule/utils/util.py
@@ -127,17 +127,22 @@ def sysexit_with_message(
     code: int = 1,
     warns: Sequence[WarningMessage] = (),
 ) -> NoReturn:
-    """This method is a lie for compatibility purposes.
+    """Exit with a message and optional warnings.
 
     Args:
         msg: The message to display.
         code: The return code to exit with.
         warns: A series of warnings to send alongside the message.
-
-    Raises:
-        MoleculeError: always.
     """
-    raise MoleculeError(message=msg, code=code, warns=warns)
+    logger = logging.getLogger(__name__)
+
+    if msg:
+        logger.critical(msg)
+
+    for warn in warns:
+        logger.warning(warn.__dict__["message"].args[0])
+
+    sys.exit(code)
 
 
 def os_walk(

--- a/src/molecule/utils/util.py
+++ b/src/molecule/utils/util.py
@@ -146,7 +146,7 @@ def sysexit_with_message(
         # Show only the error message in normal mode for failures
         LOG.error(msg)
 
-    sys.exit(code)
+    sysexit(code)
 
 
 def sysexit_from_exception(exc: MoleculeError) -> NoReturn:

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -158,8 +158,6 @@ class Testinfra(Verifier):
 
         Args:
             action_args: list of arguments to be passed.
-
-        Exits with error code when verifier tests fail.
         """
         if not self.enabled:
             msg = "Skipping, verifier is disabled."

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -160,8 +160,7 @@ class Testinfra(Verifier):
         Args:
             action_args: list of arguments to be passed.
 
-        Raises:
-            SystemExit: When verifier tests fail.
+        Exits with error code when verifier tests fail.
         """
         if not self.enabled:
             msg = "Skipping, verifier is disabled."

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -31,7 +31,6 @@ from molecule import logger
 from molecule.api import Verifier
 from molecule.reporting.definitions import CompletionState
 from molecule.utils import util
-from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -194,7 +193,7 @@ class Testinfra(Verifier):
             self._log.info(msg)
         else:
             msg = "Verifier tests failed"
-            sysexit_with_message(msg, code=result.returncode)
+            util.sysexit_with_message(msg, code=result.returncode)
 
     def _get_tests(self, action_args: list[str] | None = None) -> list[str]:
         """Walk the verifier's directory for tests.

--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -29,9 +29,9 @@ from typing import TYPE_CHECKING, cast
 
 from molecule import logger
 from molecule.api import Verifier
-from molecule.exceptions import ImmediateExit
 from molecule.reporting.definitions import CompletionState
 from molecule.utils import util
+from molecule.utils.util import sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -161,7 +161,7 @@ class Testinfra(Verifier):
             action_args: list of arguments to be passed.
 
         Raises:
-            ImmediateExit: When verifier tests fail.
+            SystemExit: When verifier tests fail.
         """
         if not self.enabled:
             msg = "Skipping, verifier is disabled."
@@ -195,7 +195,7 @@ class Testinfra(Verifier):
             self._log.info(msg)
         else:
             msg = "Verifier tests failed"
-            raise ImmediateExit(msg, code=result.returncode)
+            sysexit_with_message(msg, code=result.returncode)
 
     def _get_tests(self, action_args: list[str] | None = None) -> list[str]:
         """Walk the verifier's directory for tests.

--- a/tests/unit/command/init/test_scenario.py
+++ b/tests/unit/command/init/test_scenario.py
@@ -27,7 +27,7 @@ import pytest
 
 from molecule.command.init.scenario import Scenario
 from molecule.config import Config
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 from molecule.utils import util
 
 
@@ -114,13 +114,13 @@ def test_execute_scenario_exists(
     monkeypatch.chdir(test_cache_path)
     instance.execute()
 
-    with pytest.raises(MoleculeError) as e:
+    with pytest.raises(ImmediateExit) as e:
         instance.execute()
 
     assert e.value.code == 1
 
     msg = "The directory molecule/test-scenario exists. Cannot create new scenario."
-    assert msg in caplog.text
+    assert e.value.message == msg
 
 
 def test_scenario_execute_collection_mode(
@@ -249,13 +249,13 @@ version: 1.0.0
     # Clear cache to ensure fresh detection
     util.get_collection_metadata.cache_clear()
 
-    with pytest.raises(MoleculeError) as e:
+    with pytest.raises(ImmediateExit) as e:
         instance.execute()
 
     assert e.value.code == 1
 
     msg = "The directory extensions/molecule/test-scenario exists. Cannot create new scenario."
-    assert msg in caplog.text
+    assert e.value.message == msg
 
 
 def test_scenario_execute_invalid_collection(

--- a/tests/unit/command/init/test_scenario.py
+++ b/tests/unit/command/init/test_scenario.py
@@ -27,7 +27,6 @@ import pytest
 
 from molecule.command.init.scenario import Scenario
 from molecule.config import Config
-from molecule.exceptions import ImmediateExit
 from molecule.utils import util
 
 
@@ -114,13 +113,13 @@ def test_execute_scenario_exists(
     monkeypatch.chdir(test_cache_path)
     instance.execute()
 
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         instance.execute()
 
     assert e.value.code == 1
 
     msg = "The directory molecule/test-scenario exists. Cannot create new scenario."
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_scenario_execute_collection_mode(
@@ -249,13 +248,13 @@ version: 1.0.0
     # Clear cache to ensure fresh detection
     util.get_collection_metadata.cache_clear()
 
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         instance.execute()
 
     assert e.value.code == 1
 
     msg = "The directory extensions/molecule/test-scenario exists. Cannot create new scenario."
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_scenario_execute_invalid_collection(

--- a/tests/unit/command/test_base.py
+++ b/tests/unit/command/test_base.py
@@ -261,7 +261,7 @@ def test_execute_cmdline_scenarios_missing(
     args: MoleculeArgs = {}
     command_args: CommandArgs = {"destroy": "always", "subcommand": "test"}
 
-    with pytest.raises(ImmediateExit):
+    with pytest.raises(SystemExit):
         base.execute_cmdline_scenarios(scenario_name, args, command_args)
 
     error_msg = "'molecule/nonexistent/molecule.yml' glob failed.  Exiting."
@@ -328,7 +328,7 @@ def test_execute_cmdline_scenarios_exit_destroy(  # noqa: PLR0913
 ) -> None:
     """Ensure execute_cmdline_scenarios handles errors correctly when 'destroy' is set.
 
-    - When ScenarioFailureError occurs, ImmediateExit should be raised immediately
+    - When ScenarioFailureError occurs, SystemExit should be raised immediately
 
     Args:
         patched_execute_scenario: Mocked execute_scenario function.
@@ -343,8 +343,8 @@ def test_execute_cmdline_scenarios_exit_destroy(  # noqa: PLR0913
     command_args: CommandArgs = {"destroy": destroy, "subcommand": "test"}
     patched_execute_scenario.side_effect = ScenarioFailureError()
 
-    # Should raise ImmediateExit when ScenarioFailureError occurs
-    with pytest.raises(ImmediateExit):
+    # Should raise SystemExit when ScenarioFailureError occurs
+    with pytest.raises(SystemExit):
         base.execute_cmdline_scenarios(scenario_name, args, command_args)
 
     assert patched_execute_scenario.called
@@ -659,7 +659,7 @@ def test_apply_cli_overrides_comprehensive(
         main.main(standalone_mode=False)
 
     # 6. Assert results
-    assert exc_info.value.code == 0  # Our ImmediateExit code was handled properly
+    assert exc_info.value.code == 0  # Our ImmediateExit code was handled properly by Click
     assert len(captured_configs) >= 1  # At least one config was created
     assert captured_configs[0].shared_state is expected  # CLI override logic worked correctly
 
@@ -771,7 +771,7 @@ def test_apply_env_overrides_comprehensive(  # noqa: PLR0913
         main.main(standalone_mode=False)
 
     # 5. Assert results
-    assert exc_info.value.code == 0  # Our ImmediateExit code was handled properly
+    assert exc_info.value.code == 0  # Our ImmediateExit code was handled properly by Click
     assert len(captured_configs) >= 1  # At least one config was created
 
     config_obj = captured_configs[0]

--- a/tests/unit/command/test_base.py
+++ b/tests/unit/command/test_base.py
@@ -659,7 +659,7 @@ def test_apply_cli_overrides_comprehensive(
         main.main(standalone_mode=False)
 
     # 6. Assert results
-    assert exc_info.value.code == 0  # Our ImmediateExit code was handled properly by Click
+    assert exc_info.value.code == 0
     assert len(captured_configs) >= 1  # At least one config was created
     assert captured_configs[0].shared_state is expected  # CLI override logic worked correctly
 
@@ -771,7 +771,7 @@ def test_apply_env_overrides_comprehensive(  # noqa: PLR0913
         main.main(standalone_mode=False)
 
     # 5. Assert results
-    assert exc_info.value.code == 0  # Our ImmediateExit code was handled properly by Click
+    assert exc_info.value.code == 0
     assert len(captured_configs) >= 1  # At least one config was created
 
     config_obj = captured_configs[0]

--- a/tests/unit/command/test_base.py
+++ b/tests/unit/command/test_base.py
@@ -318,11 +318,10 @@ def test_execute_cmdline_scenarios_no_prune(
     ),
 )
 @pytest.mark.usefixtures("config_instance")
-def test_execute_cmdline_scenarios_exit_destroy(  # noqa: PLR0913
+def test_execute_cmdline_scenarios_exit_destroy(
     patched_execute_scenario: MagicMock,
     patched_prune: MagicMock,
     patched_execute_subcommand: MagicMock,
-    patched_sysexit: MagicMock,
     destroy: Literal["always", "never"],
     subcommands: tuple[str, ...],
 ) -> None:
@@ -334,7 +333,6 @@ def test_execute_cmdline_scenarios_exit_destroy(  # noqa: PLR0913
         patched_execute_scenario: Mocked execute_scenario function.
         patched_prune: Mocked prune function.
         patched_execute_subcommand: Mocked execute_subcommand function.
-        patched_sysexit: Mocked util.sysexit function.
         destroy: Value to set 'destroy' arg to.
         subcommands: Expected subcommands to run after execute_scenario fails.
     """

--- a/tests/unit/command/test_login.py
+++ b/tests/unit/command/test_login.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from molecule.command import login
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 
 
 if TYPE_CHECKING:
@@ -81,13 +81,13 @@ def test_get_hostname_does_not_match(  # noqa: D103
 ) -> None:
     _instance._config.command_args = {"host": "invalid"}
     hosts = ["instance-1"]
-    with pytest.raises(MoleculeError) as e:
+    with pytest.raises(ImmediateExit) as e:
         _instance._get_hostname(hosts)
 
     assert e.value.code == 1
 
     msg = "There are no hosts that match 'invalid'.  You can only login to valid hosts."
-    assert msg in caplog.text
+    assert e.value.message == msg
 
 
 def test_get_hostname_exact_match_with_one_host(  # noqa: D103
@@ -132,7 +132,7 @@ def test_get_hostname_partial_match_with_multiple_hosts_raises(  # noqa: D103
 ) -> None:
     _instance._config.command_args = {"host": "inst"}
     hosts = ["instance-1", "instance-2"]
-    with pytest.raises(MoleculeError) as e:
+    with pytest.raises(ImmediateExit) as e:
         _instance._get_hostname(hosts)
 
     assert e.value.code == 1
@@ -144,7 +144,7 @@ def test_get_hostname_partial_match_with_multiple_hosts_raises(  # noqa: D103
         "instance-1\n"
         "instance-2"
     )
-    assert msg in caplog.text
+    assert e.value.message == msg
 
 
 def test_get_hostname_no_host_flag_specified_on_cli(  # noqa: D103
@@ -163,7 +163,7 @@ def test_get_hostname_no_host_flag_specified_on_cli_with_multiple_hosts_raises( 
 ) -> None:
     _instance._config.command_args = {}
     hosts = ["instance-1", "instance-2"]
-    with pytest.raises(MoleculeError) as e:
+    with pytest.raises(ImmediateExit) as e:
         _instance._get_hostname(hosts)
 
     assert e.value.code == 1
@@ -175,4 +175,4 @@ def test_get_hostname_no_host_flag_specified_on_cli_with_multiple_hosts_raises( 
         "instance-1\n"
         "instance-2"
     )
-    assert msg in caplog.text
+    assert e.value.message == msg

--- a/tests/unit/command/test_login.py
+++ b/tests/unit/command/test_login.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from molecule.command import login
-from molecule.exceptions import ImmediateExit
 
 
 if TYPE_CHECKING:
@@ -81,13 +80,13 @@ def test_get_hostname_does_not_match(  # noqa: D103
 ) -> None:
     _instance._config.command_args = {"host": "invalid"}
     hosts = ["instance-1"]
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         _instance._get_hostname(hosts)
 
     assert e.value.code == 1
 
     msg = "There are no hosts that match 'invalid'.  You can only login to valid hosts."
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_get_hostname_exact_match_with_one_host(  # noqa: D103
@@ -132,7 +131,7 @@ def test_get_hostname_partial_match_with_multiple_hosts_raises(  # noqa: D103
 ) -> None:
     _instance._config.command_args = {"host": "inst"}
     hosts = ["instance-1", "instance-2"]
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         _instance._get_hostname(hosts)
 
     assert e.value.code == 1
@@ -144,7 +143,7 @@ def test_get_hostname_partial_match_with_multiple_hosts_raises(  # noqa: D103
         "instance-1\n"
         "instance-2"
     )
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_get_hostname_no_host_flag_specified_on_cli(  # noqa: D103
@@ -163,7 +162,7 @@ def test_get_hostname_no_host_flag_specified_on_cli_with_multiple_hosts_raises( 
 ) -> None:
     _instance._config.command_args = {}
     hosts = ["instance-1", "instance-2"]
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         _instance._get_hostname(hosts)
 
     assert e.value.code == 1
@@ -175,4 +174,4 @@ def test_get_hostname_no_host_flag_specified_on_cli_with_multiple_hosts_raises( 
         "instance-1\n"
         "instance-2"
     )
-    assert e.value.message == msg
+    assert msg in caplog.text

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,7 +29,6 @@ import pytest
 
 from molecule import config, platforms, scenario, state
 from molecule.dependency import ansible_galaxy, shell
-from molecule.exceptions import ImmediateExit
 from molecule.provisioner import ansible
 from molecule.utils import util
 from molecule.verifier.ansible import Ansible as AnsibleVerifier
@@ -278,7 +277,7 @@ def test_get_driver_name_from_state_file(  # noqa: D103
 ) -> None:
     config_instance.state.change_state("driver", "state-driver")
 
-    with pytest.raises(ImmediateExit):
+    with pytest.raises(SystemExit):
         config_instance._get_driver_name()
 
     mocker.patch("molecule.api.drivers", return_value=["state-driver"])
@@ -301,7 +300,7 @@ def test_get_driver_name_raises_when_different_driver_used(  # noqa: D103
 ) -> None:
     config_instance.state.change_state("driver", "foo")
     config_instance.command_args = {"driver_name": "bar"}
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         config_instance._get_driver_name()
 
     assert e.value.code == 1
@@ -310,7 +309,7 @@ def test_get_driver_name_raises_when_different_driver_used(  # noqa: D103
         "Instance(s) were created with the 'foo' driver, but the subcommand is using 'bar' driver."
     )
 
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_get_config(config_instance: config.Config) -> None:  # noqa: D103
@@ -394,7 +393,7 @@ def test_interpolate_raises_on_failed_interpolation(  # noqa: D103
 ) -> None:
     string = "$6$8I5Cfmpr$kGZB"
 
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         config_instance._interpolate(string, os.environ, "")
 
     assert e.value.code == 1
@@ -404,7 +403,7 @@ def test_interpolate_raises_on_failed_interpolation(  # noqa: D103
         "Invalid placeholder in string: line 1, col 1\n"
         "$6$8I5Cfmpr$kGZB"
     )
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_get_defaults(  # noqa: D103
@@ -465,13 +464,13 @@ def test_validate_exists_when_validation_fails(  # noqa: D103
     m = mocker.patch("molecule.model.schema_v3.validate")
     m.return_value = "validation errors"
 
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         config_instance._validate()
 
     assert e.value.code == 1
 
     msg = f"Failed to validate {config_instance.molecule_file}\n\nvalidation errors"
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_molecule_directory() -> None:  # noqa: D103

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -25,7 +25,7 @@ import pytest
 
 from molecule import config, scenario, scenarios
 from molecule.console import console
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ImmediateExit
 from molecule.text import chomp, strip_ansi_escape
 
 
@@ -137,13 +137,13 @@ def test_verify_raises_when_scenario_not_found(  # noqa: D103
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     _instance._scenario_names = ["invalid"]
-    with pytest.raises(MoleculeError) as e:
+    with pytest.raises(ImmediateExit) as e:
         _instance._verify()
 
     assert e.value.code == 1
 
     msg = "Scenario 'invalid' not found.  Exiting."
-    assert msg in caplog.text
+    assert e.value.message == msg
 
 
 def test_verify_raises_when_multiple_scenarios_not_found(  # noqa: D103
@@ -151,13 +151,13 @@ def test_verify_raises_when_multiple_scenarios_not_found(  # noqa: D103
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     _instance._scenario_names = ["invalid", "also invalid"]
-    with pytest.raises(MoleculeError) as e:
+    with pytest.raises(ImmediateExit) as e:
         _instance._verify()
 
     assert e.value.code == 1
 
     msg = "Scenarios 'also invalid, invalid' not found.  Exiting."
-    assert msg in caplog.text
+    assert e.value.message == msg
 
 
 def test_filter_for_scenario(  # noqa: D103

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -25,7 +25,6 @@ import pytest
 
 from molecule import config, scenario, scenarios
 from molecule.console import console
-from molecule.exceptions import ImmediateExit
 from molecule.text import chomp, strip_ansi_escape
 
 
@@ -137,13 +136,13 @@ def test_verify_raises_when_scenario_not_found(  # noqa: D103
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     _instance._scenario_names = ["invalid"]
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         _instance._verify()
 
     assert e.value.code == 1
 
     msg = "Scenario 'invalid' not found.  Exiting."
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_verify_raises_when_multiple_scenarios_not_found(  # noqa: D103
@@ -151,13 +150,13 @@ def test_verify_raises_when_multiple_scenarios_not_found(  # noqa: D103
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     _instance._scenario_names = ["invalid", "also invalid"]
-    with pytest.raises(ImmediateExit) as e:
+    with pytest.raises(SystemExit) as e:
         _instance._verify()
 
     assert e.value.code == 1
 
     msg = "Scenarios 'also invalid, invalid' not found.  Exiting."
-    assert e.value.message == msg
+    assert msg in caplog.text
 
 
 def test_filter_for_scenario(  # noqa: D103


### PR DESCRIPTION
## Problem

User-facing validation errors currently display full Python tracebacks, creating poor UX for common scenarios like invalid molecule.yml configuration or missing scenarios.

Fixes #4532 

## Solution

Replace `raise ImmediateExit()` calls with `sysexit_with_message()` for user-facing validation errors, simplifying error handling by using direct `sys.exit()` instead of exception propagation.

## Changes

Source code:
- Replace `ImmediateExit` exceptions with `sysexit_with_message()` calls in validation functions
- Maintain existing logging behavior (`logger.critical`) and exit codes  
- Preserve `ImmediateExit` handling in Click decorators for integration compatibility
- Update docstrings to reflect direct exit behavior

Tests:
- Update tests to catch `SystemExit` instead of `ImmediateExit`
- Modify test assertions to verify logged messages via `caplog` instead of exception attributes

## Technical Details

This change moves from an exception-based exit pattern to a direct exit pattern for user-facing validation errors. The `sysexit_with_message()` function logs the error message using `logger.critical()` and calls `sys.exit()` directly, providing the same user experience with cleaner code flow.

Functions affected include config validation, scenario verification, host selection validation, and dependency installation error handling.

## Behavior

Before:
```
$ molecule login
CRITICAL Failed to validate /path/to/molecule.yml

<full Python traceback>
molecule.exceptions.MoleculeError
```

After:  
```
$ molecule login
CRITICAL Failed to validate /path/to/molecule.yml
```

This provides clean error messages without tracebacks while maintaining the same logging behavior and exit codes.