### PR TITLE
fix: run cleanup and destroy when a verifier fails

### DIFF
--- a/src/molecule/verifier/testinfra.py
+++ b/src/molecule/verifier/testinfra.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, cast
 
 from molecule import logger, util
 from molecule.api import Verifier
+from molecule.exceptions import ScenarioFailureError
 from molecule.reporting.definitions import CompletionState
 
 
@@ -157,6 +158,9 @@ class Testinfra(Verifier):
 
         Args:
             action_args: list of arguments to be passed.
+
+        Raises:
+            ScenarioFailureError: when the verifier reports a non-zero return code.
         """
         if not self.enabled:
             msg = "Skipping, verifier is disabled."
@@ -190,7 +194,8 @@ class Testinfra(Verifier):
             self._log.info(msg)
         else:
             msg = "Verifier tests failed"
-            util.sysexit_with_message(msg, code=result.returncode)
+            self._config.scenario.results.add_completion(CompletionState.failed(note=msg))
+            raise ScenarioFailureError(message=msg, code=result.returncode)
 
     def _get_tests(self, action_args: list[str] | None = None) -> list[str]:
         """Walk the verifier's directory for tests.

--- a/tests/unit/test_click_command_ex.py
+++ b/tests/unit/test_click_command_ex.py
@@ -9,7 +9,7 @@ import click
 from click.testing import CliRunner
 
 from molecule.click_cfg import click_command_ex
-from molecule.exceptions import ImmediateExit, MoleculeError
+from molecule.exceptions import ImmediateExit, MoleculeError, ScenarioFailureError
 
 
 if TYPE_CHECKING:
@@ -174,6 +174,36 @@ def test_click_command_ex_with_molecule_error(mocker: MockerFixture) -> None:
 
     mock_logger.return_value.error.assert_not_called()
     mock_sysexit.assert_called_once_with(code=3)
+
+
+def test_click_command_ex_scenario_failure_exits_with_code(mocker: MockerFixture) -> None:
+    """A ScenarioFailureError exits with the code it carries.
+
+    A failed verifier raises ScenarioFailureError with the tool's return code
+    (see verifier/testinfra.py), so the process must exit with that same code
+    rather than a generic 1.
+
+    Args:
+        mocker: pytest-mock fixture for mocking.
+    """
+    mocker.patch("molecule.click_cfg.logging.getLogger")
+    mock_sysexit = mocker.patch("molecule.util.sysexit")
+    mocker.patch("molecule.click_cfg.util.is_debug_mode", return_value=False)
+
+    @click_command_ex()
+    def test_command() -> None:
+        """Test command that raises ScenarioFailureError.
+
+        Raises:
+            ScenarioFailureError: Always raised for testing.
+        """
+        msg = "Verifier tests failed"
+        raise ScenarioFailureError(message=msg, code=2)
+
+    runner = CliRunner()
+    runner.invoke(test_command, [])
+
+    mock_sysexit.assert_called_once_with(code=2)
 
 
 def test_click_command_ex_with_message_less_molecule_error(mocker: MockerFixture) -> None:

--- a/tests/unit/verifier/test_testinfra.py
+++ b/tests/unit/verifier/test_testinfra.py
@@ -21,9 +21,12 @@ from __future__ import annotations
 
 import os
 
+from subprocess import CompletedProcess
+
 import pytest
 
 from molecule.config import Config
+from molecule.exceptions import ScenarioFailureError
 from molecule.util import write_file
 from molecule.verifier import testinfra
 
