### PR TITLE
Replace to_bool calls with boolean function

### DIFF
--- a/src/molecule/ansi_output.py
+++ b/src/molecule/ansi_output.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 
 from molecule.constants import DEFAULT_BORDER_WIDTH, MARKUP_MAP, SCENARIO_RECAP_STATE_ORDER
 from molecule.constants import ANSICodes as A
-from molecule.util import to_bool
+from molecule.util import boolean
 
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ def should_do_markup() -> bool:
     for v in ["PY_COLORS", "CLICOLOR", "FORCE_COLOR", "ANSIBLE_FORCE_COLOR"]:
         value = os.environ.get(v, None)
         if value is not None:
-            py_colors = to_bool(value)
+            py_colors = boolean(value, default=False)
             break
 
     # If deliberately disabled colors
@@ -62,7 +62,7 @@ def should_do_markup() -> bool:
 
     # User configuration requested colors
     if py_colors is not None:
-        return to_bool(py_colors)
+        return boolean(py_colors)
 
     term = os.environ.get("TERM", "")
     if "xterm" in term:

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -40,7 +40,7 @@ from molecule.data import __file__ as data_module
 from molecule.dependency import ansible_galaxy, shell
 from molecule.model import schema_v3
 from molecule.provisioner import ansible
-from molecule.util import boolean, sysexit_with_message, to_bool
+from molecule.util import boolean, sysexit_with_message
 
 
 if TYPE_CHECKING:
@@ -61,8 +61,8 @@ if TYPE_CHECKING:
     from molecule.verifier.base import Verifier
 
 
-MOLECULE_PARALLEL: bool = boolean(os.environ.get("MOLECULE_PARALLEL", ""))
-MOLECULE_DEBUG: bool = boolean(os.environ.get("MOLECULE_DEBUG", "False"))
+MOLECULE_PARALLEL: bool = boolean(os.environ.get("MOLECULE_PARALLEL", ""), default=False)
+MOLECULE_DEBUG: bool = boolean(os.environ.get("MOLECULE_DEBUG", "False"), default=False)
 MOLECULE_VERBOSITY: int = int(os.environ.get("MOLECULE_VERBOSITY", "0"))
 MOLECULE_DIRECTORY = "molecule"
 MOLECULE_FILE = "molecule.yml"
@@ -187,7 +187,7 @@ class Config:
 
             try:
                 converted_value = (
-                    to_bool(env_value) if expected_type is bool else expected_type(env_value)
+                    boolean(env_value) if expected_type is bool else expected_type(env_value)
                 )
                 self.command_args[config_attr] = converted_value
             except (ValueError, TypeError):

--- a/tests/unit/test_ansi_output.py
+++ b/tests/unit/test_ansi_output.py
@@ -6,35 +6,6 @@ import pytest
 
 from molecule.ansi_output import AnsiOutput, should_do_markup
 from molecule.constants import ANSICodes as A
-from molecule.util import to_bool
-
-
-@pytest.mark.parametrize(
-    ("input_value", "expected"),
-    (
-        (None, False),
-        (True, True),
-        (False, False),
-        ("yes", True),
-        ("YES", True),
-        ("on", True),
-        ("ON", True),
-        ("1", True),
-        ("true", True),
-        ("TRUE", True),
-        ("no", False),
-        ("off", False),
-        ("0", False),
-        ("false", False),
-        ("random", False),
-        (1, True),
-        (0, False),
-        (42, False),
-    ),
-)
-def test_to_bool(input_value: object, expected: bool) -> None:  # noqa: FBT001
-    """Test to_bool function with various inputs."""
-    assert to_bool(input_value) is expected
 
 
 def test_should_do_markup_basic() -> None:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,4 +1,7 @@
-#  Copyright (c) 2015-2018 Cisco Systems, Inc.  # noqa: D100
+# pylint: disable=too-many-lines
+
+
+#  Copyright (c) 2015-2018 Cisco Systems, Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to
@@ -938,3 +941,75 @@ def test_lookup_config_file_collection_no_extensions_dir(
 
     # Should fall back to home directory since collection extensions dir doesn't exist
     assert result == str(home_config)
+
+
+@pytest.mark.parametrize(
+    ("input_value", "expected"),
+    (
+        (True, True),
+        (False, False),
+        ("yes", True),
+        ("YES", True),
+        ("on", True),
+        ("ON", True),
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("no", False),
+        ("off", False),
+        ("0", False),
+        ("false", False),
+        (1, True),
+        (0, False),
+        ("", False),
+    ),
+)
+def test_boolean_valid_inputs(input_value: object, expected: bool) -> None:  # noqa: FBT001
+    """Test boolean function with valid inputs.
+
+    Args:
+        input_value: The input value to test.
+        expected: The expected boolean result.
+    """
+    assert util.boolean(input_value) is expected
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    (
+        None,
+        "random",
+        42,
+        "invalid",
+    ),
+)
+def test_boolean_invalid_values(input_value: object) -> None:
+    """Test boolean function raises TypeError for invalid inputs.
+
+    Args:
+        input_value: The invalid input value to test.
+    """
+    with pytest.raises(TypeError):
+        util.boolean(input_value)
+
+
+@pytest.mark.parametrize(
+    ("input_value", "default_value", "expected"),
+    (
+        (None, False, False),
+        ("random", True, True),
+        (42, False, False),
+        ("invalid", True, True),
+        ("yes", False, True),  # Valid input should ignore default
+        ("no", True, False),  # Valid input should ignore default
+    ),
+)
+def test_boolean_with_default(input_value: object, default_value: bool, expected: bool) -> None:  # noqa: FBT001
+    """Test boolean function with default parameter.
+
+    Args:
+        input_value: The input value to test.
+        default_value: The default value to use for invalid inputs.
+        expected: The expected boolean result.
+    """
+    assert util.boolean(input_value, default=default_value) is expected


### PR DESCRIPTION
This PR replaces all calls to the to_bool function with the existing boolean function for consistency.

Changes:
- Replace to_bool function calls with boolean function calls in config.py and ansi_output.py
- Add optional default parameter to boolean function to return fallback value for invalid inputs
- Apply default parameter to environment variable parsing to prevent TypeError exceptions
- Move boolean function tests from test_ansi_output.py to test_util.py for proper organization
- Add comprehensive test coverage for the new default parameter functionality
- Update type annotations and add proper docstring documentation

The boolean function now accepts a default parameter that provides graceful fallback for invalid environment variable values while maintaining strict behavior when no default is specified.