### PR TITLE
fix(docs): update the systemd container guide to use podman's systemd mode

### DIFF
--- a/docs/guides/systemd-container.md
+++ b/docs/guides/systemd-container.md
@@ -1,73 +1,100 @@
+<!-- cspell:ignore oneshot -->
 ## Systemd Container
 
-To start a service which requires systemd, [in a non-privileged
-container](https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/),
-configure `molecule.yml` with a systemd compliant image, tmpfs, volumes,
-and command as follows.
+To test a role that manages services, the test instance needs `systemd` running as PID 1. The [Using podman containers](../examples/podman.md) example already stands a container up from a plain `create.yml` driven entirely by inventory variables. This guide is the systemd delta on that scenario: you keep its `create.yml`, `destroy.yml`, and `molecule.yml`, point the inventory at init images, and swap converge and verify for playbooks that apply and check a service-managing role.
+
+### Make the instance systemd-capable
+
+The example's `create.yml` already reads `container_image`, `container_command`, and `container_systemd` from inventory, so making the instance systemd-capable is an inventory change, not a change to any playbook. Point each host at an init image, and set the two shared settings as group variables in the same file:
 
 ```yaml
-platforms:
-  - name: instance
-    image: quay.io/centos/centos:stream8
-    command: /sbin/init
-    tmpfs:
-      - /run
-      - /tmp
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+# inventory/hosts.yml
+all:
+  children:
+    molecule:
+      hosts:
+        ubi10:
+          container_image: registry.access.redhat.com/ubi10/ubi-init:latest
+        centos-stream10:
+          container_image: quay.io/centos/centos:stream10
+      vars:
+        ansible_connection: containers.podman.podman
+        container_command: /sbin/init
+        container_systemd: always
 ```
 
