### PR TITLE
fix(deps): remove self-referential dependency from collection group

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,23 +97,6 @@ plugins:
       separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
   - material/social
   - material/tags
-  - mkdocstrings:
-      enable_inventory: true
-      default_handler: python
-      handlers:
-        python:
-          paths: [src]
-          options:
-            # Sphinx is for historical reasons, but we could consider switching if needed
-            # https://mkdocstrings.github.io/griffe/docstrings/
-            docstring_style: sphinx
-            merge_init_into_class: yes
-            show_submodules: yes
-          inventories:
-            - url: https://docs.ansible.com/projects/ansible/latest/objects.inv
-              domains: [py, std, "std:doc", "std:label"]
-            - url: https://pip.pypa.io/en/latest/objects.inv
-              domains: [py, std]
 
 markdown_extensions:
   - markdown_include.include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ dev = [
   "types-pyyaml>=6.0.12.20250822",
 ]
 collection = [
-  "molecule>=6.0.0",
   "pip>=2.20.3",
   "pytest-ansible>=26.2.0",
   "tox>=4.46.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1716,7 +1716,6 @@ dependencies = [
 
 [package.dev-dependencies]
 collection = [
-    { name = "molecule" },
     { name = "pip" },
     { name = "pytest-ansible" },
     { name = "tox" },
@@ -1784,7 +1783,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 collection = [
-    { name = "molecule", specifier = ">=6.0.0" },
     { name = "pip", specifier = ">=2.20.3" },
     { name = "pytest-ansible", specifier = ">=26.2.0" },
     { name = "tox", specifier = ">=4.46.0" },


### PR DESCRIPTION
The `collection` dependency group lists `molecule>=6.0.0`, but the project itself is `molecule`. This self-reference causes Dependabot to fail when resolving security updates because it resolves without installing the project, hitting a circular dependency.

The reference is also redundant since tox installs molecule as editable by default (no `skip_install = true` is set).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the Molecule package from the collection’s dependency requirements.
  * Simplified the documentation configuration by removing automated API reference generation and related source and inventory settings.

* **Documentation**
  * Documentation builds no longer include the removed API reference integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->