### PR TITLE
Improve documentation with paragraph about selection of container images to use with Podman

### DIFF
--- a/docs/examples/podman.md
+++ b/docs/examples/podman.md
@@ -40,6 +40,8 @@ Container definitions are managed through standard Ansible inventory:
 
 **Key points**: Containers are defined as inventory hosts with connection and configuration details. The `molecule` group contains test targets.
 
+When selecting the container image, remember that the container image **must** have Python installed to be able to run many of the builtin tasks.
+
 ```yaml title="inventory/group_vars/molecule.yml"
 {!tests/fixtures/integration/test_command/molecule/podman/inventory/group_vars/molecule.yml!}
 ```


### PR DESCRIPTION
I was studying the "[Using podman containers](https://docs.ansible.com/projects/molecule/examples/podman/) example and I had issues when I try to replace the container image used in the example, `ghcr.io/ansible/community-ansible-dev-tools:latest`, with another one.

I was getting a failure when running the module `ansible.builtin.wait_for_connection` with the message `timed out waiting for ping module test: 'ping'` that was not very helpful. After some investigation, I discover the problem. The container images that I was trying did not have Python. This pull request improves the example with a reminder to future readers.

More details of what I was experimenting in https://github.com/rgaiacs/ansible-molecule-mwe-native-configuration

This is my first pull request. Because it only adds a minor change to the documentation, I did not sign it. I'm happy to amend the commit with a signature if it is required to be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to the Podman inventory documentation noting that selected container images must include Python for many built-in Ansible tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->