@@ -314,13 +317,24 @@ def test_execute_bakes_env(  # type: ignore[no-untyped-def]  # noqa: ANN201, D10
     assert patched_run_command.call_args[1]["env"]["FOO"] == "bar"
 
 
-def test_testinfra_executes_catches_and_exits_return_code(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+def test_testinfra_execute_failed_tests_raise_scenario_failure(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     patched_run_command,
     _patched_testinfra_get_tests,  # noqa: PT019
     _instance,  # noqa: PT019
 ):
-    patched_run_command.side_effect = SystemExit(1)
-    with pytest.raises(SystemExit) as e:
+    # A non-zero verifier return code must raise ScenarioFailureError (not
+    # sysexit) so `molecule test` still runs cleanup/destroy on --destroy=always.
+    returncode = 2
+    patched_run_command.return_value = CompletedProcess(
+        args="foo",
+        returncode=returncode,
+        stdout="",
+        stderr="",
+    )
+    with pytest.raises(ScenarioFailureError) as e:
         _instance.execute()
 
-    assert e.value.code == 1
+    assert e.value.code == returncode
+    # The failure is recorded so the scenario recap reports verify as failed,
+    # not the empty-state default of "successful".
+    assert _instance._config.scenario.results.last_action_summary.state == "failed"


### PR DESCRIPTION
Fixes #4677.

## Problem

When a verifier fails during `molecule test`, molecule exits immediately after the `verify` action and never runs `cleanup` or `destroy` — even though `--destroy=always` is the default. Instances are left running.

This contradicts the documented `molecule test` behavior, which is to stop on the first failure but still tear down unless `--destroy=never` (`docs/workflow.md`). A verify failure was the one path that stopped *and* skipped teardown.

## Root cause

The testinfra verifier reports a non-zero return code by calling `util.sysexit_with_message()`, which raises `SystemExit`:

```python
# src/molecule/verifier/testinfra.py (before)
else:
    msg = "Verifier tests failed"
    util.sysexit_with_message(msg, code=result.returncode)
```

Every other action in a scenario sequence signals failure by raising `ScenarioFailureError` (e.g. a failed playbook in `provisioner/ansible_playbook.py`). The `--destroy=always` teardown in `command/base.py::_run_scenarios` only catches `ScenarioFailureError`:

```python
try:
    execute_scenario(scenario, shared_state=scenarios.shared_state)
    scenarios.results.append(scenario.results)
except ScenarioFailureError:
    if command_args.get("destroy") == "always":
        _handle_scenario_failure(...)   # runs cleanup + destroy
    raise
```

`SystemExit` is not a `ScenarioFailureError` (it isn't even an `Exception`), so it passes straight through the handler and the process exits before cleanup/destroy run. testinfra was the only action in the whole verify/sequence path using `sysexit` instead of raising.

## Fix

Raise `ScenarioFailureError` with the verifier's return code instead of calling `sysexit`, and record the failure on the scenario results. A verify failure now flows through the same teardown path as a failed playbook action, so cleanup and destroy run under `--destroy=always`, and the failure is still surfaced with the same exit code.

```python
# src/molecule/verifier/testinfra.py (after)
else:
    msg = "Verifier tests failed"
    self._config.scenario.results.add_completion(CompletionState.failed(note=msg))
    raise ScenarioFailureError(message=msg, code=result.returncode)
```

The `add_completion(...)` call mirrors what the ansible verifier already does (`provisioner/ansible_playbook.py`). Without it, a `molecule test` run's recap renders a failed `verify` as "successful", because an action with no recorded state defaults to successful — so this keeps the recap honest.

Two things worth noting for review:

- Raising `ScenarioFailureError` also means a verify failure is now caught by the parallel worker's `except Exception` handler (`worker.py`) instead of escaping it as a `SystemExit` (a `BaseException`) — so `--workers` runs report the failed scenario cleanly rather than losing the worker.
- Because `ScenarioFailureError` logs its message at `CRITICAL` on construction, the "Verifier tests failed" line now logs at `CRITICAL` (and, like every other scenario failure, is echoed once more at `ERROR` as the run exits). This matches how failed playbook actions already report; it is a small, deliberate consistency change from the previous `ERROR`-only line.

## Reproduction

I used the minimal scenario from #4677 (default driver, `create → verify → destroy`, an intentionally-failing Testinfra test, and marker files written by the create/destroy playbooks), and ran `molecule test` with molecule installed from source — once with this change reverted, once with it applied.

**Before the fix** — `molecule test` stops at `verify`:

```
INFO     [default > create] Executed: Successful
INFO     [default > verify] Executing Testinfra tests found in .../tests/...
FAILED tests/test_default.py::test_verify_fails_intentionally
ERROR    Verifier tests failed

MOLECULE_EXIT=1
create.marker=present
destroy.marker=absent          <-- destroy skipped
```

**After the fix** — the failure still exits non-zero, but cleanup and destroy run:

```
INFO     [default > create] Executed: Successful
INFO     [default > verify] Executing Testinfra tests found in .../tests/...
CRITICAL Verifier tests failed
WARNING  [default > verify] An error occurred during the test sequence action: 'verify'. Cleaning up.
INFO     [default > cleanup] Executing
INFO     [default > destroy] Executing
...
MOLECULE_EXIT=1
create.marker=present
destroy.marker=present         <-- destroy now runs
```

## Tests

`tests/unit/verifier/test_testinfra.py` had a test named `test_testinfra_executes_catches_and_exits_return_code` that stubbed `run_command` to raise `SystemExit`, so it never actually exercised the non-zero-return-code branch. I replaced it with a test that drives a real non-zero return code and asserts the verifier raises `ScenarioFailureError` carrying that code — covering the changed branch directly.

I also added `tests/unit/test_click_command_ex.py::test_click_command_ex_scenario_failure_exits_with_code`, which asserts a `ScenarioFailureError` carrying a non-`1` code exits the process with that same code — so a failed verifier's return code is preserved end to end, not flattened to a generic `1`.

The existing `--destroy=always` handling in `tests/unit/command/test_base.py` already covers `ScenarioFailureError` triggering teardown.

Full unit suite green: `866 passed, 6 skipped` (`tox -e py -- tests/unit/`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Verifier failures now raise a dedicated scenario failure error instead of terminating through a system-exit path.
  - Scenario failures correctly preserve the failed completion status.
  - Command-line execution now exits with the appropriate status code for scenario failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->