-When needed, such security profiles can be reused (for example [the one
-available in
-Fedora](https://src.fedoraproject.org/rpms/docker/raw/88fa030b904d7af200b150e10ea4a700f759cca4/f/seccomp.json)):
+Pick an init image that matches the distribution your role targets. Red Hat's [UBI 10 init image](https://catalog.redhat.com/software/containers/ubi10-init/) ships `systemd` as PID 1 and can be pulled without a subscription; `quay.io/centos/centos:stream10` covers CentOS Stream. The example loops over every host in the `molecule` group, so add as many as you need to test across distributions.
+
+The two shared settings are what turn these into systemd instances:
+
+- `container_command: /sbin/init` runs the image's init as PID 1. The example defaults the command to `sleep 1d`; if you leave that default, `sleep` is PID 1, `systemd` never starts, and converge fails with `System has not been booted with systemd as init system (PID 1)`. Override it to the init.
+- `container_systemd: always` puts Podman in systemd mode, wiring up the cgroup and tmpfs mounts `systemd` needs. Use `always` rather than `true`: `true` only auto-detects, and with a command set it will not enable systemd mode.
+
+Running `systemd` as PID 1 needs a cgroup v2 host, which is the default on current distributions; rootless Podman additionally needs the v2 hierarchy delegated to your user.
+
+### Converge and verify
+
+The example's converge and verify inspect the container's OS. Replace them with playbooks that apply your role and check the service it manages.
+
+`converge.yml` applies the role under test. Because the container runs `systemd` as PID 1, a role that installs and manages a service works the same as it would on a full host. `your_role` is whatever role you are testing:
 
 ```yaml
-platforms:
-  - name: instance
-    image: debian:stretch
-    command: /sbin/init
-    security_opts:
-      - seccomp=path/to/seccomp.json
-    tmpfs:
-      - /run
-      - /tmp
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+# converge.yml
+---
+- name: Converge
+  hosts: molecule
+  gather_facts: false
+  tasks:
+    - name: Apply the role under test
+      ansible.builtin.include_role:
+        name: your_role
 ```
 
-The developer can also opt to [start the container with extended
-privileges](https://blog.docker.com/2013/09/docker-can-now-run-within-docker/),
-by either giving it `SYS_ADMIN` capabilities or running it in
-`privileged` mode.
+`verify.yml` asserts the outcome the guide is about: that `systemd` actually brought the role's unit up. It reads the running services with `service_facts` and fails the scenario if the unit is not active, so a container where `systemd` never took over as PID 1 is caught rather than passing silently. Point the assertion at the unit your role manages; here that unit is `demo.service`:
+
+```yaml
+# verify.yml
+---
+- name: Verify
+  hosts: molecule
+  gather_facts: false
+  tasks:
+    - name: Collect the instance's service facts
+      ansible.builtin.service_facts:
+
+    - name: Confirm systemd is running the managed service
+      ansible.builtin.assert:
+        that:
+          - "{% raw %}'demo.service' in ansible_facts.services{% endraw %}"
+          - "{% raw %}ansible_facts.services['demo.service'].state == 'running'{% endraw %}"
+        fail_msg: demo.service is not running
+        success_msg: demo.service is active
+```
+
+`state == 'running'` is the right check for a long-running unit (`Type=simple` or `exec`). A `Type=oneshot` unit that finished cleanly reports `stopped`, so for those assert on enablement or on the effect the unit produced instead.
+
+### Extended privileges
+
+The example's `create.yml` also reads `container_capabilities` and `container_privileged` from inventory, so extended privileges are inventory changes too, not playbook edits. Most systemd workloads run under the default container above; some need more, for example mounting filesystems or loading kernel modules. Set these on a host, or in the group `vars:` block to apply them to every host:
+
+```yaml
+        container_capabilities:
+          - SYS_ADMIN
+        # or, for full privilege:
+        container_privileged: true
+```
+
+For a custom seccomp profile, add a `security_opt` field to the example's `create.yml`, which does not expose one by default.
 
 !!! warning
 
-    Use caution when using `privileged` mode or `SYS_ADMIN` capabilities as
-    it grants the container elevated access to the underlying system.
+    Use caution with `privileged` mode or `SYS_ADMIN`: they grant the container elevated access to the host. Reach for them only when a specific task needs them, not by default.
 
-To limit the scope of the extended privileges, grant `SYS_ADMIN`
-capabilities along with the same image, command, and volumes as shown in
-the `non-privileged` example.
+### Common failure modes
 
-```yaml
-platforms:
-  - name: instance
-    image: quay.io/centos/centos:stream8
-    command: /sbin/init
-    capabilities:
-      - SYS_ADMIN
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-```
-
-To start the container in `privileged` mode, set the privileged flag
-along with the same image and command as shown in the `non-privileged`
-example.
-
-```yaml
-platforms:
-  - name: instance
-    image: quay.io/centos/centos:stream8
-    command: /sbin/init
-    privileged: True
-```
+- **Converge fails with `System has not been booted with systemd as init system (PID 1)`.** The container is running the default `sleep 1d` command instead of the init. Set `container_command` to the image's init (`/sbin/init`) and `container_systemd: always`.
+- **The same failure even though you set `container_systemd: always`.** Check where it takes effect. The example ships `group_vars/molecule.yml` with `container_systemd: false`, and a `group_vars` file outranks the group `vars:` set inline in `inventory/hosts.yml`, so the inline value is silently ignored. Remove or update that `group_vars` entry.
+- **The service is not running, but the container started.** Confirm the image is an init image (for example `ubi-init`, not plain `ubi`); a plain image has no `systemd` to bring the unit up.
+- **The same failure only on an older host.** `systemd` as PID 1 needs cgroup v2. A host still on cgroup v1, or rootless Podman without the v2 hierarchy delegated, brings the container up but never boots `systemd`.
+- **`Failed to connect to bus` or other D-Bus errors during converge.** The container answered the connection before `systemd` finished booting. `wait_for_connection` confirms the Podman connection is up, not that `multi-user.target` is reached; if your role needs a completed boot, wait on a unit with `retries`/`until`.
+- **Writing into `/etc/systemd/system` fails with permission denied.** The image's default user is not root. Add `become: true` or use an image that runs as root (`ubi-init` does).


### PR DESCRIPTION
Part of #4679.

## What

Rewrites `docs/guides/systemd-container.md` to show the current way to run a systemd-capable test container. The old guide configured systemd through a `platforms:` block (`command: /sbin/init` plus `tmpfs` and a `/sys/fs/cgroup` volume mount) driven by the Docker driver, which now lives in the external [molecule-plugins](https://github.com/ansible-community/molecule-plugins) collection rather than in Molecule.

Rather than introduce a second, competing scenario, the rewrite builds on the existing [Using podman containers](https://docs.ansible.com/projects/molecule/examples/podman/) example, whose `create.yml` is already driven by inventory variables (`container_image`, `container_command`, `container_systemd`, `container_capabilities`, `container_privileged`). Making that scenario systemd-capable is an inventory change, not a new `create.yml`: point each host at an init image, and set two shared group variables in the same inventory file:

```yaml
# inventory/hosts.yml, under the molecule group's vars:
container_command: /sbin/init
container_systemd: always
```

The guide then swaps the example's OS-checking converge and verify: converge applies the role under test (`include_role`), and verify asserts the service that role manages is active. Extended privileges reuse the example's `container_capabilities` / `container_privileged`.

## Why

Testing a role that manages services needs systemd running as PID 1, which a plain container does not provide. As written, the guide points readers at a Docker-driver configuration that Molecule no longer ships.

## Verification

I built the scenario the guide describes on top of the `Using podman containers` example: its exact `create.yml`, `destroy.yml`, and `cleanup.yml`, the systemd inventory changes above, and the `converge`/`verify` playbooks shown in the guide. `converge.yml` applies `your_role`; the proof scenario stands that in with a small role that installs and starts a unit, the way a real service-managing role would. The inventory has two hosts so the guide is exercised across distributions: `ubi10` (`registry.access.redhat.com/ubi10/ubi-init:latest`) and `centos-stream10` (`quay.io/centos/centos:stream10`). Environment: Molecule 26.6.0 on Python 3.14, `containers.podman` 1.20.2.

`molecule test` passes the full sequence on both hosts and is idempotent:

<details>
<summary><code>molecule test</code>, full sequence, exit 0, both hosts</summary>

```
INFO     [default > create] Executing
PLAY [Create container instances] **********************************************
TASK [Create containers from inventory] ****************************************
changed: [localhost] => (item=ubi10)
changed: [localhost] => (item=centos-stream10)
INFO     [default > converge] Executing
PLAY [Converge] ****************************************************************
TASK [Apply the role under test] ***********************************************
included: your_role for ubi10, centos-stream10
TASK [your_role : Install the demo unit] ***************************************
TASK [your_role : Enable and start the unit] ***********************************
ubi10                      : ok=3    changed=2    unreachable=0    failed=0
centos-stream10            : ok=3    changed=2    unreachable=0    failed=0
INFO     [default > idempotence] Executing
PLAY [Converge] ****************************************************************
ubi10                      : ok=3    changed=0    unreachable=0    failed=0
centos-stream10            : ok=3    changed=0    unreachable=0    failed=0
INFO     [default > verify] Executing
PLAY [Verify] ******************************************************************
TASK [Confirm systemd is running the managed service] **************************
    "msg": "demo.service is active"
    "msg": "demo.service is active"
ubi10                      : ok=2    changed=0    unreachable=0    failed=0
centos-stream10            : ok=2    changed=0    unreachable=0    failed=0
INFO     [default > cleanup] Executing
INFO     [default > destroy] Executing
SCENARIO RECAP *****************************************************************
default                   : actions=8  successful=7  disabled=0  skipped=0  missing=0  failed=0
```

Both hosts run the role, are idempotent (`changed=0` on the second pass), and `verify.yml` asserts the managed service is active via `service_facts` on each.
</details>

The guide tells readers to override `container_command` to the image's init. That instruction is load-bearing, so I confirmed the failure it prevents: with `container_command` left at the example's default (`sleep 1d`) and only `container_systemd: always` set, the role's service task fails because `systemd` is not PID 1:

<details>
<summary>Without the <code>container_command</code> override, converge fails as documented</summary>

```
TASK [your_role : Enable and start the unit] ***********************************
fatal: [ubi10]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload:
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to system scope bus via local transport: Host is down"}
```
</details>

`ansible-lint` is clean at the production profile (run with `containers.podman` installed from `requirements.yml`):

<details>
<summary><code>ansible-lint</code>, clean at the production profile</summary>

```
Passed: 0 failure(s), 0 warning(s) in 11 files processed of 11 encountered.
Last profile that met the validation criteria was 'production'.
```
</details>

`tox -e docs` renders the guide with no errors of its own; the Jinja in the YAML examples is wrapped in `{% raw %}` so the mkdocs-macros plugin renders it. The `--strict` build currently aborts on one external error, mkdocstrings loading `https://docs.ansible.com/projects/ansible/latest/objects.inv` (HTTP 429), which is unrelated to this diff and hits real CI identically.

## Scope

I kept this to the one guide so it is easy to review. Five other pages still use the legacy `platforms:`/`driver:`/`provisioner:` syntax (`docker-rootless`, `podman-inside-docker`, `sharing`, `monolith`, and `ci.md`); I opened #4679 to agree the direction before converting them. I am happy to do them the same way, building and running each, as follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the systemd container guide with instructions for the Podman-based Molecule example.
  * Added configuration guidance for init images, cgroups, capabilities, privileged mode, and seccomp limitations.
  * Documented converge and verification playbooks for applying roles and checking managed services.
  * Added troubleshooting guidance for common systemd container setup and permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
