### PR TITLE
Replace util.print_as_yaml with ansi_output.print_matrix

### DIFF
--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 
 from molecule import ansi_output
 from molecule.reporting.definitions import ScenariosResults
-
+from molecule.utils import util
 
 if TYPE_CHECKING:
     from molecule.config import Config

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -26,7 +26,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from molecule import ansi_output
-from molecule.exceptions import MoleculeError
 from molecule.reporting.definitions import ScenariosResults
 
 

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -29,6 +29,7 @@ from molecule import ansi_output
 from molecule.reporting.definitions import ScenariosResults
 from molecule.utils import util
 
+
 if TYPE_CHECKING:
     from molecule.config import Config
     from molecule.scenario import Scenario

--- a/src/molecule/scenarios.py
+++ b/src/molecule/scenarios.py
@@ -25,9 +25,9 @@ import logging
 
 from typing import TYPE_CHECKING
 
+from molecule import ansi_output
 from molecule.exceptions import MoleculeError
 from molecule.reporting.definitions import ScenariosResults
-from molecule.utils import util
 
 
 if TYPE_CHECKING:
@@ -105,14 +105,14 @@ class Scenarios:
         return any(scenario.config.shared_state for scenario in self.all)
 
     def print_matrix(self) -> None:
-        """Show the test matrix for all scenarios."""
-        msg = "Test matrix"
-        LOG.info(msg)
-
+        """Show the matrix for all scenarios."""
         tree = {}
         for scenario in self.all:
             tree[scenario.name] = list(scenario.sequence)
-        util.print_as_yaml(tree)
+
+        # Use the first scenario's config for playbook path resolution
+        config = self.all[0].config if self.all else None
+        ansi_output.print_matrix(tree, config)
 
     def sequence(self, scenario_name: str) -> list[str]:
         """Sequence for a given scenario.

--- a/src/molecule/utils/util.py
+++ b/src/molecule/utils/util.py
@@ -36,7 +36,6 @@ import yaml
 
 from ansible_compat.ports import cache
 
-from molecule.console import console
 from molecule.constants import (
     MOLECULE_COLLECTION_GLOB,
     MOLECULE_COLLECTION_ROOT,

--- a/src/molecule/utils/util.py
+++ b/src/molecule/utils/util.py
@@ -35,7 +35,6 @@ import jinja2
 import yaml
 
 from ansible_compat.ports import cache
-from rich.syntax import Syntax
 
 from molecule.console import console
 from molecule.constants import (
@@ -577,17 +576,6 @@ def bool2args(data: bool | list[str]) -> list[str]:  # noqa: ARG001, FBT001
         An empty list
     """
     return []
-
-
-def print_as_yaml(data: object) -> None:
-    """Render python object as yaml on console.
-
-    Args:
-        data: A YAML object.
-    """
-    # https://github.com/Textualize/rich/discussions/990#discussioncomment-342217
-    result = Syntax(code=safe_dump(data), lexer="yaml", background_color="default")
-    console.print(result)
 
 
 def oxford_comma(listed: Iterable[bool | str | Path], condition: str = "and") -> str:

--- a/tests/fixtures/integration/test_command/molecule/kubevirt/molecule.yml
+++ b/tests/fixtures/integration/test_command/molecule/kubevirt/molecule.yml
@@ -4,8 +4,6 @@ dependency:
   options:
     requirements-file: requirements.yml
     role-file: requirements.yml
-executor:
-  backend: ansible-playbook
 platforms:
   - name: rhel9
     image: registry.redhat.io/rhel9/rhel-guest-image

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -96,8 +96,8 @@ def test_print_matrix(  # noqa: D103
     # Check that the simplified matrix format is present
     assert "Test matrix" in result
     assert "-----------" in result
-    assert "default:" in result
-    assert "foo:" in result
+    assert "default" in result
+    assert "foo" in result
     assert "├─ dependency" in result
     assert "├─ converge" in result
     assert "├─ destroy" in result or "└─ destroy" in result

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -24,9 +24,8 @@ import copy
 import pytest
 
 from molecule import config, scenario, scenarios
-from molecule.console import console
 from molecule.exceptions import MoleculeError
-from molecule.text import chomp, strip_ansi_escape
+from molecule.text import strip_ansi_escape
 
 
 @pytest.fixture
@@ -90,38 +89,23 @@ def test_print_matrix(  # noqa: D103
     capsys: pytest.CaptureFixture[str],
     _instance: scenarios.Scenarios,  # noqa: PT019
 ) -> None:
-    with console.capture() as capture:
-        _instance.print_matrix()
-    result = chomp(strip_ansi_escape(capture.get()))
+    _instance.print_matrix()
+    captured = capsys.readouterr()
+    result = strip_ansi_escape(captured.out)
 
-    matrix_out = """---
-default:
-  - dependency
-  - cleanup
-  - destroy
-  - syntax
-  - create
-  - prepare
-  - converge
-  - idempotence
-  - side_effect
-  - verify
-  - cleanup
-  - destroy
-foo:
-  - dependency
-  - cleanup
-  - destroy
-  - syntax
-  - create
-  - prepare
-  - converge
-  - idempotence
-  - side_effect
-  - verify
-  - cleanup
-  - destroy"""
-    assert matrix_out in result
+    # Check that the simplified matrix format is present
+    assert "Test matrix" in result
+    assert "-----------" in result
+    assert "default:" in result
+    assert "foo:" in result
+    assert "├─ dependency" in result
+    assert "├─ converge" in result
+    assert "├─ destroy" in result or "└─ destroy" in result
+    # Should show Missing for actions without playbook files
+    assert "Missing playbook" in result
+    assert "to suppress" in result
+    # Should show tree tail for last item
+    assert "└─" in result
 
 
 def test_verify_does_not_raise_when_found(  # noqa: D103

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -24,10 +24,7 @@ import copy
 import pytest
 
 from molecule import config, scenario, scenarios
-from molecule.exceptions import MoleculeError
 from molecule.text import strip_ansi_escape
-from molecule.console import console
-from molecule.text import chomp, strip_ansi_escape
 
 
 @pytest.fixture


### PR DESCRIPTION
<img width="2224" height="1825" alt="image" src="https://github.com/user-attachments/assets/743f08b1-524f-4be5-8e13-de95db575dff" />


## Summary

Refactors matrix output to use a dedicated function in `ansi_output.py`, replacing the generic YAML printer with a purpose-built tree-like display.

## Changes

- **New**: `ansi_output.print_matrix()` with tree structure and file path display
- **Removed**: `util.print_as_yaml()` reducing Rich dependency usage in utils
- **Enhanced**: Dynamic headers based on subcommand ("Create matrix", "Test matrix", etc.)
- **Improved**: Missing playbook warnings with actionable suppression instructions
- **Consistent**: Uses Molecule's standard color scheme (green scenarios, yellow actions)

## Benefits

- Cleaner, more readable matrix output
- Reduced dependency on Rich in core utilities  
- Better UX with file paths and missing playbook guidance
- Maintains full color environment variable support (NO_COLOR, etc.)

## Testing

- Matrix display works across subcommands (create, test, converge)
- File path resolution and missing playbook detection
- Color environment variables respected
- Existing tests updated and passing